### PR TITLE
Generate javadocs for Kotlin project with Dokka

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,10 @@ dependencies {
   api localGroovy()
   api "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
+  def dokkaVersion = '0.9.17'
+  runtime "org.jetbrains.dokka:dokka-android-gradle-plugin:${dokkaVersion}"
+  runtime "org.jetbrains.dokka:dokka-gradle-plugin:${dokkaVersion}"
+
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.assertj:assertj-core:3.10.0'
   testImplementation 'com.android.tools.build:gradle:3.1.2'

--- a/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
@@ -50,7 +50,6 @@ class MavenPublishPlugin extends BaseMavenPublishPlugin {
         outputFormat 'javadoc'
         outputDirectory dokkaOutput
       }
-      androidJavadocsJar.dependsOn("dokka")
       androidJavadocsJar.configure {
         dependsOn "dokka"
         from dokkaOutput

--- a/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
@@ -41,18 +41,25 @@ class MavenPublishPlugin extends BaseMavenPublishPlugin {
 
     def androidJavadocsJar = project.tasks.create("androidJavadocsJar", Jar.class) {
       classifier = 'javadoc'
-      from project.androidJavadocs.destinationDir
     }
 
     if (plugins.hasPlugin('kotlin-android')) {
+      def dokkaOutput = "${project.docsDir}/dokka"
       project.plugins.apply('org.jetbrains.dokka-android')
       project.dokka {
         outputFormat 'javadoc'
-        outputDirectory project.androidJavadocs.destinationDir.path
+        outputDirectory dokkaOutput
       }
       androidJavadocsJar.dependsOn("dokka")
+      androidJavadocsJar.configure {
+        dependsOn "dokka"
+        from dokkaOutput
+      }
     } else {
-      androidJavadocsJar.dependsOn("androidJavadocs")
+      androidJavadocsJar.configure {
+        dependsOn "androidJavadocs"
+        from project.androidJavadocs.destinationDir
+      }
     }
 
     project.tasks.create("androidSourcesJar", Jar.class) {
@@ -85,18 +92,24 @@ class MavenPublishPlugin extends BaseMavenPublishPlugin {
 
     def javadocsJar = project.tasks.create("javadocsJar", Jar.class) {
       classifier = 'javadoc'
-      from project.javadoc.destinationDir
     }
 
     if (project.plugins.hasPlugin("kotlin")) {
+      def dokkaOutput = "${project.docsDir}/dokka"
       project.plugins.apply('org.jetbrains.dokka')
       project.dokka {
         outputFormat 'javadoc'
-        outputDirectory project.javadoc.destinationDir.path
+        outputDirectory dokkaOutput
       }
-      javadocsJar.dependsOn("dokka")
+      javadocsJar.configure {
+        dependsOn "dokka"
+        from dokkaOutput
+      }
     } else {
-      javadocsJar.dependsOn("javadoc")
+      javadocsJar.configure {
+        dependsOn "javadoc"
+        from project.javadoc.destinationDir
+      }
     }
 
     configurer.addComponent(project.components.java)

--- a/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
@@ -39,10 +39,21 @@ class MavenPublishPlugin extends BaseMavenPublishPlugin {
       options.linksOffline "https://developer.android.com/reference", "${project.android.sdkDirectory}/docs/reference"
     }
 
-    project.tasks.create("androidJavadocsJar", Jar.class) {
+    def androidJavadocsJar = project.tasks.create("androidJavadocsJar", Jar.class) {
       classifier = 'javadoc'
       from project.androidJavadocs.destinationDir
-    }.dependsOn("androidJavadocs")
+    }
+
+    if (plugins.hasPlugin('kotlin-android')) {
+      project.plugins.apply('org.jetbrains.dokka-android')
+      project.dokka {
+        outputFormat 'javadoc'
+        outputDirectory project.androidJavadocs.destinationDir.path
+      }
+      androidJavadocsJar.dependsOn("dokka")
+    } else {
+      androidJavadocsJar.dependsOn("androidJavadocs")
+    }
 
     project.tasks.create("androidSourcesJar", Jar.class) {
       classifier = 'sources'
@@ -72,10 +83,21 @@ class MavenPublishPlugin extends BaseMavenPublishPlugin {
       from project.sourceSets.main.allSource
     }.dependsOn("classes")
 
-    project.tasks.create("javadocsJar", Jar.class) {
+    def javadocsJar = project.tasks.create("javadocsJar", Jar.class) {
       classifier = 'javadoc'
       from project.javadoc.destinationDir
-    }.dependsOn("javadoc")
+    }
+
+    if (project.plugins.hasPlugin("kotlin")) {
+      project.plugins.apply('org.jetbrains.dokka')
+      project.dokka {
+        outputFormat 'javadoc'
+        outputDirectory project.javadoc.destinationDir.path
+      }
+      javadocsJar.dependsOn("dokka")
+    } else {
+      javadocsJar.dependsOn("javadoc")
+    }
 
     configurer.addComponent(project.components.java)
     configurer.addTaskOutput(project.jar)


### PR DESCRIPTION
Fixes https://github.com/vanniktech/gradle-maven-publish-plugin/issues/21

Since Dokka [does not support mixing with `JavaDocs`](https://github.com/Kotlin/dokka/issues/352#issuecomment-431342768) Dokka is now used to generate docs for both Kotlin and Java files on projects which uses `Kotlin`.