### PR TITLE
move javadoc configuration to Kotlin, add html5 option

### DIFF
--- a/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
@@ -123,17 +123,6 @@ class MavenPublishPlugin extends BaseMavenPublishPlugin {
   }
 
   @Override
-  protected void java8Javadoc(Project project) {
-    if (JavaVersion.current().isJava8Compatible()) {
-      project.allprojects {
-        tasks.withType(Javadoc) {
-          options.addStringOption('Xdoclint:none', '-quiet')
-        }
-      }
-    }
-  }
-
-  @Override
   protected void configureMavenDeployer(Upload upload, Project project, MavenPublishTarget target) {
     upload.repositories {
       mavenDeployer {

--- a/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
@@ -1,8 +1,11 @@
 package com.vanniktech.maven.publish
 
+import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.Upload
+import org.gradle.api.tasks.javadoc.Javadoc
+import org.gradle.external.javadoc.StandardJavadocDocletOptions
 import org.gradle.util.VersionNumber
 
 internal abstract class BaseMavenPublishPlugin : Plugin<Project> {
@@ -18,6 +21,8 @@ internal abstract class BaseMavenPublishPlugin : Plugin<Project> {
     val pom = MavenPublishPom.fromProject(p)
     p.group = pom.groupId
     p.version = pom.version
+
+    configureJavadoc(p)
 
     p.afterEvaluate { project ->
       val configurer = when {
@@ -37,16 +42,24 @@ internal abstract class BaseMavenPublishPlugin : Plugin<Project> {
       } else {
         setupConfigurerForJava(project, configurer)
       }
+    }
+  }
 
-      java8Javadoc(project)
+  private fun configureJavadoc(project: Project) {
+    project.tasks.withType(Javadoc::class.java) {
+      val options = it.options as StandardJavadocDocletOptions
+      if(JavaVersion.current().isJava9Compatible) {
+        options.addBooleanOption("html5", true)
+      }
+      if (JavaVersion.current().isJava8Compatible) {
+        options.addStringOption("Xdoclint:none", "-quiet")
+      }
     }
   }
 
   protected abstract fun setupConfigurerForAndroid(project: Project, configurer: Configurer)
 
   protected abstract fun setupConfigurerForJava(project: Project, configurer: Configurer)
-
-  protected abstract fun java8Javadoc(project: Project)
 
   protected abstract fun configureMavenDeployer(
     upload: Upload,

--- a/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
@@ -48,7 +48,7 @@ internal abstract class BaseMavenPublishPlugin : Plugin<Project> {
   private fun configureJavadoc(project: Project) {
     project.tasks.withType(Javadoc::class.java).configureEach {
       val options = it.options as StandardJavadocDocletOptions
-      if(JavaVersion.current().isJava9Compatible) {
+      if (JavaVersion.current().isJava9Compatible) {
         options.addBooleanOption("html5", true)
       }
       if (JavaVersion.current().isJava8Compatible) {

--- a/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
@@ -46,7 +46,7 @@ internal abstract class BaseMavenPublishPlugin : Plugin<Project> {
   }
 
   private fun configureJavadoc(project: Project) {
-    project.tasks.withType(Javadoc::class.java) {
+    project.tasks.withType(Javadoc::class.java).configureEach {
       val options = it.options as StandardJavadocDocletOptions
       if(JavaVersion.current().isJava9Compatible) {
         options.addBooleanOption("html5", true)


### PR DESCRIPTION
The html5 option is taken from this guide:
https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:complete_example