### PR TITLE
 create interface to capsulate maven plugin specific configuration

### DIFF
--- a/src/main/groovy/com/vanniktech/maven/publish/GroovyUploadArchivesConfigurer.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/GroovyUploadArchivesConfigurer.groovy
@@ -1,0 +1,18 @@
+package com.vanniktech.maven.publish
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.Upload
+import org.jetbrains.annotations.NotNull
+
+class GroovyUploadArchivesConfigurer extends UploadArchivesConfigurer {
+
+    GroovyUploadArchivesConfigurer(@NotNull Project project, @NotNull MavenPublishPluginExtension extension) {
+        super(project, extension)
+    }
+
+    @Override
+    void configureTarget(@NotNull MavenPublishTarget target) {
+        Upload upload = MavenPublishPlugin.getUploadTask(project, target.name, target.taskName)
+        MavenPublishPlugin.configureMavenDeployer(project, upload, target)
+    }
+}

--- a/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
@@ -145,34 +145,36 @@ class MavenPublishPlugin implements Plugin<Project> {
   }
 
   private static void configurePom(Project project, MavenPom pom) {
-    pom.groupId = project.findProperty("GROUP")
-    pom.artifactId = project.findProperty("POM_ARTIFACT_ID")
-    pom.version = project.findProperty("VERSION_NAME")
+    MavenPublishPom publishPom = MavenPublishPom.fromProject(project)
+
+    pom.groupId = publishPom.groupId
+    pom.artifactId = publishPom.artifactId
+    pom.version = publishPom.version
 
     pom.project {
-      name project.findProperty("POM_NAME")
-      packaging project.findProperty("POM_PACKAGING")
-      description project.findProperty("POM_DESCRIPTION")
-      url project.findProperty("POM_URL")
+      name publishPom.name
+      packaging publishPom.packaging
+      description publishPom.description
+      url publishPom.url
 
       scm {
-        url project.findProperty("POM_SCM_URL")
-        connection project.findProperty("POM_SCM_CONNECTION")
-        developerConnection project.findProperty("POM_SCM_DEV_CONNECTION")
+        url publishPom.scmUrl
+        connection publishPom.scmConnection
+        developerConnection publishPom.scmDeveloperConnection
       }
 
       licenses {
         license {
-          name project.findProperty("POM_LICENCE_NAME")
-          url project.findProperty("POM_LICENCE_URL")
-          distribution project.findProperty("POM_LICENCE_DIST")
+          name publishPom.licenseName
+          url publishPom.licenseUrl
+          distribution publishPom.licenseDistribution
         }
       }
 
       developers {
         developer {
-          id project.findProperty("POM_DEVELOPER_ID")
-          name project.findProperty("POM_DEVELOPER_NAME")
+          id publishPom.developerId
+          name publishPom.developerName
         }
       }
     }

--- a/src/main/kotlin/com/vanniktech/maven/publish/Configurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/Configurer.kt
@@ -1,0 +1,10 @@
+package com.vanniktech.maven.publish
+
+import org.gradle.api.component.SoftwareComponent
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
+
+internal interface Configurer {
+  fun configureTarget(target: MavenPublishTarget)
+  fun addComponent(component: SoftwareComponent)
+  fun addTaskOutput(task: AbstractArchiveTask)
+}

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPom.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPom.kt
@@ -1,0 +1,47 @@
+package com.vanniktech.maven.publish
+
+import org.gradle.api.Project
+
+internal data class MavenPublishPom(
+  val groupId: String?,
+  val artifactId: String?,
+  val version: String?,
+
+  val name: String?,
+  val packaging: String?,
+  val description: String?,
+  val url: String?,
+
+  val scmUrl: String?,
+  val scmConnection: String?,
+  val scmDeveloperConnection: String?,
+
+  val licenseName: String?,
+  val licenseUrl: String?,
+  val licenseDistribution: String?,
+
+  val developerId: String?,
+  val developerName: String?
+) {
+
+  internal companion object {
+    @JvmStatic
+    fun fromProject(project: Project) = MavenPublishPom(
+        project.findProperty("GROUP") as String?,
+        project.findProperty("POM_ARTIFACT_ID") as String?,
+        project.findProperty("VERSION_NAME") as String?,
+        project.findProperty("POM_NAME") as String?,
+        project.findProperty("POM_PACKAGING") as String?,
+        project.findProperty("POM_DESCRIPTION") as String?,
+        project.findProperty("POM_URL") as String?,
+        project.findProperty("POM_SCM_URL") as String?,
+        project.findProperty("POM_SCM_CONNECTION") as String?,
+        project.findProperty("POM_SCM_DEV_CONNECTION") as String?,
+        project.findProperty("POM_LICENCE_NAME") as String?,
+        project.findProperty("POM_LICENCE_URL") as String?,
+        project.findProperty("POM_LICENCE_DIST") as String?,
+        project.findProperty("POM_DEVELOPER_ID") as String?,
+        project.findProperty("POM_DEVELOPER_NAME") as String?
+    )
+  }
+}

--- a/src/main/kotlin/com/vanniktech/maven/publish/UploadArchivesConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/UploadArchivesConfigurer.kt
@@ -1,0 +1,48 @@
+package com.vanniktech.maven.publish
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency.ARCHIVES_CONFIGURATION
+import org.gradle.api.component.SoftwareComponent
+import org.gradle.api.plugins.MavenPlugin
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
+import org.gradle.plugins.signing.Sign
+import org.gradle.plugins.signing.SigningExtension
+import org.gradle.plugins.signing.SigningPlugin
+import java.util.concurrent.Callable
+import kotlin.math.sign
+
+internal abstract class UploadArchivesConfigurer(
+  protected val project: Project,
+  private val extension: MavenPublishPluginExtension
+) : Configurer {
+
+  init {
+    project.plugins.apply(MavenPlugin::class.java)
+    project.plugins.apply(SigningPlugin::class.java)
+
+    project.signing.apply {
+      setRequired(Callable<Boolean> { !project.version.toString().contains("SNAPSHOT") })
+      sign(project.configurations.getByName(ARCHIVES_CONFIGURATION))
+    }
+    project.tasks.withType(Sign::class.java).all { sign ->
+      sign.onlyIf { _ ->
+        val signedTargets = extension.targets.filter { it.signing }
+        sign.logger.info("Targets that should be signed: ${signedTargets.map { it.name }}")
+        signedTargets.any { target ->
+          val task = project.tasks.getByName(target.taskName)
+          project.gradle.taskGraph.hasTask(task).also {
+            sign.logger.info("Task for ${target.name} will be executed: $it")
+          }
+        }
+      }
+    }
+  }
+
+  override fun addComponent(component: SoftwareComponent) {}
+
+  override fun addTaskOutput(task: AbstractArchiveTask) {
+    project.artifacts.add(ARCHIVES_CONFIGURATION, task)
+  }
+
+  private val Project.signing get() = extensions.getByType(SigningExtension::class.java)
+}

--- a/src/main/kotlin/com/vanniktech/maven/publish/UploadArchivesConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/UploadArchivesConfigurer.kt
@@ -38,7 +38,7 @@ internal abstract class UploadArchivesConfigurer(
     }
   }
 
-  override fun addComponent(component: SoftwareComponent) {}
+  override fun addComponent(component: SoftwareComponent) = Unit
 
   override fun addTaskOutput(task: AbstractArchiveTask) {
     project.artifacts.add(ARCHIVES_CONFIGURATION, task)


### PR DESCRIPTION
This is what I mentioned when we talked at KotlinConf. I'd be very happy if we can come up with a better name than `Configurer`.

A wip commit of an implementation for maven-publish can be found here https://github.com/gabrielittner/gradle-maven-publish-plugin/compare/interface...gabrielittner:maven-publish