### PR TITLE
fix plugin marker pom not containing name and description

### DIFF
--- a/src/integrationTest/fixtures/passing_java_gradle_plugin_project/expected/com.example.test-plugin.gradle.plugin-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_java_gradle_plugin_project/expected/com.example.test-plugin.gradle.plugin-1.0.0.pom
@@ -24,6 +24,8 @@
     <developerConnection>scm:git:ssh://git@github.com/vanniktech/gradle-maven-publish-plugin.git</developerConnection>
     <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
   </scm>
+  <name>Gradle Maven Publish Plugin Test Artifact</name>
+  <description>Testing the Gradle Maven Publish Plugin</description>
   <dependencies>
     <dependency>
       <groupId>com.example</groupId>

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
@@ -150,8 +150,12 @@ internal class MavenPublishConfigurer(
           configurePom(it, groupId = it.groupId, artifactId = it.artifactId)
           // workaround for https://github.com/gradle/gradle/issues/12259
           it.pom.withXml { pom ->
-            pom.asNode().appendNode("name", publishPom.name)
-            pom.asNode().appendNode("description", publishPom.description)
+            if (pom.asNode().get("name") == null) {
+              pom.asNode().appendNode("name", publishPom.name)
+            }
+            if (pom.asNode().get("description") == null) {
+              pom.asNode().appendNode("description", publishPom.description)
+            }
           }
 
           val emptyJavadocsJar = project.tasks.register("emptyJavadocsJar", EmptyJavadocsJar::class.java)

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
@@ -148,6 +148,12 @@ internal class MavenPublishConfigurer(
         if (it.name == "${plugin.name}PluginMarkerMaven") {
           // keep the current group and artifact ids, they are based on the gradle plugin id
           configurePom(it, groupId = it.groupId, artifactId = it.artifactId)
+          // workaround for https://github.com/gradle/gradle/issues/12259
+          it.pom.withXml { pom ->
+            pom.asNode().appendNode("name", publishPom.name)
+            pom.asNode().appendNode("description", publishPom.description)
+          }
+
           val emptyJavadocsJar = project.tasks.register("emptyJavadocsJar", EmptyJavadocsJar::class.java)
           it.addTaskOutput(emptyJavadocsJar)
           val emptySourcesJar = project.tasks.register("emptySourcesJar", EmptySourcesJar::class.java)

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
@@ -151,10 +151,10 @@ internal class MavenPublishConfigurer(
           configurePom(it, groupId = it.groupId, artifactId = it.artifactId)
           // workaround for https://github.com/gradle/gradle/issues/12259
           it.pom.withXml { pom ->
-            if ((pom.asNode().get("name") as NodeList).isEmpty()) {
+            if ((pom.asNode().get("name") as? NodeList)?.isEmpty() == true) {
               pom.asNode().appendNode("name", publishPom.name)
             }
-            if ((pom.asNode().get("description") as NodeList).isEmpty()) {
+            if ((pom.asNode().get("description") as? NodeList)?.isEmpty() == true) {
               pom.asNode().appendNode("description", publishPom.description)
             }
           }

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
@@ -10,6 +10,7 @@ import com.vanniktech.maven.publish.tasks.EmptySourcesJar
 import com.vanniktech.maven.publish.tasks.GroovydocsJar
 import com.vanniktech.maven.publish.tasks.JavadocsJar
 import com.vanniktech.maven.publish.tasks.SourcesJar
+import groovy.util.NodeList
 import org.gradle.api.Project
 import org.gradle.api.publish.Publication
 import org.gradle.api.publish.maven.MavenPublication
@@ -150,10 +151,10 @@ internal class MavenPublishConfigurer(
           configurePom(it, groupId = it.groupId, artifactId = it.artifactId)
           // workaround for https://github.com/gradle/gradle/issues/12259
           it.pom.withXml { pom ->
-            if (pom.asNode().get("name") == null) {
+            if ((pom.asNode().get("name") as NodeList).isEmpty()) {
               pom.asNode().appendNode("name", publishPom.name)
             }
-            if (pom.asNode().get("description") == null) {
+            if ((pom.asNode().get("description") as NodeList).isEmpty()) {
               pom.asNode().appendNode("description", publishPom.description)
             }
           }


### PR DESCRIPTION
I found a workaround. Closes #117 