### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ __Note:__ To prevent looping behavior, especially in Kotlin projects / modules, 
 
 ### Signing
 
-The plugin supports setting up all your artifacts to be signed with GPG. Since that is a requirement
+The plugin supports signing all of your artifacts with GPG. This is a requirement when publishing to Maven Central - our default behavior. Signing parameters can be configured via:
 for our default publishing target Maven Central, signing is enabled by default. For that please add the following 
 Gradle properties.
 ```groovy

--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ __Note:__ To prevent looping behavior, especially in Kotlin projects / modules, 
 ### Signing
 
 The plugin supports signing all of your artifacts with GPG. This is a requirement when publishing to Maven Central - our default behavior. Signing parameters can be configured via:
-Gradle properties.
 ```groovy
 signing.keyId=12345678
 signing.password=some_password

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ POM_ARTIFACT_ID=mylibrary-runtime
 VERSION_NAME=3.0.5
 ```
 
-In addition to that there are some optional properties to give more details about your project:
+In addition, there are some optional properties to give more details about your project:
 
 ```
 POM_NAME=My Library

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # gradle-maven-publish-plugin
 
-Gradle plugin that creates an `uploadArchives` task to automatically upload all of your Java, Kotlin or Android libraries to any Maven instance. This plugin is based on [Chris Banes initial implementation](https://github.com/chrisbanes/gradle-mvn-push) and has been enhanced to add Kotlin support and keep up with the latest changes.
+Gradle plugin that creates an `uploadArchives` task to automatically upload all of your Java, Kotlin or Android 
+libraries to any Maven instance. This plugin is based on [Chris Banes initial implementation](https://github.com/chrisbanes/gradle-mvn-push) 
+and has been enhanced to add Kotlin support and keep up with the latest changes.
 
 # Set up
 
@@ -110,7 +112,9 @@ __Note:__ To prevent looping behavior, especially in Kotlin projects / modules, 
 
 ### Signing
 
-The plugin supports signing all of your artifacts with GPG. This is a requirement when publishing to Maven Central - our default behavior. Signing parameters can be configured via:
+The plugin supports signing all of your artifacts with GPG. This is a requirement when publishing to 
+Maven Central - our default behavior. Signing parameters can be configured via:
+
 ```groovy
 signing.keyId=12345678
 signing.password=some_password
@@ -123,7 +127,8 @@ To disable signing you can set the `signing = false` on a target (see above).
 
 ### Releasing
 
-Once `uploadArchives` is called, and if you're using a Nexus repository, you'll have to make a release. This can be done manually by following the [release steps at sonatype](https://central.sonatype.org/pages/releasing-the-deployment.html).
+Once `uploadArchives` is called, and if you're using a Nexus repository, you'll have to make a release. This can 
+be done manually by following the [release steps at sonatype](https://central.sonatype.org/pages/releasing-the-deployment.html).
 
 Alternatively, you can configure the plugin to do so automatically:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To configure the coordinates of your published artifacts as well as the POM this
 uses Gradle properties. It's generally recommended to set them in your `gradle.properties`
 file.
 
-There are 3 required properties:
+There are three required properties:
 ```
 GROUP=com.test.mylibrary
 POM_ARTIFACT_ID=mylibrary-runtime

--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ __Note:__ To prevent looping behavior, especially in Kotlin projects / modules, 
 ### Signing
 
 The plugin supports signing all of your artifacts with GPG. This is a requirement when publishing to Maven Central - our default behavior. Signing parameters can be configured via:
-for our default publishing target Maven Central, signing is enabled by default. For that please add the following 
 Gradle properties.
 ```groovy
 signing.keyId=12345678


### PR DESCRIPTION
- tries to go through the steps in the right order
- mention all properties we support
- mention Sonatype OSS more explicitly
- make signing more prominent