### PR TITLE
don't fail on unknown plugins

### DIFF
--- a/src/integrationTest/fixtures/passing_groovy_project/build.gradle
+++ b/src/integrationTest/fixtures/passing_groovy_project/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id "groovy"
+    id "com.vanniktech.maven.publish"
+}
+
+sourceSets {
+    main {
+        groovy {
+            srcDirs = ['src/main/groovy']
+        }
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile 'org.codehaus.groovy:groovy-all:2.5.6'
+}
+
+apply from: "maven-publish.gradle"

--- a/src/integrationTest/fixtures/passing_groovy_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_groovy_project/expected/test-artifact-1.0.0.pom
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>test-artifact</artifactId>
+  <version>1.0.0</version>
+  <name>Gradle Maven Publish Plugin Test Artifact</name>
+  <description>Testing the Gradle Maven Publish Plugin</description>
+  <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>vanniktech</id>
+      <name>Niklas Baudy</name>
+      <url>https://github.com/vanniktech/</url>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:git://github.com/vanniktech/gradle-maven-publish-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/vanniktech/gradle-maven-publish-plugin.git</developerConnection>
+    <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  </scm>
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-all</artifactId>
+      <version>2.5.6</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/integrationTest/fixtures/passing_groovy_project/src/main/groovy/com/vanniktech/maven/publish/test/TestClass.groovy
+++ b/src/integrationTest/fixtures/passing_groovy_project/src/main/groovy/com/vanniktech/maven/publish/test/TestClass.groovy
@@ -1,0 +1,15 @@
+package com.vanniktech.maven.publish.test
+
+/**
+ * Just a test class with Javadoc.
+ */
+class TestClass {
+  /**
+   * Main method which does something.
+   *
+   * @param args Command-line arguments passed to the program.
+   */
+  static void main(String[] args) {
+    System.out.println("Hello World!")
+  }
+}

--- a/src/integrationTest/fixtures/passing_kotlin_js_project/build.gradle
+++ b/src/integrationTest/fixtures/passing_kotlin_js_project/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id "org.jetbrains.kotlin.js"
+    id "com.vanniktech.maven.publish"
+}
+
+repositories {
+    mavenCentral()
+    jcenter()
+}
+
+dependencies {
+    api "org.jetbrains.kotlin:kotlin-stdlib-js:1.3.61"
+}
+
+apply from: "maven-publish.gradle"

--- a/src/integrationTest/fixtures/passing_kotlin_js_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_js_project/expected/test-artifact-1.0.0.pom
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>test-artifact</artifactId>
+  <version>1.0.0</version>
+  <name>Gradle Maven Publish Plugin Test Artifact</name>
+  <description>Testing the Gradle Maven Publish Plugin</description>
+  <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>vanniktech</id>
+      <name>Niklas Baudy</name>
+      <url>https://github.com/vanniktech/</url>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:git://github.com/vanniktech/gradle-maven-publish-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/vanniktech/gradle-maven-publish-plugin.git</developerConnection>
+    <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  </scm>
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>1.3.61</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/integrationTest/fixtures/passing_kotlin_js_project/settings.gradle
+++ b/src/integrationTest/fixtures/passing_kotlin_js_project/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "org.jetbrains.kotlin.jvm") {
+                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
+            }
+        }
+    }
+}

--- a/src/integrationTest/fixtures/passing_kotlin_js_project/src/main/java/com/vanniktech/maven/publish/test/TestClass.kt
+++ b/src/integrationTest/fixtures/passing_kotlin_js_project/src/main/java/com/vanniktech/maven/publish/test/TestClass.kt
@@ -1,0 +1,16 @@
+package com.vanniktech.maven.publish.test
+
+/**
+ * Just a test class with Javadoc.
+ */
+object TestClass {
+  /**
+   * Main method which does something.
+   *
+   * @param args Command-line arguments passed to the program.
+   */
+  @Suppress("UnusedPrivateMember")
+  fun main(args: Array<String?>?) {
+    System.out.println("Hello World!")
+  }
+}

--- a/src/integrationTest/fixtures/passing_kotlin_jvm_project/build.gradle
+++ b/src/integrationTest/fixtures/passing_kotlin_jvm_project/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id "org.jetbrains.kotlin.jvm"
+    id "com.vanniktech.maven.publish"
+}
+
+repositories {
+    mavenCentral()
+    jcenter()
+}
+
+dependencies {
+    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.61"
+}
+
+apply from: "maven-publish.gradle"

--- a/src/integrationTest/fixtures/passing_kotlin_jvm_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_jvm_project/expected/test-artifact-1.0.0.pom
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>test-artifact</artifactId>
+  <version>1.0.0</version>
+  <name>Gradle Maven Publish Plugin Test Artifact</name>
+  <description>Testing the Gradle Maven Publish Plugin</description>
+  <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>vanniktech</id>
+      <name>Niklas Baudy</name>
+      <url>https://github.com/vanniktech/</url>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:git://github.com/vanniktech/gradle-maven-publish-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/vanniktech/gradle-maven-publish-plugin.git</developerConnection>
+    <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  </scm>
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>1.3.61</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/integrationTest/fixtures/passing_kotlin_jvm_project/settings.gradle
+++ b/src/integrationTest/fixtures/passing_kotlin_jvm_project/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "org.jetbrains.kotlin.jvm") {
+                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
+            }
+        }
+    }
+}

