### PR TITLE
reuse MavenDeployer configuration

### DIFF
--- a/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
@@ -27,7 +27,7 @@ class MavenPublishPlugin implements Plugin<Project> {
       configureMavenDeployer(project, (Upload) project.uploadArchives, extension.defaultTarget)
 
       extraRepos.map.each { key, value ->
-        def taskName = "upload" + key.capitalize()
+        def taskName = "uploadArchives" + key.capitalize()
         project.logger.debug("Creating $taskName to upload to ${value.releaseRepositoryUrl} / ${value.snapshotRepositoryUrl}")
         project.tasks.create(taskName, Upload.class) {
 

--- a/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
@@ -14,7 +14,7 @@ import org.gradle.plugins.signing.SigningPlugin
 
 class MavenPublishPlugin implements Plugin<Project> {
   @Override void apply(final Project p) {
-    p.extensions.create('mavenPublish', MavenPublishPluginExtension.class, p)
+    def extension = p.extensions.create('mavenPublish', MavenPublishPluginExtension.class, p)
     def extraRepos = p.extensions.create('mavenRepositories', MavenPublishRepositories.class)
 
     p.plugins.apply(MavenPlugin)
@@ -23,26 +23,8 @@ class MavenPublishPlugin implements Plugin<Project> {
     p.group = p.findProperty("GROUP")
     p.version = p.findProperty("VERSION_NAME")
 
-    def extension = p.mavenPublish
-
-    p.afterEvaluate { project ->
-      project.uploadArchives {
-        repositories {
-          mavenDeployer {
-            beforeDeployment { MavenDeployment deployment -> project.signing.signPom(deployment) }
-
-            repository(url: extension.releaseRepositoryUrl) {
-              authentication(userName: extension.repositoryUsername, password: extension.repositoryPassword)
-            }
-
-            snapshotRepository(url: extension.snapshotRepositoryUrl) {
-              authentication(userName: extension.repositoryUsername, password: extension.repositoryPassword)
-            }
-
-            configurePom(p, pom)
-          }
-        }
-      }
+    p.afterEvaluate { Project project ->
+      configureMavenDeployer(project, (Upload) project.uploadArchives, extension.defaultTarget)
 
       extraRepos.map.each { key, value ->
         def taskName = "upload" + key.capitalize()
@@ -61,20 +43,7 @@ class MavenPublishPlugin implements Plugin<Project> {
           dependsOn(defaultUploadArchives.dependsOn.clone())
 
           // setup repositories
-          repositories {
-            mavenDeployer {
-              beforeDeployment { MavenDeployment deployment -> project.signing.signPom(deployment) }
-
-              repository(url: value.releaseRepositoryUrl) {
-                authentication(userName: value.repositoryUsername, password: value.repositoryPassword)
-              }
-
-              snapshotRepository(url: value.snapshotRepositoryUrl) {
-                authentication(userName: value.repositoryUsername, password: value.repositoryPassword)
-              }
-              configurePom(p, pom)
-            }
-          }
+          configureMavenDeployer(project, it, value)
         }
       }
 
@@ -164,13 +133,30 @@ class MavenPublishPlugin implements Plugin<Project> {
         description = "Installs the artifacts to the local Maven repository."
         group = "upload"
         configuration = project.configurations['archives']
-        repositories {
-          mavenDeployer {
-            repository url: project.repositories.mavenLocal().url
 
-            configurePom(p, pom)
+        configureMavenDeployer(project, it, extension.localTarget)
+      }
+    }
+  }
+
+  private void configureMavenDeployer(Project project, Upload upload, MavenPublishTarget target) {
+    upload.repositories {
+      mavenDeployer {
+        if (target.signing) {
+          beforeDeployment { MavenDeployment deployment -> project.signing.signPom(deployment) }
+        }
+
+        repository(url: target.releaseRepositoryUrl) {
+          authentication(userName: target.repositoryUsername, password: target.repositoryPassword)
+        }
+
+        if (target.snapshotRepositoryUrl != null) {
+          snapshotRepository(url: target.snapshotRepositoryUrl) {
+            authentication(userName: target.repositoryUsername, password: target.repositoryPassword)
           }
         }
+
+        configurePom(project, pom)
       }
     }
   }

--- a/src/main/groovy/com/vanniktech/maven/publish/MavenPublishRepositories.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/MavenPublishRepositories.groovy
@@ -2,11 +2,11 @@ package com.vanniktech.maven.publish
 
 class MavenPublishRepositories {
 
-    Map<String, MavenPublishRepositoryModel> map = new HashMap<>()
+    Map<String, MavenPublishTarget> map = new HashMap<>()
 
     def propertyMissing(String name, value) {
         // Create the new configuration and add to the map
-        def data = new MavenPublishRepositoryModel()
+        def data = new MavenPublishTarget("", null, null, null, false)
         map.put(name, data)
 
         // setup and execute the client closure to configure the repo

--- a/src/main/groovy/com/vanniktech/maven/publish/MavenPublishRepositoryModel.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/MavenPublishRepositoryModel.groovy
@@ -1,8 +1,0 @@
-package com.vanniktech.maven.publish
-
-class MavenPublishRepositoryModel {
-    String releaseRepositoryUrl
-    String snapshotRepositoryUrl
-    String repositoryUsername
-    String repositoryPassword
-}

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
@@ -7,31 +7,52 @@ import org.gradle.api.Project
  * @since 0.1.0
  */
 open class MavenPublishPluginExtension(project: Project) {
+
+  @JvmField
+  internal val defaultTarget = MavenPublishTarget(
+    project.findProperty("RELEASE_REPOSITORY_URL") as String? ?: System.getenv("RELEASE_REPOSITORY_URL") ?: "https://oss.sonatype.org/service/local/staging/deploy/maven2/",
+    project.findProperty("SNAPSHOT_REPOSITORY_URL") as String? ?: System.getenv("SNAPSHOT_REPOSITORY_URL") ?: "https://oss.sonatype.org/content/repositories/snapshots/",
+    project.findProperty("SONATYPE_NEXUS_USERNAME") as String? ?: System.getenv("SONATYPE_NEXUS_USERNAME"),
+    project.findProperty("SONATYPE_NEXUS_PASSWORD") as String? ?: System.getenv("SONATYPE_NEXUS_PASSWORD"))
+
+  @JvmField
+  internal val localTarget = MavenPublishTarget(
+    releaseRepositoryUrl = project.repositories.mavenLocal().url.toASCIIString(),
+    signing = false)
+
   /**
    * The release repository url this should be published to.
    * This defaults to either the RELEASE_REPOSITORY_URL Gradle property, the system environment variable or the sonatype url.
    * @since 0.1.0
    */
-  var releaseRepositoryUrl: String = project.findProperty("RELEASE_REPOSITORY_URL") as String? ?: System.getenv("RELEASE_REPOSITORY_URL") ?: "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+  var releaseRepositoryUrl: String
+    get() = defaultTarget.releaseRepositoryUrl
+    set(value) { defaultTarget.releaseRepositoryUrl = value }
 
   /**
    * The snapshot repository url this should be published to.
    * This defaults to either the SNAPSHOT_REPOSITORY_URL Gradle property, the system environment variable or the snapshot sonatype url.
    * @since 0.1.0
    */
-  var snapshotRepositoryUrl: String = project.findProperty("SNAPSHOT_REPOSITORY_URL") as String? ?: System.getenv("SNAPSHOT_REPOSITORY_URL") ?: "https://oss.sonatype.org/content/repositories/snapshots/"
+  var snapshotRepositoryUrl: String?
+    get() = defaultTarget.snapshotRepositoryUrl
+    set(value) { defaultTarget.snapshotRepositoryUrl = value }
 
   /**
    * The username that should be used for publishing.
    * This defaults to either the SONATYPE_NEXUS_USERNAME Gradle property or the system environment variable.
    * @since 0.1.0
    */
-  var repositoryUsername: String? = project.findProperty("SONATYPE_NEXUS_USERNAME") as String? ?: System.getenv("SONATYPE_NEXUS_USERNAME")
+  var repositoryUsername: String?
+    get() = defaultTarget.repositoryUsername
+    set(value) { defaultTarget.repositoryUsername = value }
 
   /**
    * The password that should be used for publishing.
    * This defaults to either the SONATYPE_NEXUS_PASSWORD Gradle property or the system environment variable.
    * @since 0.1.0
    */
-  var repositoryPassword: String? = project.findProperty("SONATYPE_NEXUS_PASSWORD") as String? ?: System.getenv("SONATYPE_NEXUS_PASSWORD")
+  var repositoryPassword: String?
+    get() = defaultTarget.repositoryPassword
+    set(value) { defaultTarget.repositoryPassword = value }
 }

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishTarget.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishTarget.kt
@@ -1,0 +1,9 @@
+package com.vanniktech.maven.publish
+
+data class MavenPublishTarget(
+  var releaseRepositoryUrl: String,
+  var snapshotRepositoryUrl: String? = null,
+  var repositoryUsername: String? = null,
+  var repositoryPassword: String? = null,
+  var signing: Boolean = true
+)


### PR DESCRIPTION
I've tested publishing a snapshot with both installArchives and uploadArchives. 

The only behavior change is that you could theoretically set the url for snapshots to null and skip the configuration of that. It seems like Gradle will try to publish the snapshot to the regular repository in that case (that's also what happens when using installArchives with snapshots). I don't think that this is a problem because someone would need to explicitly set that.

There are still some things that I will address in other PRs 
- combining the old and new extension
- share some of the task creation logic between the new tasks and installArchives
- the signing config doesn't account for new upload tasks https://github.com/gabrielittner/gradle-maven-publish-plugin/blob/dbb373ef5ffa1d946f0c9ee353e47586a6aa84d8/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy#L50-L53

cc @budius