### PR TITLE
initial Android support for maven-publish

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -125,8 +125,8 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin ; then
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
     JAVACMD=`cygpath --unix "$JAVACMD"`

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem      https://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/integrationTest/fixtures/passing_android_project/expected/test-artifact.pom
+++ b/src/integrationTest/fixtures/passing_android_project/expected/test-artifact.pom
@@ -5,7 +5,6 @@
   <groupId>com.example</groupId>
   <artifactId>test-artifact</artifactId>
   <version>1.0.0</version>
-  <packaging>aar</packaging>
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>

--- a/src/integrationTest/fixtures/passing_android_project/settings.gradle
+++ b/src/integrationTest/fixtures/passing_android_project/settings.gradle
@@ -8,7 +8,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "com.android.library") {
-                useModule("com.android.tools.build:gradle:3.5.3")
+                useModule("com.android.tools.build:gradle:3.6.0-rc01")
             }
         }
     }

--- a/src/integrationTest/fixtures/passing_android_with_kotlin_project/expected/test-artifact.pom
+++ b/src/integrationTest/fixtures/passing_android_with_kotlin_project/expected/test-artifact.pom
@@ -5,7 +5,6 @@
   <groupId>com.example</groupId>
   <artifactId>test-artifact</artifactId>
   <version>1.0.0</version>
-  <packaging>aar</packaging>
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>

--- a/src/integrationTest/fixtures/passing_android_with_kotlin_project/settings.gradle
+++ b/src/integrationTest/fixtures/passing_android_with_kotlin_project/settings.gradle
@@ -8,7 +8,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "com.android.library") {
-                useModule("com.android.tools.build:gradle:3.5.3")
+                useModule("com.android.tools.build:gradle:3.6.0-rc01")
             }
             if (requested.id.id == "org.jetbrains.kotlin.android") {
                 useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")

--- a/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
@@ -10,7 +10,6 @@ import org.gradle.api.tasks.Upload
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.jetbrains.annotations.NotNull
-import java.lang.IllegalStateException
 
 class MavenPublishPlugin extends BaseMavenPublishPlugin {
 
@@ -18,6 +17,10 @@ class MavenPublishPlugin extends BaseMavenPublishPlugin {
   protected void setupConfigurerForAndroid(@NotNull Project project, @NotNull Configurer configurer) {
     PluginContainer plugins = project.plugins
     MavenPublishPluginExtension extension = project.extensions.getByType(MavenPublishPluginExtension.class)
+
+    if (!extension.useLegacyMode) {
+      configurer.addComponent(project.components.getByName(extension.androidVariantToPublish))
+    }
 
     // Append also the classpath and files for release library variants. This fixes the javadoc warnings.
     // Got it from here - https://github.com/novoda/bintray-release/pull/39/files
@@ -70,10 +73,6 @@ class MavenPublishPlugin extends BaseMavenPublishPlugin {
       from project.android.sourceSets.main.java.srcDirs
     }
     configurer.addTaskOutput(androidSourcesJar)
-
-    if (!extension.useLegacyMode) {
-      throw IllegalArgumentException("Using maven-publish for Android libraries is currently unsupported.")
-    }
   }
 
   @Override

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
@@ -36,6 +36,16 @@ open class MavenPublishPluginExtension(project: Project) {
   var useLegacyMode: Boolean = true
 
   /**
+   * The Android library variant that should be published. Projects not using any product flavors, that just want
+   * to publish the release build type can use the default.
+   *
+   * This is **not supported** in legacy mode.
+   *
+   * @Since 0.9.0
+   */
+  var androidVariantToPublish: String = "release"
+
+  /**
    * Allows to add additional [MavenPublishTargets][MavenPublishTarget] to publish to multiple repositories.
    * @since 0.7.0
    */

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
@@ -28,8 +28,7 @@ open class MavenPublishPluginExtension(project: Project) {
    * If set to false the new `maven-publish` plugin will be used instead of the soon to be deprecated
    * `maven` plugin.
    *
-   * This is **experimental** and Android projects are unsupported until
-   * [this issue][https://issuetracker.google.com/issues/37055147] is fixed.
+   * For Android libraries version 3.6.0 of the Android Gradle Plugin is required in non legacy mode.
    *
    * @Since 0.9.0
    */


### PR DESCRIPTION
Except for the already existing pom issue described in #82 it seems to work out of the box. Since that issue is already existent in published releases I've added a workaround to the tests for now.

Updated Gradle to 5.6.4 which is required by AGP 3.6.0-rc01.

Closes #34 