--- a/src/integrationTest/fixtures/passing_kotlin_jvm_project/src/main/java/com/vanniktech/maven/publish/test/TestClass.kt
+++ b/src/integrationTest/fixtures/passing_kotlin_jvm_project/src/main/java/com/vanniktech/maven/publish/test/TestClass.kt
@@ -1,0 +1,16 @@
+package com.vanniktech.maven.publish.test
+
+/**
+ * Just a test class with Javadoc.
+ */
+object TestClass {
+  /**
+   * Main method which does something.
+   *
+   * @param args Command-line arguments passed to the program.
+   */
+  @Suppress("UnusedPrivateMember")
+  fun main(args: Array<String?>?) {
+    System.out.println("Hello World!")
+  }
+}

--- a/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -134,10 +134,11 @@ class MavenPublishPluginIntegrationTest(
   @Test fun doesNotFailOnKotlinJsProject() {
     setupFixture("passing_kotlin_js_project")
 
-    val result = executeGradleCommands(uploadArchivesTargetTaskName, "--info")
+    val result = executeGradleCommands(uploadArchivesTargetTaskName, "publish", "build", "--info")
 
-    assertThat(result.task("build")?.outcome).isEqualTo(SUCCESS)
     assertThat(result.task(":$uploadArchivesTargetTaskName")?.outcome).isEqualTo(UP_TO_DATE)
+    assertThat(result.task(":publish")?.outcome).isEqualTo(UP_TO_DATE)
+    assertThat(result.task(":build")?.outcome).isEqualTo(UP_TO_DATE)
   }
 
   @Test fun generatesArtifactsAndDocumentationOnAndroidProject() {
@@ -319,5 +320,6 @@ class MavenPublishPluginIntegrationTest(
       .withProjectDir(testProjectDir.root)
       .withArguments(*commands, "-Ptest.releaseRepository=$repoFolder")
       .withPluginClasspath()
+    .forwardOutput()
       .build()
 }

--- a/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -138,7 +138,7 @@ class MavenPublishPluginIntegrationTest(
 
     assertThat(result.task(":$uploadArchivesTargetTaskName")?.outcome).isEqualTo(UP_TO_DATE)
     assertThat(result.task(":publish")?.outcome).isEqualTo(UP_TO_DATE)
-    assertThat(result.task(":build")?.outcome).isEqualTo(UP_TO_DATE)
+    assertThat(result.task(":build")?.outcome).isEqualTo(SUCCESS)
   }
 
   @Test fun generatesArtifactsAndDocumentationOnAndroidProject() {

--- a/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -128,6 +129,15 @@ class MavenPublishPluginIntegrationTest(
     assertExpectedCommonArtifactsGenerated()
     assertPomContentMatches()
     assertSourceJarContainsFile("com/vanniktech/maven/publish/test/TestClass.kt", "src/main/java")
+  }
+
+  @Test fun doesNotFailOnKotlinJsProject() {
+    setupFixture("passing_kotlin_js_project")
+
+    val result = executeGradleCommands(uploadArchivesTargetTaskName, "--info")
+
+    assertThat(result.task("build")?.outcome).isEqualTo(SUCCESS)
+    assertThat(result.task(":$uploadArchivesTargetTaskName")?.outcome).isEqualTo(UP_TO_DATE)
   }
 
   @Test fun generatesArtifactsAndDocumentationOnAndroidProject() {

--- a/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -106,6 +106,30 @@ class MavenPublishPluginIntegrationTest(
     assertSourceJarContainsFile("com/vanniktech/maven/publish/test/TestClass.java", "src/main/java")
   }
 
+  @Test fun generatesArtifactsAndDocumentationOnGroovyProject() {
+    setupFixture("passing_groovy_project")
+
+    val result = executeGradleCommands(uploadArchivesTargetTaskName, "--info")
+
+    assertExpectedTasksRanSuccessfully(result)
+    assertExpectedCommonArtifactsGenerated()
+    assertArtifactGenerated(artifactFileNameWithExtension = "$TEST_POM_ARTIFACT_ID-$TEST_VERSION_NAME-groovydoc.jar")
+    assertPomContentMatches()
+    assertSourceJarContainsFile("com/vanniktech/maven/publish/test/TestClass.groovy", "src/main/groovy")
+  }
+
+  @Test fun generatesArtifactsAndDocumentationOnKotlinJvmProject() {
+    setupFixture("passing_kotlin_jvm_project")
+
+    val result = executeGradleCommands(uploadArchivesTargetTaskName, "--info")
+
+    assertExpectedTasksRanSuccessfully(result)
+    assertThat(result.task(":dokka")?.outcome).isEqualTo(SUCCESS)
+    assertExpectedCommonArtifactsGenerated()
+    assertPomContentMatches()
+    assertSourceJarContainsFile("com/vanniktech/maven/publish/test/TestClass.kt", "src/main/java")
+  }
+
   @Test fun generatesArtifactsAndDocumentationOnAndroidProject() {
     setupFixture("passing_android_project")
 

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -98,8 +98,10 @@ open class MavenPublishPlugin : Plugin<Project> {
       configurer.configureGradlePluginProject()
     } else if (project.plugins.hasPlugin("com.android.library")) {
       configurer.configureAndroidArtifacts()
-    } else {
+    } else if (project.plugins.hasPlugin("java") || project.plugins.hasPlugin("java-library")) {
       configurer.configureJavaArtifacts()
+    } else {
+      project.logger.warn("No compatible plugin found in project ${project.name} for publishing")
     }
   }
 


### PR DESCRIPTION
Addresses the exception in #141. Before we would treat any project that doesn't have one of the other plugins that we explicitly support as java projects. Now we check for `java` and `java-library` plugins and otherwise print a warning. This might break some projects if there are more plugins that create a `java` software component for publishing. 