### PR TITLE
Nexus release automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ classpath 'com.vanniktech:gradle-maven-publish-plugin:0.9.0-SNAPSHOT'
 
 ## Configuration
 
+***Uploading:***
+
 Those are all the available configurations - shown with default values and their types. More information can be found in the [Documentation of the Extension](src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt).
 
 ```groovy
@@ -75,7 +77,33 @@ __Note:__ To prevent looping behavior, especially in Kotlin projects / modules, 
 
 `./gradlew uploadArchives --no-daemon --no-parallel`
 
-__Note:__  Other than the common maven plugin you must do the [release steps at sonatype](https://central.sonatype.org/pages/releasing-the-deployment.html) manually.
+***Releasing:***
+
+Once `uploadArchives` is called, and if you're using a Nexus repository, you'll have to make a release. This can be done manually by following the [release steps at sonatype](https://central.sonatype.org/pages/releasing-the-deployment.html).
+
+Alternatively, you can configure the plugin to do so automatically:
+
+```groovy
+mavenPublish {
+    // ...
+    nexus {
+        baseUrl = "https://your_nexus_instance" // defaults to "https://oss.sonatype.org/service/local/"
+        groupId = "net.example" // defaults to the GROUP Gradle Property if not set
+        respositoryUserName = "username" // defaults to the SONATYPE_NEXUS_USERNAME Gradle Property if not set
+        respositoryPassword = "password" // defaults to the SONATYPE_NEXUS_PASSWORD Gradle Property if not set
+    }
+}
+```
+
+This will create a `closeAndReleaseRepository` task that you can call after `uploadArchives`:
+
+```
+# prepare your release by assigning a version (remove the -SNAPSHOT suffix)
+./gradlew uploadArchives
+./gradlew closeAndReleaseRepository
+```
+
+It assumes there's only one staging repository active when closeAndReleaseRepository is called. If you have stale staging repositories, you'll have to delete them by logging at https://oss.sonatype.org (or you Nexus instance).
 
 # Sample
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ apply plugin: 'groovy'
 apply plugin: 'java-library'
 apply plugin: 'java-gradle-plugin'
 apply plugin: 'kotlin'
+apply plugin: 'kotlin-kapt'
 apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'com.vanniktech.code.quality.tools'
 apply plugin: 'com.vanniktech.android.junit.jacoco'
@@ -83,6 +84,12 @@ dependencies {
 
   compileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
   compileOnly "com.android.tools.build:gradle:3.6.0-rc01"
+
+  kapt "com.squareup.moshi:moshi-kotlin-codegen:1.8.0"
+
+  implementation("com.squareup.moshi:moshi:1.8.0")
+  implementation 'com.squareup.retrofit2:retrofit:2.5.0'
+  implementation 'com.squareup.retrofit2:converter-moshi:2.5.0'
 
   testImplementation "junit:junit:$junitVersion"
   testImplementation "org.assertj:assertj-core:$assertjVersion"

--- a/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
@@ -1,6 +1,7 @@
 package com.vanniktech.maven.publish
 
 import org.gradle.api.JavaVersion
+import com.vanniktech.maven.publish.nexus.NexusConfigurer
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginConvention
@@ -45,6 +46,8 @@ internal abstract class BaseMavenPublishPlugin : Plugin<Project> {
       } else {
         setupConfigurerForJava(project, configurer)
       }
+
+      NexusConfigurer(project)
     }
   }
 

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
@@ -1,6 +1,8 @@
 package com.vanniktech.maven.publish
 
+import com.vanniktech.maven.publish.nexus.NexusOptions
 import groovy.lang.Closure
+import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 
@@ -43,6 +45,20 @@ open class MavenPublishPluginExtension(project: Project) {
    * @Since 0.9.0
    */
   var androidVariantToPublish: String = "release"
+
+  /**
+   * Allows to promote repositories without connecting to the nexus instance console.
+   * @since 0.9.0
+   */
+  var nexusOptions = NexusOptions()
+
+  /**
+   * Allows to promote repositories without connecting to the nexus instance console.
+   * @since 0.9.0
+   */
+  fun nexus(action: Action<NexusOptions>) {
+    action.execute(nexusOptions)
+  }
 
   /**
    * Allows to add additional [MavenPublishTargets][MavenPublishTarget] to publish to multiple repositories.

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPom.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPom.kt
@@ -45,12 +45,5 @@ internal data class MavenPublishPom(
         project.findOptionalProperty("POM_DEVELOPER_NAME"),
         project.findOptionalProperty("POM_DEVELOPER_URL")
     )
-
-    private fun Project.findMandatoryProperty(propertyName: String): String {
-      val value = this.findOptionalProperty(propertyName)
-      return requireNotNull(value) { "Please define \"$propertyName\" in your gradle.properties file" }
-    }
-
-    private fun Project.findOptionalProperty(propertyName: String) = findProperty(propertyName)?.toString()
   }
 }

--- a/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
@@ -1,0 +1,10 @@
+package com.vanniktech.maven.publish
+
+import org.gradle.api.Project
+
+fun Project.findMandatoryProperty(propertyName: String): String {
+  val value = this.findOptionalProperty(propertyName)
+  return requireNotNull(value) { "Please define \"$propertyName\" in your gradle.properties file" }
+}
+
+fun Project.findOptionalProperty(propertyName: String) = findProperty(propertyName)?.toString()

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/CloseAndReleaseRepositoryTask.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/CloseAndReleaseRepositoryTask.kt
@@ -1,0 +1,26 @@
+package com.vanniktech.maven.publish.nexus
+
+import com.vanniktech.maven.publish.MavenPublishPluginExtension
+import com.vanniktech.maven.publish.findMandatoryProperty
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+open class CloseAndReleaseRepositoryTask : DefaultTask() {
+  @SuppressWarnings("unused")
+  @TaskAction
+  fun closeAndReleaseRepository() {
+    val mavenPublishPluginExtension = project.extensions.getByType(MavenPublishPluginExtension::class.java)
+    val nexusOptions = mavenPublishPluginExtension.nexusOptions
+
+    val baseUrl = nexusOptions.baseUrl ?: OSSRH_API_BASE_URL
+    val groupId = nexusOptions.groupId ?: project.findMandatoryProperty("GROUP")
+    val repositoryUsername = nexusOptions.repositoryUsername ?: project.findMandatoryProperty("SONATYPE_NEXUS_USERNAME")
+    val repositoryPassword = nexusOptions.repositoryPassword ?: project.findMandatoryProperty("SONATYPE_NEXUS_PASSWORD")
+
+    Nexus(repositoryUsername, repositoryPassword, groupId, baseUrl).closeAndReleaseRepository()
+  }
+
+  companion object {
+    const val OSSRH_API_BASE_URL = "https://oss.sonatype.org/service/local/"
+  }
+}

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/CloseAndReleaseRepositoryTask.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/CloseAndReleaseRepositoryTask.kt
@@ -2,6 +2,7 @@ package com.vanniktech.maven.publish.nexus
 
 import com.vanniktech.maven.publish.MavenPublishPluginExtension
 import com.vanniktech.maven.publish.findMandatoryProperty
+import com.vanniktech.maven.publish.findOptionalProperty
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
@@ -14,8 +15,21 @@ open class CloseAndReleaseRepositoryTask : DefaultTask() {
 
     val baseUrl = nexusOptions.baseUrl ?: OSSRH_API_BASE_URL
     val groupId = nexusOptions.groupId ?: project.findMandatoryProperty("GROUP")
-    val repositoryUsername = nexusOptions.repositoryUsername ?: project.findMandatoryProperty("SONATYPE_NEXUS_USERNAME")
-    val repositoryPassword = nexusOptions.repositoryPassword ?: project.findMandatoryProperty("SONATYPE_NEXUS_PASSWORD")
+    val repositoryUsername = nexusOptions.repositoryUsername
+      ?: project.findOptionalProperty("SONATYPE_NEXUS_USERNAME")
+      ?: System.getenv("SONATYPE_NEXUS_USERNAME")
+
+    requireNotNull(repositoryUsername) {
+      "Please set a value for SONATYPE_NEXUS_USERNAME"
+    }
+
+    val repositoryPassword = nexusOptions.repositoryPassword
+      ?: project.findOptionalProperty("SONATYPE_NEXUS_PASSWORD")
+      ?: System.getenv("SONATYPE_NEXUS_PASSWORD")
+
+    requireNotNull(repositoryPassword) {
+      "Please set a value for SONATYPE_NEXUS_PASSWORD"
+    }
 
     Nexus(repositoryUsername, repositoryPassword, groupId, baseUrl).closeAndReleaseRepository()
   }

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
@@ -86,6 +86,8 @@ class Nexus(username: String, password: String, val groupId: String, baseUrl: St
       }
 
       print("\r${waitingChars[i++ % waitingChars.size]} waiting for close...")
+      System.out.flush()
+      
       Thread.sleep(CLOSE_WAIT_INTERVAL_MILLIS)
 
       try {

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
@@ -87,7 +87,7 @@ class Nexus(username: String, password: String, val groupId: String, baseUrl: St
 
       print("\r${waitingChars[i++ % waitingChars.size]} waiting for close...")
       System.out.flush()
-      
+
       Thread.sleep(CLOSE_WAIT_INTERVAL_MILLIS)
 
       try {

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
@@ -1,0 +1,137 @@
+package com.vanniktech.maven.publish.nexus
+
+import com.vanniktech.maven.publish.nexus.model.TransitionRepositoryInput
+import com.vanniktech.maven.publish.nexus.model.TransitionRepositoryInputData
+import com.vanniktech.maven.publish.nexus.model.Repository
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import java.io.IOException
+import java.lang.IllegalArgumentException
+
+class Nexus(username: String, password: String, val groupId: String, baseUrl: String) {
+  private val service by lazy {
+    val okHttpClient = OkHttpClient.Builder()
+      .addInterceptor(NexusOkHttpInterceptor(username, password))
+      .build()
+    val retrofit = Retrofit.Builder()
+      .addConverterFactory(MoshiConverterFactory.create())
+      .client(okHttpClient)
+      .baseUrl(baseUrl)
+      .build()
+
+    retrofit.create(NexusService::class.java)
+  }
+
+  private fun getProfileRepositories(): List<Repository>? {
+    val profileRepositoriesResponse = service.getProfileRepositories().execute()
+
+    if (!profileRepositoriesResponse.isSuccessful) {
+      throw IOException("Cannot get profileRepositories: ${profileRepositoriesResponse.errorBody()?.string()}")
+    }
+
+    return profileRepositoriesResponse.body()?.data
+  }
+
+  private fun findStagingRepository(): Repository {
+    val candidateRepositories = getProfileRepositories()
+      ?.filter { it.repositoryId.startsWith(groupId.replace(".", "")) } ?: emptyList()
+
+    if (candidateRepositories.isEmpty()) {
+      throw IllegalArgumentException("No staging repository find. Did you call ./gradlew uploadArchives ?")
+    }
+
+    if (candidateRepositories.size > 1) {
+      throw IllegalArgumentException("You have ${candidateRepositories.size} staging repositories, please login on https://oss.sonatype.org and drop stale repositories. This script only works with one active staging repository at a time.")
+    }
+    return candidateRepositories[0]
+  }
+
+  fun findAndCloseStagingRepository(): String {
+    val stagingRepository = findStagingRepository()
+    val repositoryId = stagingRepository.repositoryId
+
+    if (stagingRepository.type != "open") {
+      throw IllegalArgumentException("Repository $repositoryId is of type '${stagingRepository.type}' and not 'open'")
+    }
+
+    println("Closing repository: $repositoryId")
+    val response = service.closeRepository(TransitionRepositoryInput(TransitionRepositoryInputData(listOf(repositoryId)))).execute()
+    if (!response.isSuccessful) {
+      throw IOException("Cannot close repository: ${response.errorBody()?.string()}")
+    }
+
+    waitForClose(repositoryId)
+
+    return repositoryId
+  }
+
+  private fun waitForClose(repositoryId: String) {
+
+    val startMillis = System.currentTimeMillis()
+
+    val waitingChars = listOf(
+      PROGRESS_1,
+      PROGRESS_2,
+      PROGRESS_3,
+      PROGRESS_4,
+      PROGRESS_5,
+      PROGRESS_6,
+      PROGRESS_7
+    )
+    var i = 0
+    while (true) {
+      if (System.currentTimeMillis() - startMillis > CLOSE_TIMEOUT_MILLIS) {
+        throw IOException("Timeout waiting for repository close")
+      }
+
+      print("\r${waitingChars[i++ % waitingChars.size]} waiting for close...")
+      Thread.sleep(CLOSE_WAIT_INTERVAL_MILLIS)
+
+      try {
+        val repository = service.getRepository(repositoryId).execute().body()
+        if (repository?.type == "closed") {
+          break
+        }
+      } catch (e: IOException) {
+        System.err.println("Exception trying to get repository status: ${e.message}")
+      }
+    }
+  }
+
+  fun releaseStagingRepository(repositoryId: String) {
+    println("Releasing repository: $repositoryId")
+    val response = service.releaseRepository(
+      TransitionRepositoryInput(
+        TransitionRepositoryInputData(
+          stagedRepositoryIds = listOf(repositoryId),
+          autoDropAfterRelease = true
+        )
+      )
+    ).execute()
+
+    if (!response.isSuccessful) {
+      throw IOException("Cannot release repository: ${response.errorBody()?.string()}")
+    }
+
+    println("Repository $repositoryId released")
+  }
+
+  fun closeAndReleaseRepository() {
+    val repositoryId = findAndCloseStagingRepository()
+    releaseStagingRepository(repositoryId)
+  }
+
+  companion object {
+    private const val PROGRESS_1 = "\u2839"
+    private const val PROGRESS_2 = "\u2838"
+    private const val PROGRESS_3 = "\u2834"
+    private const val PROGRESS_4 = "\u2826"
+    private const val PROGRESS_5 = "\u2807"
+    private const val PROGRESS_6 = "\u280F"
+    private const val PROGRESS_7 = "\u2819"
+
+    private const val CLOSE_TIMEOUT_MILLIS = 15 * 60 * 1000L
+    private const val CLOSE_WAIT_INTERVAL_MILLIS = 10_000L
+  }
+}

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusConfigurer.kt
@@ -1,0 +1,11 @@
+package com.vanniktech.maven.publish.nexus
+
+import org.gradle.api.Project
+
+class NexusConfigurer(project: Project) {
+  init {
+    val task = project.tasks.create<CloseAndReleaseRepositoryTask>("closeAndReleaseRepository", CloseAndReleaseRepositoryTask::class.java)
+    task.description = "Closes and releases an artifacts repository in Nexus"
+    task.group = "release"
+  }
+}

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusOkHttpInterceptor.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusOkHttpInterceptor.kt
@@ -1,0 +1,16 @@
+package com.vanniktech.maven.publish.nexus
+
+import okhttp3.Credentials
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class NexusOkHttpInterceptor(val username: String, val password: String) : Interceptor {
+  override fun intercept(chain: Interceptor.Chain): Response {
+    val requestBuilder = chain.request().newBuilder()
+
+    requestBuilder.addHeader("Accept", "application/json") // request json by default, XML is returned else
+    requestBuilder.addHeader("Authorization", Credentials.basic(username, password))
+
+    return chain.proceed(requestBuilder.build())
+  }
+}

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusOptions.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusOptions.kt
@@ -1,0 +1,31 @@
+package com.vanniktech.maven.publish.nexus
+
+class NexusOptions {
+  /**
+   * Base url of the REST API of the nexus instance you are using.
+   * Defaults to OSSRH ("https://oss.sonatype.org/service/local/").
+   * @since 0.9.0
+   */
+  var baseUrl: String? = null
+
+  /**
+   * The groupId associated with your username.
+   * Defaults to the GROUP Gradle Property.
+   * @since 0.9.0
+   */
+  var groupId: String? = null
+
+  /**
+   * The username used to access the Nexus REST API.
+   * Defaults to the SONATYPE_NEXUS_USERNAME Gradle property.
+   * @since 0.9.0
+   */
+  var repositoryUsername: String? = null
+
+  /**
+   * The username used to access the Nexus REST API.
+   * Defaults to the SONATYPE_NEXUS_PASSWORD Gradle property.
+   * @since 0.9.0
+   */
+  var repositoryPassword: String? = null
+}

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusService.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusService.kt
@@ -1,0 +1,28 @@
+package com.vanniktech.maven.publish.nexus
+
+import com.vanniktech.maven.publish.nexus.model.TransitionRepositoryInput
+import com.vanniktech.maven.publish.nexus.model.ProfileRepositoriesResponse
+import com.vanniktech.maven.publish.nexus.model.Repository
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+/* Nexus service definition based on the incomplete documentation at:
+ * -Nexus STAGING API: https://oss.sonatype.org/nexus-staging-plugin/default/docs/index.html
+ * -Nexus CORE API: https://repository.sonatype.org/nexus-restlet1x-plugin/default/docs/index.html
+ */
+interface NexusService {
+  @GET("staging/profile_repositories")
+  fun getProfileRepositories(): Call<ProfileRepositoriesResponse>
+
+  @GET("staging/repository/{repositoryId}")
+  fun getRepository(@Path("repositoryId") repositoryId: String): Call<Repository>
+
+  @POST("staging/bulk/close")
+  fun closeRepository(@Body input: TransitionRepositoryInput): Call<Unit>
+
+  @POST("staging/bulk/promote")
+  fun releaseRepository(@Body input: TransitionRepositoryInput): Call<Unit>
+}

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/model/Model.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/model/Model.kt
@@ -1,0 +1,15 @@
+package com.vanniktech.maven.publish.nexus.model
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Repository(val repositoryId: String, val transitioning: Boolean, val type: String)
+
+@JsonClass(generateAdapter = true)
+data class ProfileRepositoriesResponse(val data: List<Repository>)
+
+@JsonClass(generateAdapter = true)
+data class TransitionRepositoryInputData(val stagedRepositoryIds: List<String>, val autoDropAfterRelease: Boolean? = null)
+
+@JsonClass(generateAdapter = true)
+data class TransitionRepositoryInput(val data: TransitionRepositoryInputData)


### PR DESCRIPTION
See https://github.com/vanniktech/gradle-maven-publish-plugin/issues/60

This pull requests add a new task named `closeAndReleaseRepository`. It automates the process listed there: https://central.sonatype.org/pages/releasing-the-deployment.html.

`closeAndReleaseRepository` is completely independent from the other tasks and it assumes `uploadArchives` has been called first. Obviously, this only works with nexus repositories as I'm unsure how the API looks like for other repos.

Usage:

    # prepare your release by assigning a version (remove the -SNAPSHOT suffix)
    ./gradlew uploadArchives
    ./gradlew closeAndReleaseRepository

Configuration:

    mavenPublish {
        nexus {
            baseUrl = "https://your_nexus_instance" // defaults to "https://oss.sonatype.org/service/local/"
            groupId = "net.example" // defaults to the GROUP Gradle Property if not set
            respositoryUserName = "username" // defaults to the SONATYPE_NEXUS_USERNAME Gradle Property if not set
            respositoryPassword = "password" // defaults to the SONATYPE_NEXUS_PASSWORD Gradle Property if not set
        }
    }

This pull request is heavily inspired by https://github.com/Codearte/gradle-nexus-staging-plugin. Kudos to them! It assumes there's only one staging repository active when `closeAndReleaseRepository` is called. If you have stale staging repositories, you'll have to delete them by logging at https://oss.sonatype.org.

Documentation and updated README is still missing as I wanted to get some feedback about what you think about the naming, etc...