### PR TITLE
experimental implementation of Configurer that uses maven-publish

### DIFF
--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
@@ -1,0 +1,116 @@
+package com.vanniktech.maven.publish
+
+import com.vanniktech.maven.publish.MavenPublishPluginExtension.Companion.DEFAULT_TARGET
+import com.vanniktech.maven.publish.MavenPublishPluginExtension.Companion.LOCAL_TARGET
+import org.gradle.api.Project
+import org.gradle.api.component.SoftwareComponent
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.plugins.MavenPublishPlugin as GradleMavenPublishPlugin
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
+import org.gradle.plugins.signing.SigningPlugin
+import java.net.URI
+
+internal class MavenPublishConfigurer(private val project: Project) : Configurer {
+
+  private val publication: MavenPublication
+
+  init {
+    project.plugins.apply(GradleMavenPublishPlugin::class.java)
+    project.plugins.apply(SigningPlugin::class.java)
+
+    val publications = project.publishing.publications
+    publication = publications.create("maven", MavenPublication::class.java) { publication ->
+      val publishPom = MavenPublishPom.fromProject(project)
+
+      publication.groupId = publishPom.groupId
+      publication.artifactId = publishPom.artifactId
+      publication.version = publishPom.version
+
+      publication.pom { pom ->
+        pom.name.set(publishPom.name)
+        pom.packaging = publishPom.packaging
+        pom.description.set(publishPom.description)
+        pom.url.set(publishPom.url)
+
+        pom.scm {
+          it.url.set(publishPom.scmUrl)
+          it.connection.set(publishPom.scmConnection)
+          it.developerConnection.set(publishPom.scmDeveloperConnection)
+        }
+
+        pom.licenses { licenses ->
+          licenses.license {
+            it.name.set(publishPom.licenseName)
+            it.url.set(publishPom.licenseUrl)
+            it.distribution.set(publishPom.licenseDistribution)
+          }
+        }
+
+        pom.developers { developers ->
+          developers.developer {
+            it.id.set(publishPom.developerId)
+            it.name.set(publishPom.developerName)
+          }
+        }
+      }
+    }
+
+    project.signing.apply {
+      setRequired(project.isSigningRequired)
+      sign(publication)
+    }
+  }
+
+  override fun configureTarget(target: MavenPublishTarget) {
+    project.publishing.repositories.maven { repo ->
+      repo.name = target.repositoryName
+      repo.url = target.repositoryUrl(project.version.toString())
+      if (target.repositoryUsername != null) {
+        repo.credentials { it ->
+          it.username = target.repositoryUsername
+          it.password = target.repositoryPassword
+        }
+      }
+    }
+
+    // create task that depends on new publishing task for compatibility and easier switching
+    project.tasks.register(target.taskName) {
+      val publicationTaskName = publishTaskName(target.repositoryName)
+      it.dependsOn(project.tasks.named(publicationTaskName))
+    }
+  }
+
+  private val MavenPublishTarget.repositoryName get(): String {
+    return when (name) {
+      DEFAULT_TARGET -> "maven"
+      LOCAL_TARGET -> "local"
+      else -> name
+    }
+  }
+
+  private fun MavenPublishTarget.repositoryUrl(version: String): URI {
+    val url = if (version.endsWith("SNAPSHOT")) {
+      snapshotRepositoryUrl ?: releaseRepositoryUrl
+    } else {
+      releaseRepositoryUrl
+    }
+    // the releaseRepositoryUrl is null checked in the plugin
+    return URI.create(@Suppress("UnsafeCallOnNullableType") url!!)
+  }
+
+  private fun publishTaskName(repository: String) =
+    "publish${publication.name.capitalize()}PublicationTo${repository.capitalize()}Repository"
+
+  override fun addComponent(component: SoftwareComponent) {
+    publication.from(component)
+  }
+
+  override fun addTaskOutput(task: AbstractArchiveTask) {
+    // default artifact should be added as SoftwareComponent
+    // TODO this is not really nice and we might need to add Android aars through this
+    if (task.classifier.isBlank()) {
+      return
+    }
+    publication.artifact(task)
+  }
+}

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
@@ -66,7 +66,7 @@ internal class MavenPublishConfigurer(private val project: Project) : Configurer
       repo.name = target.repositoryName
       repo.url = target.repositoryUrl(project.version.toString())
       if (target.repositoryUsername != null) {
-        repo.credentials { it ->
+        repo.credentials {
           it.username = target.repositoryUsername
           it.password = target.repositoryPassword
         }
@@ -94,8 +94,7 @@ internal class MavenPublishConfigurer(private val project: Project) : Configurer
     } else {
       releaseRepositoryUrl
     }
-    // the releaseRepositoryUrl is null checked in the plugin
-    return URI.create(@Suppress("UnsafeCallOnNullableType") url!!)
+    return URI.create(requireNotNull(url))
   }
 
   private fun publishTaskName(repository: String) =

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
@@ -25,6 +25,17 @@ open class MavenPublishPluginExtension(project: Project) {
   )
 
   /**
+   * If set to true the new `maven-publish` plugin will be used instead of the soon to be deprecated
+   * `maven` plugin.
+   *
+   * This is **experimental** and Android projects are unsupported until
+   * [this issue][https://issuetracker.google.com/issues/37055147] is fixed.
+   *
+   * @Since 0.8.0
+   */
+  var useMavenPublish: Boolean = false
+
+  /**
    * Allows to add additional [MavenPublishTargets][MavenPublishTarget] to publish to multiple repositories.
    * @since 0.7.0
    */

