### PR TITLE
move dokka configuration to Kotlin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,8 +78,8 @@ dependencies {
   api localGroovy()
   api "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
-  runtime "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokkaVersion"
-  runtime "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
+  implementation "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokkaVersion"
+  implementation "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
 
   testImplementation "junit:junit:$junitVersion"
   testImplementation "org.assertj:assertj-core:$assertjVersion"

--- a/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
@@ -50,16 +50,10 @@ class MavenPublishPlugin extends BaseMavenPublishPlugin {
     }
     configurer.addTaskOutput(androidJavadocsJar)
 
-    if (plugins.hasPlugin('kotlin-android')) {
-      def dokkaOutput = "${project.docsDir}/dokka"
-      project.plugins.apply('org.jetbrains.dokka')
-      project.dokka {
-        outputFormat 'html'
-        outputDirectory dokkaOutput
-      }
+    if (project.plugins.hasPlugin("org.jetbrains.dokka")) {
       androidJavadocsJar.configure {
         dependsOn "dokka"
-        from dokkaOutput
+        from project.dokka.outputDirectory
       }
     } else {
       androidJavadocsJar.configure {
@@ -103,16 +97,10 @@ class MavenPublishPlugin extends BaseMavenPublishPlugin {
     }
     configurer.addTaskOutput(javadocsJar)
 
-    if (project.plugins.hasPlugin("kotlin")) {
-      def dokkaOutput = "${project.docsDir}/dokka"
-      project.plugins.apply('org.jetbrains.dokka')
-      project.dokka {
-        outputFormat 'html'
-        outputDirectory dokkaOutput
-      }
+    if (project.plugins.hasPlugin("org.jetbrains.dokka")) {
       javadocsJar.configure {
         dependsOn "dokka"
-        from dokkaOutput
+        from project.dokka.outputDirectory
       }
     } else {
       javadocsJar.configure {

--- a/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
@@ -48,12 +48,12 @@ internal abstract class BaseMavenPublishPlugin : Plugin<Project> {
 
   private fun configureDokka(project: Project) {
     project.plugins.withId("org.jetbrains.kotlin.jvm") {
-      project.plugins.apply("org.jetbrains.dokka")
+      project.plugins.apply(PLUGIN_DOKKA)
     }
     project.plugins.withId("org.jetbrains.kotlin.android") {
-      project.plugins.apply("org.jetbrains.dokka")
+      project.plugins.apply(PLUGIN_DOKKA)
     }
-    project.plugins.withId("org.jetbrains.dokka") {
+    project.plugins.withId(PLUGIN_DOKKA) {
       project.tasks.withType(DokkaTask::class.java).configureEach {
         if (it.outputDirectory.isEmpty()) {
           val javaConvention = project.convention.getPlugin(JavaPluginConvention::class.java)
@@ -79,5 +79,7 @@ internal abstract class BaseMavenPublishPlugin : Plugin<Project> {
     const val MINIMUM_GRADLE_MAJOR = 4
     const val MINIMUM_GRADLE_MINOR = 10
     const val MINIMUM_GRADLE_MICRO = 1
+
+    const val PLUGIN_DOKKA = "org.jetbrains.dokka"
   }
 }


### PR DESCRIPTION
To fix #68 this is making 2 changes to the configuration. Everything is moved out of `afterEvaluate` which will make overwriting what we do in build scripts possible without them having to use afterEvaluate as well. The other change is that we will only set the `outputDirectory` when it wasn't set before, in most cases that shouldn't be necessary but it avoids conflicts with other `plugins.withId("org.jetbrains.dokka")` usages that might run before us. I removed the `outputFormat` because it already defaults to html.