### PR TITLE
new signing property outside of targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ mavenPublish {
       snapshotRepositoryUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
       repositoryUsername = null // This defaults to either the SONATYPE_NEXUS_USERNAME Gradle property or the system environment variable.
       repositoryPassword = null // This defaults to either the SONATYPE_NEXUS_PASSWORD Gradle property or the system environment variable.
-      signing = true // This defaults to true. GPG signing is required by mavenCentral. If you are deploying elsewhere, you can set this to false.
     }
   }
 }

--- a/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
@@ -30,7 +30,7 @@ internal abstract class BaseMavenPublishPlugin : Plugin<Project> {
 
     p.afterEvaluate { project ->
       val configurer = when {
-        extension.useLegacyMode -> UploadArchivesConfigurer(project, extension.targets, ::configureMavenDeployer)
+        extension.useLegacyMode -> UploadArchivesConfigurer(project, ::configureMavenDeployer)
         else -> MavenPublishConfigurer(project)
       }
 

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
@@ -16,7 +16,9 @@ import org.gradle.api.tasks.bundling.AbstractArchiveTask
 import org.gradle.plugins.signing.SigningPlugin
 import java.net.URI
 
-internal class MavenPublishConfigurer(private val project: Project) : Configurer {
+internal class MavenPublishConfigurer(
+  private val project: Project
+) : Configurer {
 
   private val publication: MavenPublication
 
@@ -67,8 +69,10 @@ internal class MavenPublishConfigurer(private val project: Project) : Configurer
 
     project.signing.apply {
       setRequired(project.isSigningRequired)
-      @Suppress("UnstableApiUsage")
-      sign(publication)
+      if (project.isSigningRequired.call() && project.project.publishExtension.releaseSigningEnabled) {
+        @Suppress("UnstableApiUsage")
+        sign(publication)
+      }
     }
   }
 
@@ -114,8 +118,7 @@ internal class MavenPublishConfigurer(private val project: Project) : Configurer
     "publish${publication.name.capitalize()}PublicationTo${repository.capitalize()}Repository"
 
   override fun configureAndroidArtifacts() {
-    val extension = project.extensions.getByType(MavenPublishPluginExtension::class.java)
-    publication.from(project.components.getByName(extension.androidVariantToPublish))
+    publication.from(project.components.getByName(project.publishExtension.androidVariantToPublish))
 
     val androidSourcesJar = project.tasks.register("androidSourcesJar", AndroidSourcesJar::class.java)
     addTaskOutput(androidSourcesJar)

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
@@ -14,10 +14,10 @@ open class MavenPublishPluginExtension(project: Project) {
 
   private val defaultTarget = MavenPublishTarget(
       DEFAULT_TARGET,
-      project.findProperty("RELEASE_REPOSITORY_URL") as String? ?: System.getenv("RELEASE_REPOSITORY_URL") ?: "https://oss.sonatype.org/service/local/staging/deploy/maven2/",
-      project.findProperty("SNAPSHOT_REPOSITORY_URL") as String? ?: System.getenv("SNAPSHOT_REPOSITORY_URL") ?: "https://oss.sonatype.org/content/repositories/snapshots/",
-      project.findProperty("SONATYPE_NEXUS_USERNAME") as String? ?: System.getenv("SONATYPE_NEXUS_USERNAME"),
-      project.findProperty("SONATYPE_NEXUS_PASSWORD") as String? ?: System.getenv("SONATYPE_NEXUS_PASSWORD")
+      project.findOptionalProperty("RELEASE_REPOSITORY_URL") ?: System.getenv("RELEASE_REPOSITORY_URL") ?: "https://oss.sonatype.org/service/local/staging/deploy/maven2/",
+      project.findOptionalProperty("SNAPSHOT_REPOSITORY_URL") ?: System.getenv("SNAPSHOT_REPOSITORY_URL") ?: "https://oss.sonatype.org/content/repositories/snapshots/",
+      project.findOptionalProperty("SONATYPE_NEXUS_USERNAME") ?: System.getenv("SONATYPE_NEXUS_USERNAME"),
+      project.findOptionalProperty("SONATYPE_NEXUS_PASSWORD") ?: System.getenv("SONATYPE_NEXUS_PASSWORD")
   )
 
   private val localTarget = MavenPublishTarget(
@@ -45,6 +45,13 @@ open class MavenPublishPluginExtension(project: Project) {
    * @Since 0.9.0
    */
   var androidVariantToPublish: String = "release"
+
+  /**
+   * Whether release artifacts should be signed before getting published.
+   *
+   * @Since 0.9.0
+   */
+  val releaseSigningEnabled: Boolean = project.findOptionalProperty("RELEASE_SIGNING_ENABLED")?.toBoolean() ?: true
 
   /**
    * Allows to promote repositories without connecting to the nexus instance console.

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishTarget.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishTarget.kt
@@ -2,7 +2,6 @@ package com.vanniktech.maven.publish
 
 import com.vanniktech.maven.publish.MavenPublishPluginExtension.Companion.DEFAULT_TARGET
 import com.vanniktech.maven.publish.MavenPublishPluginExtension.Companion.LOCAL_TARGET
-import org.gradle.api.artifacts.transform.InputArtifactDependencies
 
 data class MavenPublishTarget(
   internal val name: String,

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishTarget.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishTarget.kt
@@ -2,6 +2,7 @@ package com.vanniktech.maven.publish
 
 import com.vanniktech.maven.publish.MavenPublishPluginExtension.Companion.DEFAULT_TARGET
 import com.vanniktech.maven.publish.MavenPublishPluginExtension.Companion.LOCAL_TARGET
+import org.gradle.api.artifacts.transform.InputArtifactDependencies
 
 data class MavenPublishTarget(
   internal val name: String,
@@ -33,6 +34,7 @@ data class MavenPublishTarget(
    * Whether release artifacts should be signed before uploading to this target.
    * @since 0.7.0
    */
+  @Deprecated("Disabling signing on a target level is not supported anymore. See releaseSigningEnabled for a replacement")
   var signing: Boolean = true
 ) {
 

--- a/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
@@ -8,3 +8,6 @@ fun Project.findMandatoryProperty(propertyName: String): String {
 }
 
 fun Project.findOptionalProperty(propertyName: String) = findProperty(propertyName)?.toString()
+
+val Project.publishExtension: MavenPublishPluginExtension
+  get() = project.extensions.getByType(MavenPublishPluginExtension::class.java)

--- a/src/main/kotlin/com/vanniktech/maven/publish/UploadArchivesConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/UploadArchivesConfigurer.kt
@@ -18,7 +18,6 @@ import org.gradle.plugins.signing.SigningPlugin
 
 internal class UploadArchivesConfigurer(
   private val project: Project,
-  private val targets: Iterable<MavenPublishTarget>,
   private val configureMavenDeployer: Upload.(Project, MavenPublishTarget) -> Unit
 ) : Configurer {
 

--- a/src/main/kotlin/com/vanniktech/maven/publish/UploadArchivesConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/UploadArchivesConfigurer.kt
@@ -14,7 +14,6 @@ import org.gradle.api.plugins.MavenPlugin
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.Upload
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
-import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningPlugin
 
 internal class UploadArchivesConfigurer(
@@ -31,18 +30,9 @@ internal class UploadArchivesConfigurer(
 
     project.signing.apply {
       setRequired(project.isSigningRequired)
-      sign(project.configurations.getByName(ARCHIVES_CONFIGURATION))
-    }
-    project.tasks.withType(Sign::class.java).all { sign ->
-      sign.onlyIf {
-        val signedTargets = targets.filter { it.signing }
-        sign.logger.info("Targets that should be signed: ${signedTargets.map { it.name }}")
-        signedTargets.any { target ->
-          val task = project.tasks.getByName(target.taskName)
-          project.gradle.taskGraph.hasTask(task).also {
-            sign.logger.info("Task for ${target.name} will be executed: $it")
-          }
-        }
+
+      if (project.isSigningRequired.call() && project.publishExtension.releaseSigningEnabled) {
+        sign(project.configurations.getByName(ARCHIVES_CONFIGURATION))
       }
     }
   }


### PR DESCRIPTION
The property on signing doesn't really make sense. For maven-publish it was never used and for the old plugin the implementation was kind of hacky by checking which the upload task was going to be executed. This replaces the old property with a single one that is used for all targets. It defaults to a gradle property so you could still dynamically change it when running certain upload tasks.

I will update the readme after both this and #100 were merged