### PR TITLE
Remove duplicate jar task from archives configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,8 @@ apply plugin: 'kotlin'
 apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'com.vanniktech.code.quality.tools'
 apply plugin: 'com.vanniktech.android.junit.jacoco'
-apply plugin: 'com.gradle.plugin-publish'
 apply plugin: "com.vanniktech.maven.publish"
+apply plugin: 'com.gradle.plugin-publish'
 
 // Workaround for having both Groovy + Kotlin.
 compileGroovy {

--- a/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
@@ -78,7 +78,6 @@ class MavenPublishPlugin extends BaseMavenPublishPlugin {
     }.dependsOn("javadoc")
 
     configurer.addComponent(project.components.java)
-    configurer.addTaskOutput(project.jar)
     configurer.addTaskOutput(project.javadocsJar)
     if (plugins.hasPlugin('groovy')) {
       configurer.addTaskOutput(project.groovydocJar)

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
@@ -105,11 +105,6 @@ internal class MavenPublishConfigurer(private val project: Project) : Configurer
   }
 
   override fun addTaskOutput(task: AbstractArchiveTask) {
-    // default artifact should be added as SoftwareComponent
-    // TODO this is not really nice and we might need to add Android aars through this
-    if (task.classifier.isBlank()) {
-      return
-    }
     publication.artifact(task)
   }
 }

--- a/src/test/kotlin/com/vanniktech/maven/publish/MavenPublishPluginTest.kt
+++ b/src/test/kotlin/com/vanniktech/maven/publish/MavenPublishPluginTest.kt
@@ -4,6 +4,7 @@ import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.LibraryPlugin
 import org.assertj.core.api.Java6Assertions.assertThat
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency.ARCHIVES_CONFIGURATION
 import org.gradle.api.internal.project.DefaultProject
 import org.gradle.api.plugins.GroovyPlugin
 import org.gradle.api.plugins.JavaLibraryPlugin
@@ -30,18 +31,20 @@ class MavenPublishPluginTest {
   @Test fun javaPlugin() {
     project.plugins.apply(JavaPlugin::class.java)
     assert(project)
+    assertThat(project.configurations.getByName(ARCHIVES_CONFIGURATION).artifacts).hasSize(6)
   }
 
   @Test fun javaLibraryPlugin() {
     project.plugins.apply(JavaLibraryPlugin::class.java)
     assert(project)
+    assertThat(project.configurations.getByName(ARCHIVES_CONFIGURATION).artifacts).hasSize(6)
   }
 
   @Test fun javaLibraryPluginWithGroovy() {
     project.plugins.apply(JavaLibraryPlugin::class.java)
     project.plugins.apply(GroovyPlugin::class.java)
     assert(project)
-
+    assertThat(project.configurations.getByName(ARCHIVES_CONFIGURATION).artifacts).hasSize(8)
     assertThat(project.tasks.getByName("groovydocJar")).isNotNull()
   }
 


### PR DESCRIPTION
Prior to this PR, the `jar` task was unconditionally added to the
artifacts of the archives configuration even though it was already added
by the `java` plugin. The resulting duplicate was silently ignored by
Gradle until now but causes an exception when executing `signArchives`
in Gradle 5.1.

In addition, this PR resolves the TODO when the `maven-publish`
plugin is used since the `jar` is already added to the published
artifacts by the used `components.java`.

Fixes #38.