--- a/src/main/kotlin/com/vanniktech/maven/publish/UploadArchivesConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/UploadArchivesConfigurer.kt
@@ -9,9 +9,7 @@ import org.gradle.api.plugins.MavenPlugin
 import org.gradle.api.tasks.Upload
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
 import org.gradle.plugins.signing.Sign
-import org.gradle.plugins.signing.SigningExtension
 import org.gradle.plugins.signing.SigningPlugin
-import java.util.concurrent.Callable
 
 internal abstract class UploadArchivesConfigurer(
   protected val project: Project,
@@ -23,7 +21,7 @@ internal abstract class UploadArchivesConfigurer(
     project.plugins.apply(SigningPlugin::class.java)
 
     project.signing.apply {
-      setRequired(Callable<Boolean> { !project.version.toString().contains("SNAPSHOT") })
+      setRequired(project.isSigningRequired)
       sign(project.configurations.getByName(ARCHIVES_CONFIGURATION))
     }
     project.tasks.withType(Sign::class.java).all { sign ->
@@ -66,6 +64,4 @@ internal abstract class UploadArchivesConfigurer(
   override fun addTaskOutput(task: AbstractArchiveTask) {
     project.artifacts.add(ARCHIVES_CONFIGURATION, task)
   }
-
-  private val Project.signing get() = extensions.getByType(SigningExtension::class.java)
 }

--- a/src/main/kotlin/com/vanniktech/maven/publish/Utils.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/Utils.kt
@@ -1,0 +1,12 @@
+package com.vanniktech.maven.publish
+
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.plugins.signing.SigningExtension
+import java.util.concurrent.Callable
+
+internal val Project.signing get() = extensions.getByType(SigningExtension::class.java)
+internal val Project.publishing get() = extensions.getByType(PublishingExtension::class.java)
+
+internal val Project.isSigningRequired
+  get() = Callable<Boolean> { !project.version.toString().contains("SNAPSHOT") }

--- a/src/main/kotlin/com/vanniktech/maven/publish/Utils.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/Utils.kt
@@ -5,8 +5,8 @@ import org.gradle.api.publish.PublishingExtension
 import org.gradle.plugins.signing.SigningExtension
 import java.util.concurrent.Callable
 
-internal val Project.signing get() = extensions.getByType(SigningExtension::class.java)
-internal val Project.publishing get() = extensions.getByType(PublishingExtension::class.java)
+internal inline val Project.signing get() = extensions.getByType(SigningExtension::class.java)
+internal inline val Project.publishing get() = extensions.getByType(PublishingExtension::class.java)
 
-internal val Project.isSigningRequired
+internal inline val Project.isSigningRequired
   get() = Callable<Boolean> { !project.version.toString().contains("SNAPSHOT") }


### PR DESCRIPTION
Android libraries aren't supported right. We'd need a SoftwareComponent implementation for those which is tracked here: https://issuetracker.google.com/issues/37055147. Which is blocked by https://github.com/gradle/gradle/issues/1842. The latter is also preventing us of providing our own implementation of SoftwareComponent unless we're ok with internal APIs. Here is an example of how to do it without SoftwareComponent, but for Android adding the dependencies to the pom is more complex

This brings one behavior change for the old implementation. The general configuration inside the Configurers `init` is now done in afterEvaluate because we need to wait until we can read the new `useMavenPublish` property.

I still want tests for at least the generated poms. Going to look into that next week.