### PR TITLE
fix overriding pom packaging, remove javadoc/sources jar from plugin marker

### DIFF
--- a/src/integrationTest/fixtures/passing_java_gradle_plugin_project/expected/com.example.test-plugin.gradle.plugin-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_java_gradle_plugin_project/expected/com.example.test-plugin.gradle.plugin-1.0.0.pom
@@ -4,6 +4,7 @@
   <groupId>com.example.test-plugin</groupId>
   <artifactId>com.example.test-plugin.gradle.plugin</artifactId>
   <version>1.0.0</version>
+  <packaging>pom</packaging>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
   <licenses>
     <license>

--- a/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-1.0.0.pom
@@ -10,6 +10,7 @@
   <groupId>com.example</groupId>
   <artifactId>test-artifact</artifactId>
   <version>1.0.0</version>
+  <packaging>pom</packaging>
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>

--- a/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-jvm-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-jvm-1.0.0.pom
@@ -9,6 +9,7 @@
   <groupId>com.example</groupId>
   <artifactId>test-artifact-jvm</artifactId>
   <version>1.0.0</version>
+  <packaging>pom</packaging>
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>

--- a/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-linux-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-linux-1.0.0.pom
@@ -9,6 +9,7 @@
   <groupId>com.example</groupId>
   <artifactId>test-artifact-linux</artifactId>
   <version>1.0.0</version>
+  <packaging>klib</packaging>
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>

--- a/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-nodejs-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-nodejs-1.0.0.pom
@@ -9,6 +9,7 @@
   <groupId>com.example</groupId>
   <artifactId>test-artifact-nodejs</artifactId>
   <version>1.0.0</version>
+  <packaging>pom</packaging>
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>

--- a/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -180,7 +180,6 @@ class MavenPublishPluginIntegrationTest(
     if (!useLegacyMode) {
       val pluginId = "com.example.test-plugin"
       val artifactId = "$pluginId.gradle.plugin"
-      assertExpectedCommonArtifactsGenerated("pom", artifactId, pluginId)
       assertPomContentMatches(artifactId, pluginId)
     }
   }

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
@@ -5,7 +5,6 @@ import com.vanniktech.maven.publish.MavenPublishPluginExtension.Companion.LOCAL_
 import com.vanniktech.maven.publish.tasks.AndroidJavadocs
 import com.vanniktech.maven.publish.tasks.AndroidJavadocsJar
 import com.vanniktech.maven.publish.tasks.AndroidSourcesJar
-import com.vanniktech.maven.publish.tasks.EmptyJavadocsJar
 import com.vanniktech.maven.publish.tasks.EmptySourcesJar
 import com.vanniktech.maven.publish.tasks.GroovydocsJar
 import com.vanniktech.maven.publish.tasks.JavadocsJar
@@ -58,7 +57,6 @@ internal class MavenPublishConfigurer(
     publication.pom { pom ->
 
       pom.name.set(publishPom.name)
-      pom.packaging = publishPom.packaging
       pom.description.set(publishPom.description)
       pom.url.set(publishPom.url)
 
@@ -158,11 +156,6 @@ internal class MavenPublishConfigurer(
               pom.asNode().appendNode("description", publishPom.description)
             }
           }
-
-          val emptyJavadocsJar = project.tasks.register("emptyJavadocsJar", EmptyJavadocsJar::class.java)
-          it.addTaskOutput(emptyJavadocsJar)
-          val emptySourcesJar = project.tasks.register("emptySourcesJar", EmptySourcesJar::class.java)
-          it.addTaskOutput(emptySourcesJar)
         }
       }
     }


### PR DESCRIPTION
I'm not sure why it initially worked when I tested the central sync requirements. 

The issue is that central expects a main artifact (like a jar or aar) when `pom.packaging` is not set to something else. By us not setting it the packaging will be present in the pom when it's set by the component. The `java-gradle-plugin` does that for the plugin marker and Kotlin MPP does that for some of it's publications. With `<packaging>pom</packaging>` being present it will not complain about the missing main artifact and also not require javadoc and sources jars.