### PR TITLE
Use POM_INCEPTION_YEAR gradle property

### DIFF
--- a/src/integrationTest/fixtures/common/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/common/expected/test-artifact-1.0.0.pom
@@ -8,6 +8,7 @@
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/src/integrationTest/fixtures/override_version_group_project/expected/test-artifact-2.0.0.pom
+++ b/src/integrationTest/fixtures/override_version_group_project/expected/test-artifact-2.0.0.pom
@@ -8,6 +8,7 @@
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/src/integrationTest/fixtures/passing_android_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_android_project/expected/test-artifact-1.0.0.pom
@@ -9,6 +9,7 @@
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/src/integrationTest/fixtures/passing_android_with_kotlin_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_android_with_kotlin_project/expected/test-artifact-1.0.0.pom
@@ -9,6 +9,7 @@
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/src/integrationTest/fixtures/passing_java_gradle_plugin_project/expected/com.example.test-plugin.gradle.plugin-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_java_gradle_plugin_project/expected/com.example.test-plugin.gradle.plugin-1.0.0.pom
@@ -8,6 +8,7 @@
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
   <licenses>
 
     <license>

--- a/src/integrationTest/fixtures/passing_java_gradle_plugin_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_java_gradle_plugin_project/expected/test-artifact-1.0.0.pom
@@ -8,6 +8,7 @@
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/src/integrationTest/fixtures/passing_java_library_with_groovy_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_java_library_with_groovy_project/expected/test-artifact-1.0.0.pom
@@ -8,6 +8,7 @@
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/src/integrationTest/fixtures/passing_java_library_with_kotlin_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_java_library_with_kotlin_project/expected/test-artifact-1.0.0.pom
@@ -7,6 +7,7 @@
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/src/integrationTest/fixtures/passing_java_with_kotlin_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_java_with_kotlin_project/expected/test-artifact-1.0.0.pom
@@ -7,6 +7,7 @@
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-1.0.0.pom
@@ -14,6 +14,7 @@
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-jvm-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-jvm-1.0.0.pom
@@ -12,6 +12,7 @@
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-linux-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-linux-1.0.0.pom
@@ -13,6 +13,7 @@
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-metadata-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-metadata-1.0.0.pom
@@ -12,6 +12,7 @@
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-nodejs-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-nodejs-1.0.0.pom
@@ -12,6 +12,7 @@
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
@@ -39,6 +39,7 @@ internal class MavenPublishConfigurer(
       pom.name.set(publishPom.name)
       pom.description.set(publishPom.description)
       pom.url.set(publishPom.url)
+      pom.inceptionYear.set(publishPom.inceptionYear)
 
       pom.scm {
         it.url.set(publishPom.scmUrl)

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPom.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPom.kt
@@ -11,6 +11,7 @@ internal data class MavenPublishPom(
   val packaging: String?,
   val description: String?,
   val url: String?,
+  val inceptionYear: String?,
 
   val scmUrl: String?,
   val scmConnection: String?,
@@ -35,6 +36,7 @@ internal data class MavenPublishPom(
         project.findOptionalProperty("POM_PACKAGING"),
         project.findOptionalProperty("POM_DESCRIPTION"),
         project.findOptionalProperty("POM_URL"),
+        project.findOptionalProperty("POM_INCEPTION_YEAR"),
         project.findOptionalProperty("POM_SCM_URL"),
         project.findOptionalProperty("POM_SCM_CONNECTION"),
         project.findOptionalProperty("POM_SCM_DEV_CONNECTION"),


### PR DESCRIPTION
The project README indicates that a Gradle property `POM_INCEPTION_YEAR` can be set to specify a value for the similarly-named pom.xml `<inceptionYear/>` element.  This property currently isn't used by the plugin.

This PR implements inception-year handling.

Fixes #134