### PR TITLE
Switch to task-configuration avoidance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,6 @@ pluginBundle {
 }
 
 wrapper {
-  gradleVersion = '5.1.1'
+  gradleVersion = '5.2.1'
   distributionType = Wrapper.DistributionType.ALL
 }

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ dependencies {
 
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.assertj:assertj-core:3.10.0'
-  testImplementation 'com.android.tools.build:gradle:3.1.2'
+  testImplementation 'com.android.tools.build:gradle:3.3.1'
   testImplementation 'com.github.stefanbirkner:system-rules:1.18.0'
   testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
   testImplementation "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlinVersion = '1.2.41'
+  ext.kotlinVersion = '1.3.21'
 
   repositories {
     mavenCentral()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -28,7 +28,7 @@ APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS=""
+DEFAULT_JVM_OPTS='"-Xmx64m"'
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -14,7 +14,7 @@ set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS=
+set DEFAULT_JVM_OPTS="-Xmx64m"
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome

--- a/src/test/kotlin/com/vanniktech/maven/publish/MavenPublishPluginTest.kt
+++ b/src/test/kotlin/com/vanniktech/maven/publish/MavenPublishPluginTest.kt
@@ -31,20 +31,20 @@ class MavenPublishPluginTest {
   @Test fun javaPlugin() {
     project.plugins.apply(JavaPlugin::class.java)
     assert(project)
-    assertThat(project.configurations.getByName(ARCHIVES_CONFIGURATION).artifacts).hasSize(6)
+    assertThat(project.configurations.getByName(ARCHIVES_CONFIGURATION).artifacts).hasSize(2)
   }
 
   @Test fun javaLibraryPlugin() {
     project.plugins.apply(JavaLibraryPlugin::class.java)
     assert(project)
-    assertThat(project.configurations.getByName(ARCHIVES_CONFIGURATION).artifacts).hasSize(6)
+    assertThat(project.configurations.getByName(ARCHIVES_CONFIGURATION).artifacts).hasSize(2)
   }
 
   @Test fun javaLibraryPluginWithGroovy() {
     project.plugins.apply(JavaLibraryPlugin::class.java)
     project.plugins.apply(GroovyPlugin::class.java)
     assert(project)
-    assertThat(project.configurations.getByName(ARCHIVES_CONFIGURATION).artifacts).hasSize(8)
+    assertThat(project.configurations.getByName(ARCHIVES_CONFIGURATION).artifacts).hasSize(2)
     assertThat(project.tasks.getByName("groovydocJar")).isNotNull()
   }
 


### PR DESCRIPTION
Resolves #44 

Requires AGP 3.3.x+, but I think this is a reasonable requirement since that's latest stable (and also what the gradle error prone plugin does) 