### PR TITLE
Update README.md to include signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ __Note:__  Other than the common maven plugin you must do the [release steps at 
 
 This Gradle plugin is using itself to publish any of the updates. It applies a previously released version in the build.gradle just as mentioned above and sets the Gradle properties in this [gradle.properties](gradle.properties).
 
+In addition to these properties, you will also want to add the following, keeping them hidden and out of source control.
+```
+signing.keyId=12345678
+signing.password=some_password
+signing.secretKeyRingFile=/Users/yourusername/.gnupg/secring.gpg
+```
+You can learn more about GPG signing in [this post](https://medium.com/@nmauti/publishing-a-project-on-maven-central-8106393db2c3).
+
 # License
 
 Copyright (C) 2018 Vanniktech - Niklas Baudy

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ __Note:__  Other than the common maven plugin you must do the [release steps at 
 This Gradle plugin is using itself to publish any of the updates. It applies a previously released version in the build.gradle just as mentioned above and sets the Gradle properties in this [gradle.properties](gradle.properties).
 
 In addition to these properties, you will also want to add the following, keeping them hidden and out of source control.
-```
+```groovy
 signing.keyId=12345678
 signing.password=some_password
 signing.secretKeyRingFile=/Users/yourusername/.gnupg/secring.gpg

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ signing.keyId=12345678
 signing.password=some_password
 signing.secretKeyRingFile=/Users/yourusername/.gnupg/secring.gpg
 ```
-You can learn more about GPG signing in [this post](https://medium.com/@nmauti/publishing-a-project-on-maven-central-8106393db2c3).
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ __Note:__  Other than the common maven plugin you must do the [release steps at 
 
 This Gradle plugin is using itself to publish any of the updates. It applies a previously released version in the build.gradle just as mentioned above and sets the Gradle properties in this [gradle.properties](gradle.properties).
 
-In addition to these properties, you will also want to add the following, keeping them hidden and out of source control.
+If you require your binary to be signed with GPG (mavenCentral requires this for instance), please add the following Gradle properties. It's best to place them inside your home directory, `$HOME/.gradle/gradle.properties`.
 ```groovy
 signing.keyId=12345678
 signing.password=some_password


### PR DESCRIPTION
I am curious where you are putting the signing values, if not in your `gradle.properties`? I was thinking `local.properties` but I don't think it reads from there, correct? Is there something else you can do or somewhere else you can put them to make it work @vanniktech ?