### PR TITLE
only create one closeAndRelease task, add new property for the profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,15 +152,16 @@ mavenPublish {
     // ...
     nexus {
         baseUrl = "https://your_nexus_instance" // defaults to "https://oss.sonatype.org/service/local/"
-        groupId = "net.example" // defaults to the GROUP Gradle Property if not set
+        stagingProfile = "net.example" // defaults to the SONATYPE_STAGING_PROFILE Gradle property or the GROUP Gradle Property if not set
         respositoryUserName = "username" // defaults to the SONATYPE_NEXUS_USERNAME Gradle Property or the system environment variable
         respositoryPassword = "password" // defaults to the SONATYPE_NEXUS_PASSWORD Gradle Property or the system environment variable
     }
 }
 ```
-The `groupId` set here has to be the group id you have publishing rights to, not necessarily the `groupId`
-of the library you are publishing. When you are publishing a library with `com.example.mylibrary` as
-it would usually be `com.example`.
+The `stagingProfile` set here is either the same as your group id or a simpler version of it. When you are publishing a 
+library with `com.example.mylibrary` as group then it would either be the same or just `com.example`. You can find it 
+by looking at your [Sonatype staging profiles](https://oss.sonatype.org/#stagingProfiles) in the name and repo target 
+columns.
 
 This will create a `closeAndReleaseRepository` task that you can call after `uploadArchives`:
 

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
@@ -47,7 +47,7 @@ open class MavenPublishPluginExtension(project: Project) {
    * Allows to promote repositories without connecting to the nexus instance console.
    * @since 0.9.0
    */
-  var nexusOptions = NexusOptions()
+  var nexusOptions = NexusOptions(project)
 
   /**
    * Allows to promote repositories without connecting to the nexus instance console.

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/CloseAndReleaseRepositoryTask.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/CloseAndReleaseRepositoryTask.kt
@@ -7,34 +7,26 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
 open class CloseAndReleaseRepositoryTask : DefaultTask() {
+
+  lateinit var nexusOptions: NexusOptions
+
   @SuppressWarnings("unused")
   @TaskAction
   fun closeAndReleaseRepository() {
-    val mavenPublishPluginExtension = project.extensions.getByType(MavenPublishPluginExtension::class.java)
-    val nexusOptions = mavenPublishPluginExtension.nexusOptions
-
-    val baseUrl = nexusOptions.baseUrl ?: OSSRH_API_BASE_URL
-    val groupId = nexusOptions.groupId ?: project.findMandatoryProperty("GROUP")
+    val baseUrl = nexusOptions.baseUrl
+    val stagingProfile = nexusOptions.stagingProfile
     val repositoryUsername = nexusOptions.repositoryUsername
-      ?: project.findOptionalProperty("SONATYPE_NEXUS_USERNAME")
-      ?: System.getenv("SONATYPE_NEXUS_USERNAME")
 
     requireNotNull(repositoryUsername) {
       "Please set a value for SONATYPE_NEXUS_USERNAME"
     }
 
     val repositoryPassword = nexusOptions.repositoryPassword
-      ?: project.findOptionalProperty("SONATYPE_NEXUS_PASSWORD")
-      ?: System.getenv("SONATYPE_NEXUS_PASSWORD")
 
     requireNotNull(repositoryPassword) {
       "Please set a value for SONATYPE_NEXUS_PASSWORD"
     }
 
-    Nexus(repositoryUsername, repositoryPassword, groupId, baseUrl).closeAndReleaseRepository()
-  }
-
-  companion object {
-    const val OSSRH_API_BASE_URL = "https://oss.sonatype.org/service/local/"
+    Nexus(repositoryUsername, repositoryPassword, stagingProfile, baseUrl).closeAndReleaseRepository()
   }
 }

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/CloseAndReleaseRepositoryTask.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/CloseAndReleaseRepositoryTask.kt
@@ -1,8 +1,5 @@
 package com.vanniktech.maven.publish.nexus
 
-import com.vanniktech.maven.publish.MavenPublishPluginExtension
-import com.vanniktech.maven.publish.findMandatoryProperty
-import com.vanniktech.maven.publish.findOptionalProperty
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/CloseAndReleaseRepositoryTask.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/CloseAndReleaseRepositoryTask.kt
@@ -15,6 +15,11 @@ open class CloseAndReleaseRepositoryTask : DefaultTask() {
   fun closeAndReleaseRepository() {
     val baseUrl = nexusOptions.baseUrl
     val stagingProfile = nexusOptions.stagingProfile
+
+    requireNotNull(stagingProfile) {
+      "Please set a value for SONATYPE_STAGING_PROFILE"
+    }
+
     val repositoryUsername = nexusOptions.repositoryUsername
 
     requireNotNull(repositoryUsername) {

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
@@ -9,7 +9,7 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 import java.io.IOException
 import java.lang.IllegalArgumentException
 
-class Nexus(username: String, password: String, val groupId: String, baseUrl: String) {
+class Nexus(username: String, password: String, val stagingProfile: String, baseUrl: String) {
   private val service by lazy {
     val okHttpClient = OkHttpClient.Builder()
       .addInterceptor(NexusOkHttpInterceptor(username, password))
@@ -34,7 +34,7 @@ class Nexus(username: String, password: String, val groupId: String, baseUrl: St
   }
 
   private fun findStagingRepository(): Repository {
-    val prefix = groupId.replace(".", "")
+    val prefix = stagingProfile.replace(".", "")
     val candidateRepositories = getProfileRepositories()
       ?.filter { it.repositoryId.startsWith(prefix) } ?: emptyList()
 

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusConfigurer.kt
@@ -1,11 +1,17 @@
 package com.vanniktech.maven.publish.nexus
 
+import com.vanniktech.maven.publish.MavenPublishPluginExtension
 import org.gradle.api.Project
 
 class NexusConfigurer(project: Project) {
   init {
-    val task = project.tasks.create<CloseAndReleaseRepositoryTask>("closeAndReleaseRepository", CloseAndReleaseRepositoryTask::class.java)
+    val mavenPublishPluginExtension = project.extensions.getByType(MavenPublishPluginExtension::class.java)
+
+    // create on rootProject so that it only exists once
+    // there is no maybeRegister https://github.com/gradle/gradle/issues/6243
+    val task = project.rootProject.tasks.maybeCreate("closeAndReleaseRepository", CloseAndReleaseRepositoryTask::class.java)
     task.description = "Closes and releases an artifacts repository in Nexus"
     task.group = "release"
+    task.nexusOptions = mavenPublishPluginExtension.nexusOptions
   }
 }

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusOptions.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusOptions.kt
@@ -17,7 +17,7 @@ class NexusOptions(project: Project) {
    * Defaults to the GROUP Gradle Property.
    * @since 0.9.0
    */
-  var stagingProfile: String =  project.findOptionalProperty("SONATYPE_STAGING_PROFILE") ?: project.findMandatoryProperty("GROUP")
+  var stagingProfile: String? = project.findOptionalProperty("SONATYPE_STAGING_PROFILE") ?: project.findOptionalProperty("GROUP")
 
   /**
    * The username used to access the Nexus REST API.

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusOptions.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusOptions.kt
@@ -1,6 +1,5 @@
 package com.vanniktech.maven.publish.nexus
 
-import com.vanniktech.maven.publish.findMandatoryProperty
 import com.vanniktech.maven.publish.findOptionalProperty
 import org.gradle.api.Project
 

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusOptions.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusOptions.kt
@@ -1,31 +1,39 @@
 package com.vanniktech.maven.publish.nexus
 
-class NexusOptions {
+import com.vanniktech.maven.publish.findMandatoryProperty
+import com.vanniktech.maven.publish.findOptionalProperty
+import org.gradle.api.Project
+
+class NexusOptions(project: Project) {
   /**
    * Base url of the REST API of the nexus instance you are using.
    * Defaults to OSSRH ("https://oss.sonatype.org/service/local/").
    * @since 0.9.0
    */
-  var baseUrl: String? = null
+  var baseUrl: String = OSSRH_API_BASE_URL
 
   /**
    * The groupId associated with your username.
    * Defaults to the GROUP Gradle Property.
    * @since 0.9.0
    */
-  var groupId: String? = null
+  var stagingProfile: String =  project.findOptionalProperty("SONATYPE_STAGING_PROFILE") ?: project.findMandatoryProperty("GROUP")
 
   /**
    * The username used to access the Nexus REST API.
    * Defaults to the SONATYPE_NEXUS_USERNAME Gradle property.
    * @since 0.9.0
    */
-  var repositoryUsername: String? = null
+  var repositoryUsername: String? = project.findOptionalProperty("SONATYPE_NEXUS_USERNAME") ?: System.getenv("SONATYPE_NEXUS_USERNAME")
 
   /**
    * The username used to access the Nexus REST API.
    * Defaults to the SONATYPE_NEXUS_PASSWORD Gradle property.
    * @since 0.9.0
    */
-  var repositoryPassword: String? = null
+  var repositoryPassword: String? = project.findOptionalProperty("SONATYPE_NEXUS_PASSWORD") ?: System.getenv("SONATYPE_NEXUS_PASSWORD")
+
+  private companion object {
+    const val OSSRH_API_BASE_URL = "https://oss.sonatype.org/service/local/"
+  }
 }


### PR DESCRIPTION
Instead of creating the `closeAndReleaseRepository` task on every module where the plugin is applied, we will now just create a single task in the root project. 

To make configuration easier I've added support for a new `SONATYPE_STAGING_PROFILE` property. I've also renamed `groupId` in the extension to `stagingProfile` to make the differentiation clearer (mentioned this in #127) before.