### PR TITLE
Make it possible to specify the release URL as a project property.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 build/
+out/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
@@ -24,16 +24,6 @@ class MavenPublishPlugin implements Plugin<Project> {
 
     p.afterEvaluate { project ->
       project.uploadArchives {
-        doFirst {
-          if (extension.repositoryUsername == null) {
-            throw new GradleException("Please configure repositoryUsername via mavenPublish.repositoryUsername or alternatively set the Gradle / System environment variable SONATYPE_NEXUS_USERNAME")
-          }
-
-          if (extension.repositoryPassword == null) {
-            throw new GradleException("Please configure repositoryPassword via mavenPublish.repositoryPassword or alternatively set the Gradle / System environment variable SONATYPE_NEXUS_PASSWORD")
-          }
-        }
-
         repositories {
           mavenDeployer {
             beforeDeployment { MavenDeployment deployment -> project.signing.signPom(deployment) }
@@ -41,6 +31,14 @@ class MavenPublishPlugin implements Plugin<Project> {
             pom.groupId = project.findProperty("GROUP")
             pom.artifactId = project.findProperty("POM_ARTIFACT_ID")
             pom.version = project.findProperty("VERSION_NAME")
+
+            if (extension.repositoryUsername == null) {
+              throw new GradleException("Please configure repositoryUsername via mavenPublish.repositoryUsername or alternatively set the Gradle / System environment variable SONATYPE_NEXUS_USERNAME")
+            }
+
+            if (extension.repositoryPassword == null) {
+              throw new GradleException("Please configure repositoryPassword via mavenPublish.repositoryPassword or alternatively set the Gradle / System environment variable SONATYPE_NEXUS_PASSWORD")
+            }
 
             repository(url: extension.releaseRepositoryUrl) {
               authentication(userName: extension.repositoryUsername, password: extension.repositoryPassword)

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
@@ -9,14 +9,14 @@ import org.gradle.api.Project
 open class MavenPublishPluginExtension(project: Project) {
   /**
    * The release repository url this should be published to.
-   * This defaults to the sonatypes url.
+   * This defaults to either the RELEASE_REPOSITORY_URL Gradle property, the system environment variable or the snapshot url.
    * @since 0.1.0
    */
   var releaseRepositoryUrl: String = project.findProperty("RELEASE_REPOSITORY_URL") as String? ?: System.getenv("RELEASE_REPOSITORY_URL") ?: "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
 
   /**
    * The snapshot repository url this should be published to.
-   * This defaults to the sonatypes url.
+   * This defaults to either the SNAPSHOT_REPOSITORY_URL Gradle property, the system environment variable or the snapshot sonatype url.
    * @since 0.1.0
    */
   var snapshotRepositoryUrl: String = project.findProperty("SNAPSHOT_REPOSITORY_URL") as String? ?: System.getenv("SNAPSHOT_REPOSITORY_URL") ?: "https://oss.sonatype.org/content/repositories/snapshots/"

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
@@ -12,14 +12,14 @@ open class MavenPublishPluginExtension(project: Project) {
    * This defaults to the sonatypes url.
    * @since 0.1.0
    */
-  var releaseRepositoryUrl: String = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+  var releaseRepositoryUrl: String = project.findProperty("RELEASE_REPOSITORY_URL") as String? ?: System.getenv("RELEASE_REPOSITORY_URL") ?: "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
 
   /**
    * The snapshot repository url this should be published to.
    * This defaults to the sonatypes url.
    * @since 0.1.0
    */
-  var snapshotRepositoryUrl: String = "https://oss.sonatype.org/content/repositories/snapshots/"
+  var snapshotRepositoryUrl: String = project.findProperty("SNAPSHOT_REPOSITORY_URL") as String? ?: System.getenv("SNAPSHOT_REPOSITORY_URL") ?: "https://oss.sonatype.org/content/repositories/snapshots/"
 
   /**
    * The username that should be used for publishing.

--- a/src/test/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtensionTest.kt
+++ b/src/test/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtensionTest.kt
@@ -26,6 +26,16 @@ class MavenPublishPluginExtensionTest {
     assertThat(MavenPublishPluginExtension(project).snapshotRepositoryUrl).isEqualTo("https://oss.sonatype.org/content/repositories/snapshots/")
   }
 
+  @Test fun defaultReleaseRepositoryUrlEnvironmentVariable() {
+    environmentVariables.set("RELEASE_REPOSITORY_URL", "https://releases.fake/")
+    assertThat(MavenPublishPluginExtension(project).releaseRepositoryUrl).isEqualTo("https://releases.fake/")
+  }
+
+  @Test fun defaultSnapshotRepositoryUrlEnvironmentVariable() {
+    environmentVariables.set("SNAPSHOT_REPOSITORY_URL", "https://snapshots.fake/")
+    assertThat(MavenPublishPluginExtension(project).snapshotRepositoryUrl).isEqualTo("https://snapshots.fake/")
+  }
+
   @Test fun defaultRepositoryUsernameEnvironmentVariable() {
     environmentVariables.set("SONATYPE_NEXUS_USERNAME", "env")
     assertThat(MavenPublishPluginExtension(project).repositoryUsername).isEqualTo("env")


### PR DESCRIPTION
We have an internal Nexus server and otherwise this is a big drag.

Also don't require username + password unless actually uploading a release.
As-is our builds on Travis fail because it doesn't have credentials.

https://travis-ci.org/square/misk/jobs/397580749