### PR TITLE
explicitly set repository credentials to null in tests

### DIFF
--- a/gradle/integration-test.gradle
+++ b/gradle/integration-test.gradle
@@ -18,10 +18,6 @@ task integrationTest(type: Test) {
   testClassesDirs = sourceSets.integrationTest.output.classesDirs
   classpath = sourceSets.integrationTest.runtimeClasspath
   mustRunAfter test
-
-  testLogging {
-    showStandardStreams = true
-  }
 }
 
 check.dependsOn integrationTest

--- a/src/integrationTest/fixtures/common/maven-publish.gradle
+++ b/src/integrationTest/fixtures/common/maven-publish.gradle
@@ -3,10 +3,14 @@ mavenPublish {
     targets {
         installArchives {
             releaseRepositoryUrl = "file://${project.property("test.releaseRepository")}"
+            repositoryUsername = null
+            repositoryPassword = null
             signing = true
         }
         uploadArchives {
             releaseRepositoryUrl = "file://${project.property("test.releaseRepository")}"
+            repositoryUsername = null
+            repositoryPassword = null
             signing = true
         }
     }

--- a/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -183,6 +183,5 @@ class MavenPublishPluginIntegrationTest(
       .withProjectDir(testProjectDir.root)
       .withArguments(*commands)
       .withPluginClasspath()
-      .forwardOutput()
       .build()
 }


### PR DESCRIPTION
It failed because the tests picked up the publishing credentials from env vars which are not added to pull requests: `Authentication scheme 'all'(Authentication) is not supported by protocol 'file'`.