### PR TITLE
migrate Upload task creation to Kotlin

### DIFF
--- a/src/main/groovy/com/vanniktech/maven/publish/GroovyUploadArchivesConfigurer.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/GroovyUploadArchivesConfigurer.groovy
@@ -11,8 +11,7 @@ class GroovyUploadArchivesConfigurer extends UploadArchivesConfigurer {
     }
 
     @Override
-    void configureTarget(@NotNull MavenPublishTarget target) {
-        Upload upload = MavenPublishPlugin.getUploadTask(project, target.name, target.taskName)
+    protected void configureMavenDeployer(@NotNull Upload upload, @NotNull MavenPublishTarget target) {
         MavenPublishPlugin.configureMavenDeployer(project, upload, target)
     }
 }

--- a/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
@@ -3,15 +3,11 @@ package com.vanniktech.maven.publish
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.maven.MavenDeployment
 import org.gradle.api.artifacts.maven.MavenPom
 import org.gradle.api.tasks.Upload
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.javadoc.Javadoc
-
-import static com.vanniktech.maven.publish.MavenPublishPluginExtension.DEFAULT_TARGET
-import static com.vanniktech.maven.publish.MavenPublishPluginExtension.LOCAL_TARGET
 
 class MavenPublishPlugin implements Plugin<Project> {
   @Override void apply(final Project p) {
@@ -101,24 +97,6 @@ class MavenPublishPlugin implements Plugin<Project> {
           }
         }
       }
-    }
-  }
-
-  static Upload getUploadTask(Project project, String name, String taskName) {
-    if (name == DEFAULT_TARGET) {
-      return (Upload) project.tasks.getByName(taskName)
-    } else if (name == LOCAL_TARGET) {
-      return createUploadTask(project, taskName, "Installs the artifacts to the local Maven repository.")
-    } else {
-      return createUploadTask(project, taskName, "Upload all artifacts to $name")
-    }
-  }
-
-  private static Upload createUploadTask(Project project, String name, String taskDescription) {
-    return (Upload) project.tasks.create(name, Upload.class) {
-      group = "upload"
-      description = taskDescription
-      configuration = project.configurations[Dependency.ARCHIVES_CONFIGURATION]
     }
   }
 


### PR DESCRIPTION
This is the Configurer part that's easily migratable. `configureMavenDeployer` needs a lot of internal APIs (can be seen here https://github.com/gabrielittner/gradle-maven-publish-plugin/compare/kotlin-task-creation...gabrielittner:kotlin-maven-deployer). 