### PR TITLE
apply signing plugin immediately, share some configuration

### DIFF
--- a/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
@@ -8,6 +8,7 @@ import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.Upload
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.external.javadoc.StandardJavadocDocletOptions
+import org.gradle.plugins.signing.SigningPlugin
 import org.gradle.util.VersionNumber
 import org.jetbrains.dokka.gradle.DokkaTask
 
@@ -25,6 +26,7 @@ internal abstract class BaseMavenPublishPlugin : Plugin<Project> {
     p.group = pom.groupId
     p.version = pom.version
 
+    configureSigning(p)
     configureJavadoc(p)
     configureDokka(p)
 
@@ -49,6 +51,11 @@ internal abstract class BaseMavenPublishPlugin : Plugin<Project> {
 
       NexusConfigurer(project)
     }
+  }
+
+  private fun configureSigning(project: Project) {
+    project.plugins.apply(SigningPlugin::class.java)
+    project.signing.setRequired(project.isSigningRequired)
   }
 
   private fun configureJavadoc(project: Project) {

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
@@ -14,7 +14,6 @@ import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin as GradleMavenPublishPlugin
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
-import org.gradle.plugins.signing.SigningPlugin
 import java.net.URI
 
 internal class MavenPublishConfigurer(

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
@@ -24,7 +24,6 @@ internal class MavenPublishConfigurer(
 
   init {
     project.plugins.apply(GradleMavenPublishPlugin::class.java)
-    project.plugins.apply(SigningPlugin::class.java)
 
     configurePublications()
     configureSigning()
@@ -72,12 +71,9 @@ internal class MavenPublishConfigurer(
   }
 
   private fun configureSigning() {
-    project.signing.apply {
-      setRequired(project.isSigningRequired)
-      if (project.isSigningRequired.call() && project.project.publishExtension.releaseSigningEnabled) {
-        @Suppress("UnstableApiUsage")
-        sign(project.publishing.publications)
-      }
+    if (project.isSigningRequired.call() && project.project.publishExtension.releaseSigningEnabled) {
+      @Suppress("UnstableApiUsage")
+      project.signing.sign(project.publishing.publications)
     }
   }
 

--- a/src/main/kotlin/com/vanniktech/maven/publish/UploadArchivesConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/UploadArchivesConfigurer.kt
@@ -14,7 +14,6 @@ import org.gradle.api.plugins.MavenPlugin
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.Upload
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
-import org.gradle.plugins.signing.SigningPlugin
 
 internal class UploadArchivesConfigurer(
   private val project: Project,

--- a/src/main/kotlin/com/vanniktech/maven/publish/UploadArchivesConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/UploadArchivesConfigurer.kt
@@ -25,14 +25,10 @@ internal class UploadArchivesConfigurer(
 
   init {
     project.plugins.apply(MavenPlugin::class.java)
-    project.plugins.apply(SigningPlugin::class.java)
 
-    project.signing.apply {
-      setRequired(project.isSigningRequired)
-
-      if (project.isSigningRequired.call() && project.publishExtension.releaseSigningEnabled) {
-        sign(project.configurations.getByName(ARCHIVES_CONFIGURATION))
-      }
+    if (project.isSigningRequired.call() && project.project.publishExtension.releaseSigningEnabled) {
+      @Suppress("UnstableApiUsage")
+      project.signing.sign(project.configurations.getByName(ARCHIVES_CONFIGURATION))
     }
   }
 


### PR DESCRIPTION
This makes it easier for users to configure some signing things themselves, before they would have needed to apply the plugin themselves or use afterEvaluate to wait for us to apply it. One use case is to use in memory keys like sqldelight does https://github.com/cashapp/sqldelight/blob/master/gradle/gradle-mvn-push.gradle#L118