### PR TITLE
improve when signing tasks run, consider all targets for signing

### DIFF
--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishTarget.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishTarget.kt
@@ -1,5 +1,8 @@
 package com.vanniktech.maven.publish
 
+import com.vanniktech.maven.publish.MavenPublishPluginExtension.Companion.DEFAULT_TARGET
+import com.vanniktech.maven.publish.MavenPublishPluginExtension.Companion.LOCAL_TARGET
+
 data class MavenPublishTarget(
   internal val name: String,
   /**
@@ -31,4 +34,13 @@ data class MavenPublishTarget(
    * @since 0.7.0
    */
   var signing: Boolean = true
-)
+) {
+
+  val taskName get(): String {
+    if (name == DEFAULT_TARGET || name == LOCAL_TARGET) {
+      return name
+    } else {
+      return DEFAULT_TARGET + name.capitalize()
+    }
+  }
+}

--- a/src/test/kotlin/com/vanniktech/maven/publish/MavenPublishTargetTest.kt
+++ b/src/test/kotlin/com/vanniktech/maven/publish/MavenPublishTargetTest.kt
@@ -1,0 +1,24 @@
+package com.vanniktech.maven.publish
+
+import com.vanniktech.maven.publish.MavenPublishPluginExtension.Companion.DEFAULT_TARGET
+import com.vanniktech.maven.publish.MavenPublishPluginExtension.Companion.LOCAL_TARGET
+import org.assertj.core.api.Java6Assertions.assertThat
+import org.junit.Test
+
+class MavenPublishTargetTest {
+
+  @Test
+  fun uploadArchivesTaskName() {
+    assertThat(MavenPublishTarget(DEFAULT_TARGET).taskName).isEqualTo("uploadArchives")
+  }
+
+  @Test
+  fun installArchivesTaskName() {
+    assertThat(MavenPublishTarget(LOCAL_TARGET).taskName).isEqualTo("installArchives")
+  }
+
+  @Test
+  fun customTaskName() {
+    assertThat(MavenPublishTarget("myRepo").taskName).isEqualTo("uploadArchivesMyRepo")
+  }
+}


### PR DESCRIPTION
- signing configuration isn't part of afterEvaluate anymore which makes manually overriding it easier
- required (= task fails when signing isn't set up on the local machine) only considers if the task is a snapshot
- signing will only be run when also running an `Upload` task  (not during things like assemble) 
- the previous point will now consider all targets, before only `uploadArchives` was considered
- added info level logs to make debugging issues easier

fixes #29 

