### PR TITLE
downgrade dokka

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
   ext.kotlinVersion = '1.3.31'
   ext.junitVersion = '4.13-beta-3'
   ext.assertjVersion = '3.12.2'
-  ext.dokkaVersion = '0.10.0'
+  ext.dokkaVersion = '0.9.18'
 
   repositories {
     mavenCentral()
@@ -80,6 +80,7 @@ dependencies {
   api "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
   implementation "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
+  implementation "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokkaVersion"
 
   compileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
   compileOnly "com.android.tools.build:gradle:3.6.0-rc01"

--- a/src/integrationTest/fixtures/passing_kotlin_mpp_project/build.gradle
+++ b/src/integrationTest/fixtures/passing_kotlin_mpp_project/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "org.jetbrains.kotlin.multiplatform"
+    id "org.jetbrains.dokka"
     id "com.vanniktech.maven.publish"
 }
 
@@ -32,6 +33,30 @@ kotlin {
         linuxMain {
             dependencies {
             }
+        }
+    }
+}
+
+dokka {
+    kotlinTasks {
+        // dokka fails to retrieve sources from MPP-tasks so they must be set empty to avoid exception
+        // use sourceRoot instead (see below)
+        []
+    }
+    sourceRoot {
+        path = kotlin.sourceSets.commonMain.kotlin.srcDirs[0]
+        platforms = ["Common"]
+    }
+    if (kotlin.sourceSets.getNames().contains("jvmMain")) {
+        sourceRoot {
+            path = kotlin.sourceSets.jvmMain.kotlin.srcDirs[0]
+            platforms = ["JVM"]
+        }
+    }
+    if (kotlin.sourceSets.getNames().contains("jsMain")) {
+        sourceRoot {
+            path = kotlin.sourceSets.jsMain.kotlin.srcDirs[0]
+            platforms = ["js"]
         }
     }
 }

--- a/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/BaseMavenPublishPlugin.kt
@@ -80,7 +80,7 @@ internal abstract class BaseMavenPublishPlugin : Plugin<Project> {
       project.plugins.apply(PLUGIN_DOKKA)
     }
     project.plugins.withId("org.jetbrains.kotlin.multiplatform") {
-      project.plugins.apply(PLUGIN_DOKKA)
+      // project.plugins.apply(PLUGIN_DOKKA)
     }
     project.plugins.withId(PLUGIN_DOKKA) {
       project.tasks.withType(DokkaTask::class.java).configureEach {


### PR DESCRIPTION
I had troubles setting up Dokka 0.10.0 in SqlDelight in an equivalent way. Since they have a working way to use Dokka 0.9.x I don't want to force the upgrade now. 

The consequences of this PR for multiplatform projects are:
- they need to apply dokka themselves
- if they decide to use 0.9.x they need to apply the same workarounds as SqlDelight or our integration tests in here
- if they decide to use dokka 0.10.0 they need to explicitly include that version and configure it

I think long term it might even be better not to apply Dokka automatically. It's still getting used when it's there. 