### PR TITLE
move task and artifact setup into configurers

### DIFF
--- a/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/maven/publish/MavenPublishPlugin.groovy
@@ -1,53 +1,11 @@
 package com.vanniktech.maven.publish
 
-import com.vanniktech.maven.publish.tasks.AndroidSourcesJar
-import com.vanniktech.maven.publish.tasks.AndroidJavadocs
-import com.vanniktech.maven.publish.tasks.AndroidJavadocsJar
-import com.vanniktech.maven.publish.tasks.GroovydocsJar
-import com.vanniktech.maven.publish.tasks.SourcesJar
-import com.vanniktech.maven.publish.tasks.JavadocsJar
 import org.gradle.api.Project
 import org.gradle.api.artifacts.maven.MavenDeployment
 import org.gradle.api.artifacts.maven.MavenPom
-import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.tasks.Upload
-import org.jetbrains.annotations.NotNull
 
 class MavenPublishPlugin extends BaseMavenPublishPlugin {
-
-  @Override
-  protected void setupConfigurerForAndroid(@NotNull Project project, @NotNull Configurer configurer) {
-    MavenPublishPluginExtension extension = project.extensions.getByType(MavenPublishPluginExtension.class)
-
-    if (!extension.useLegacyMode) {
-      configurer.addComponent(project.components.getByName(extension.androidVariantToPublish))
-    }
-
-    def androidSourcesJar = project.tasks.register("androidSourcesJar", AndroidSourcesJar.class)
-    configurer.addTaskOutput(androidSourcesJar)
-
-    project.tasks.register("androidJavadocs", AndroidJavadocs.class)
-    def androidJavadocsJar = project.tasks.register("androidJavadocsJar", AndroidJavadocsJar.class)
-    configurer.addTaskOutput(androidJavadocsJar)
-  }
-
-  @Override
-  protected void setupConfigurerForJava(@NotNull Project project, @NotNull Configurer configurer) {
-    PluginContainer plugins = project.plugins
-
-    configurer.addComponent(project.components.java)
-
-    def sourcesJar = project.tasks.register("sourcesJar", SourcesJar.class)
-    configurer.addTaskOutput(sourcesJar)
-
-    def javadocsJar = project.tasks.register("javadocsJar", JavadocsJar.class)
-    configurer.addTaskOutput(javadocsJar)
-
-    if (plugins.hasPlugin('groovy')) {
-      def goovydocsJar = project.tasks.register("groovydocJar", GroovydocsJar.class)
-      configurer.addTaskOutput(goovydocsJar)
-    }
-  }
 
   @Override
   protected void configureMavenDeployer(Upload upload, Project project, MavenPublishTarget target) {

--- a/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
@@ -42,9 +42,9 @@ internal abstract class BaseMavenPublishPlugin : Plugin<Project> {
       }
 
       if (project.plugins.hasPlugin("com.android.library")) {
-        setupConfigurerForAndroid(project, configurer)
+        configurer.configureAndroidArtifacts()
       } else {
-        setupConfigurerForJava(project, configurer)
+        configurer.configureJavaArtifacts()
       }
 
       NexusConfigurer(project)
@@ -79,10 +79,6 @@ internal abstract class BaseMavenPublishPlugin : Plugin<Project> {
       }
     }
   }
-
-  protected abstract fun setupConfigurerForAndroid(project: Project, configurer: Configurer)
-
-  protected abstract fun setupConfigurerForJava(project: Project, configurer: Configurer)
 
   protected abstract fun configureMavenDeployer(
     upload: Upload,

--- a/src/main/kotlin/com/vanniktech/maven/publish/Configurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/Configurer.kt
@@ -1,9 +1,5 @@
 package com.vanniktech.maven.publish
 
-import org.gradle.api.component.SoftwareComponent
-import org.gradle.api.tasks.TaskProvider
-import org.gradle.api.tasks.bundling.AbstractArchiveTask
-
 internal interface Configurer {
   /**
    * Needs to be called for all targets before `addComponent` and
@@ -11,7 +7,7 @@ internal interface Configurer {
    */
   fun configureTarget(target: MavenPublishTarget)
 
-  fun addComponent(component: SoftwareComponent)
+  fun configureAndroidArtifacts()
 
-  fun addTaskOutput(taskProvider: TaskProvider<AbstractArchiveTask>)
+  fun configureJavaArtifacts()
 }

--- a/src/main/kotlin/com/vanniktech/maven/publish/UploadArchivesConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/UploadArchivesConfigurer.kt
@@ -2,9 +2,14 @@ package com.vanniktech.maven.publish
 
 import com.vanniktech.maven.publish.MavenPublishPluginExtension.Companion.DEFAULT_TARGET
 import com.vanniktech.maven.publish.MavenPublishPluginExtension.Companion.LOCAL_TARGET
+import com.vanniktech.maven.publish.tasks.AndroidJavadocs
+import com.vanniktech.maven.publish.tasks.AndroidJavadocsJar
+import com.vanniktech.maven.publish.tasks.AndroidSourcesJar
+import com.vanniktech.maven.publish.tasks.GroovydocsJar
+import com.vanniktech.maven.publish.tasks.JavadocsJar
+import com.vanniktech.maven.publish.tasks.SourcesJar
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency.ARCHIVES_CONFIGURATION
-import org.gradle.api.component.SoftwareComponent
 import org.gradle.api.plugins.MavenPlugin
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.Upload
@@ -65,9 +70,29 @@ internal class UploadArchivesConfigurer(
       it.configuration = project.configurations.getByName(ARCHIVES_CONFIGURATION)
     }
 
-  override fun addComponent(component: SoftwareComponent) = Unit
+  override fun configureAndroidArtifacts() {
+    val androidSourcesJar = project.tasks.register("androidSourcesJar", AndroidSourcesJar::class.java)
+    addTaskOutput(androidSourcesJar)
 
-  override fun addTaskOutput(taskProvider: TaskProvider<AbstractArchiveTask>) {
+    project.tasks.register("androidJavadocs", AndroidJavadocs::class.java)
+    val androidJavadocsJar = project.tasks.register("androidJavadocsJar", AndroidJavadocsJar::class.java)
+    addTaskOutput(androidJavadocsJar)
+  }
+
+  override fun configureJavaArtifacts() {
+    val sourcesJar = project.tasks.register("sourcesJar", SourcesJar::class.java)
+    addTaskOutput(sourcesJar)
+
+    val javadocsJar = project.tasks.register("javadocsJar", JavadocsJar::class.java)
+    addTaskOutput(javadocsJar)
+
+    if (project.plugins.hasPlugin("groovy")) {
+      val goovydocsJar = project.tasks.register("groovydocJar", GroovydocsJar::class.java)
+      addTaskOutput(goovydocsJar)
+    }
+  }
+
+  private fun addTaskOutput(taskProvider: TaskProvider<out AbstractArchiveTask>) {
     taskProvider.configure { task ->
         project.artifacts.add(ARCHIVES_CONFIGURATION, task)
     }


### PR DESCRIPTION
I've decided to not just move them into the base plugin class, but instead to the individual configurers. For now that means the task registration itself is duplicated, but since the actual task logic is already extracted it's not that much. The reason is that for maven publish we will be able to get rid of our own javadoc/source tasks to some degree.

For java projects there is 
```
java {
    withJavadocJar()
    withSourcesJar()
}
``` 
to automatically add them to the publication. The only blocker for that right now is updating to Gradle 6, which doesn't seem work with the jacoco plugin. On the Android side it's planned to at least have support for source jars https://issuetracker.google.com/145670440.