### PR TITLE
forward Gradle test output

### DIFF
--- a/gradle/integration-test.gradle
+++ b/gradle/integration-test.gradle
@@ -18,6 +18,10 @@ task integrationTest(type: Test) {
   testClassesDirs = sourceSets.integrationTest.output.classesDirs
   classpath = sourceSets.integrationTest.runtimeClasspath
   mustRunAfter test
+
+  testLogging {
+    showStandardStreams = true
+  }
 }
 
 check.dependsOn integrationTest

--- a/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -175,5 +175,6 @@ class MavenPublishPluginIntegrationTest(
       .withProjectDir(testProjectDir.root)
       .withArguments(*commands)
       .withPluginClasspath()
+      .forwardOutput()
       .build()
 }


### PR DESCRIPTION
The maven-publish tests for uploadArchives are failing on master. This should give the exact information why.