### PR TITLE
Change docs format for Kotlin project docs

### DIFF
--- a/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
@@ -47,7 +47,7 @@ class MavenPublishPlugin extends BaseMavenPublishPlugin {
       def dokkaOutput = "${project.docsDir}/dokka"
       project.plugins.apply('org.jetbrains.dokka-android')
       project.dokka {
-        outputFormat 'javadoc'
+        outputFormat 'html'
         outputDirectory dokkaOutput
       }
       androidJavadocsJar.configure {
@@ -97,7 +97,7 @@ class MavenPublishPlugin extends BaseMavenPublishPlugin {
       def dokkaOutput = "${project.docsDir}/dokka"
       project.plugins.apply('org.jetbrains.dokka')
       project.dokka {
-        outputFormat 'javadoc'
+        outputFormat 'html'
         outputDirectory dokkaOutput
       }
       javadocsJar.configure {


### PR DESCRIPTION
Initial Dokka integration implemented in https://github.com/vanniktech/gradle-maven-publish-plugin/pull/37 missed external documentation linking which resulted in Android SDK not being linked with project docs. 

I was not able to make Dokka link Android SDK using `javadocs` format, which should happen by default since Dokka [links Android SDK](https://github.com/Kotlin/dokka/blob/fc3b668e2acefad7990b8ed02b9382c0c800a04e/runners/android-gradle-plugin/src/main/kotlin/mainAndroid.kt#L36) from the box if `dokka-android` plugin is used. 

However, Dokka does link Android SDK for `Dokka` docs format.