### PR TITLE
rename useMavenPublish to useLegacyMode

### DIFF
--- a/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -4,7 +4,6 @@ import org.assertj.core.api.Java6Assertions.assertThat
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
-import org.junit.Assume.assumeFalse
 import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Rule

--- a/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
@@ -10,6 +10,7 @@ import org.gradle.api.tasks.Upload
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.jetbrains.annotations.NotNull
+import java.lang.IllegalStateException
 
 class MavenPublishPlugin extends BaseMavenPublishPlugin {
 
@@ -70,7 +71,7 @@ class MavenPublishPlugin extends BaseMavenPublishPlugin {
     }
     configurer.addTaskOutput(androidSourcesJar)
 
-    if (extension.useMavenPublish) {
+    if (!extension.useLegacyMode) {
       throw IllegalArgumentException("Using maven-publish for Android libraries is currently unsupported.")
     }
   }

--- a/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
@@ -21,8 +21,8 @@ internal abstract class BaseMavenPublishPlugin : Plugin<Project> {
 
     p.afterEvaluate { project ->
       val configurer = when {
-        extension.useMavenPublish -> MavenPublishConfigurer(project)
-        else -> UploadArchivesConfigurer(project, extension.targets, ::configureMavenDeployer)
+        extension.useLegacyMode -> UploadArchivesConfigurer(project, extension.targets, ::configureMavenDeployer)
+        else -> MavenPublishConfigurer(project)
       }
 
       extension.targets.all {

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
@@ -25,15 +25,15 @@ open class MavenPublishPluginExtension(project: Project) {
   )
 
   /**
-   * If set to true the new `maven-publish` plugin will be used instead of the soon to be deprecated
+   * If set to false the new `maven-publish` plugin will be used instead of the soon to be deprecated
    * `maven` plugin.
    *
    * This is **experimental** and Android projects are unsupported until
    * [this issue][https://issuetracker.google.com/issues/37055147] is fixed.
    *
-   * @Since 0.8.0
+   * @Since 0.9.0
    */
-  var useMavenPublish: Boolean = false
+  var useLegacyMode: Boolean = true
 
   /**
    * Allows to add additional [MavenPublishTargets][MavenPublishTarget] to publish to multiple repositories.


### PR DESCRIPTION
The current name is not wrong, but can be a bit confusing since this plugin is also called contains maven publish in it's name. Since we never advertised this in the readme I think it's fine to do the breaking change.