### PR TITLE
update documentation and error message for closeAndReleaseRepository

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ mavenPublish {
     }
 }
 ```
+The `groupId` set here has to be the group id you have publishing rights to, not necessarily the `groupId`
+of the library you are publishing. When you are publishing a library with `com.example.mylibrary` as 
+it would usually be `com.example`.
 
 This will create a `closeAndReleaseRepository` task that you can call after `uploadArchives`:
 

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
@@ -34,11 +34,12 @@ class Nexus(username: String, password: String, val groupId: String, baseUrl: St
   }
 
   private fun findStagingRepository(): Repository {
+    val prefix = groupId.replace(".", "")
     val candidateRepositories = getProfileRepositories()
-      ?.filter { it.repositoryId.startsWith(groupId.replace(".", "")) } ?: emptyList()
+      ?.filter { it.repositoryId.startsWith(prefix) } ?: emptyList()
 
     if (candidateRepositories.isEmpty()) {
-      throw IllegalArgumentException("No staging repository find. Did you call ./gradlew uploadArchives ?")
+      throw IllegalArgumentException("No staging repository prefixed with \"$prefix\" found. Mae sure you called ./gradlew uploadArchives and `mavenPublish.nexus.groupId` is set correctly.")
     }
 
     if (candidateRepositories.size > 1) {


### PR DESCRIPTION
We're defaulting `mavenPublish.nexus.groupId` to `GROUP` but it's often not. The `groupId` needs to be what you see in Sonatype, not the group of the library. Maybe we should rename the property to make it more clear.