### PR TITLE
update to Gradle 6.6

### DIFF
--- a/gradle/integration-test.gradle
+++ b/gradle/integration-test.gradle
@@ -2,6 +2,7 @@ sourceSets {
   integrationTest {
     kotlin.srcDirs = ['src/integrationTest/kotlin']
     resources.srcDir file('src/integrationTest/resources')
+    resources.srcDir "$buildDir/pluginUnderTestMetadata"
     compileClasspath += sourceSets.main.output + configurations.testRuntime
     runtimeClasspath += output + compileClasspath
   }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/integrationTest/fixtures/common/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/common/expected/test-artifact-1.0.0.pom
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
   <artifactId>test-artifact</artifactId>

--- a/src/integrationTest/fixtures/minimal_pom_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/minimal_pom_project/expected/test-artifact-1.0.0.pom
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
   <artifactId>test-artifact</artifactId>

--- a/src/integrationTest/fixtures/override_version_group_project/expected/test-artifact-2.0.0.pom
+++ b/src/integrationTest/fixtures/override_version_group_project/expected/test-artifact-2.0.0.pom
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example2</groupId>
   <artifactId>test-artifact</artifactId>

--- a/src/integrationTest/fixtures/passing_android_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_android_project/expected/test-artifact-1.0.0.pom
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
   <artifactId>test-artifact</artifactId>

--- a/src/integrationTest/fixtures/passing_android_with_kotlin_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_android_with_kotlin_project/expected/test-artifact-1.0.0.pom
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
   <artifactId>test-artifact</artifactId>

--- a/src/integrationTest/fixtures/passing_groovy_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_groovy_project/expected/test-artifact-1.0.0.pom
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
   <artifactId>test-artifact</artifactId>

--- a/src/integrationTest/fixtures/passing_java_gradle_plugin_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_java_gradle_plugin_project/expected/test-artifact-1.0.0.pom
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
   <artifactId>test-artifact</artifactId>

--- a/src/integrationTest/fixtures/passing_java_library_with_groovy_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_java_library_with_groovy_project/expected/test-artifact-1.0.0.pom
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
   <artifactId>test-artifact</artifactId>

--- a/src/integrationTest/fixtures/passing_java_library_with_kotlin_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_java_library_with_kotlin_project/expected/test-artifact-1.0.0.pom
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
   <artifactId>test-artifact</artifactId>

--- a/src/integrationTest/fixtures/passing_java_with_kotlin_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_java_with_kotlin_project/expected/test-artifact-1.0.0.pom
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
   <artifactId>test-artifact</artifactId>

--- a/src/integrationTest/fixtures/passing_kotlin_js_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_js_project/expected/test-artifact-1.0.0.pom
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
   <artifactId>test-artifact</artifactId>

--- a/src/integrationTest/fixtures/passing_kotlin_jvm_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_jvm_project/expected/test-artifact-1.0.0.pom
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
   <artifactId>test-artifact</artifactId>

--- a/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-1.0.0.pom
@@ -5,7 +5,7 @@
   <!-- which should be used instead. Do not delete the following line which  -->
   <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
   <!-- that they should prefer consuming it instead. -->
-  <!-- do-not-remove: published-with-gradle-metadata -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
   <artifactId>test-artifact</artifactId>

--- a/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-jvm-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-jvm-1.0.0.pom
@@ -4,7 +4,7 @@
   <!-- which should be used instead. Do not delete the following line which  -->
   <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
   <!-- that they should prefer consuming it instead. -->
-  <!-- do-not-remove: published-with-gradle-metadata -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
   <artifactId>test-artifact-jvm</artifactId>

--- a/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-linux-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-linux-1.0.0.pom
@@ -4,7 +4,7 @@
   <!-- which should be used instead. Do not delete the following line which  -->
   <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
   <!-- that they should prefer consuming it instead. -->
-  <!-- do-not-remove: published-with-gradle-metadata -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
   <artifactId>test-artifact-linux</artifactId>

--- a/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-metadata-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-metadata-1.0.0.pom
@@ -4,7 +4,7 @@
   <!-- which should be used instead. Do not delete the following line which  -->
   <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
   <!-- that they should prefer consuming it instead. -->
-  <!-- do-not-remove: published-with-gradle-metadata -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
   <artifactId>test-artifact-metadata</artifactId>

--- a/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-nodejs-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_mpp_project/expected/test-artifact-nodejs-1.0.0.pom
@@ -4,7 +4,7 @@
   <!-- which should be used instead. Do not delete the following line which  -->
   <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
   <!-- that they should prefer consuming it instead. -->
-  <!-- do-not-remove: published-with-gradle-metadata -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
   <artifactId>test-artifact-nodejs</artifactId>

--- a/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -173,27 +173,25 @@ class MavenPublishPluginIntegrationTest(
     assertThat(result.task(":$uploadArchivesTargetTaskName")?.outcome).isEqualTo(SUCCESS)
     assertThat(result.task(":dokka")?.outcome).isEqualTo(SUCCESS)
 
+    // the general coordinate does not have an actual artifact like a jar or klib
+    // so we are checking the module file twice as a workaround
     assertExpectedCommonArtifactsGenerated(artifactExtension = "module")
     assertPomContentMatches()
 
     val metadataArtifactId = "$TEST_POM_ARTIFACT_ID-metadata"
-    assertExpectedCommonArtifactsGenerated("module", metadataArtifactId)
-    assertArtifactGenerated("$metadataArtifactId-$TEST_VERSION_NAME.jar", metadataArtifactId)
+    assertExpectedCommonArtifactsGenerated(artifactId = metadataArtifactId)
     assertPomContentMatches(metadataArtifactId)
 
     val jvmArtifactId = "$TEST_POM_ARTIFACT_ID-jvm"
-    assertExpectedCommonArtifactsGenerated("module", jvmArtifactId)
-    assertArtifactGenerated("$jvmArtifactId-$TEST_VERSION_NAME.jar", jvmArtifactId)
+    assertExpectedCommonArtifactsGenerated(artifactId = jvmArtifactId)
     assertPomContentMatches(jvmArtifactId)
 
     val nodejsArtifactId = "$TEST_POM_ARTIFACT_ID-nodejs"
-    assertExpectedCommonArtifactsGenerated("module", nodejsArtifactId)
-    assertArtifactGenerated("$nodejsArtifactId-$TEST_VERSION_NAME.jar", nodejsArtifactId)
+    assertExpectedCommonArtifactsGenerated(artifactId = nodejsArtifactId)
     assertPomContentMatches(nodejsArtifactId)
 
     val linuxArtifactId = "$TEST_POM_ARTIFACT_ID-linux"
-    assertExpectedCommonArtifactsGenerated("module", linuxArtifactId)
-    assertArtifactGenerated("$linuxArtifactId-$TEST_VERSION_NAME.klib", linuxArtifactId)
+    assertExpectedCommonArtifactsGenerated(artifactExtension = "klib", artifactId = linuxArtifactId)
     assertPomContentMatches(linuxArtifactId)
   }
 
@@ -255,10 +253,12 @@ class MavenPublishPluginIntegrationTest(
   ) {
     val artifactJar = "$artifactId-$version.$artifactExtension"
     val pomFile = "$artifactId-$version.pom"
+    val moduleFile = "$artifactId-$version.module"
     val javadocJar = "$artifactId-$version-javadoc.jar"
     val sourcesJar = "$artifactId-$version-sources.jar"
     assertArtifactGenerated(artifactJar, artifactId, groupId, version)
     assertArtifactGenerated(pomFile, artifactId, groupId, version)
+    assertArtifactGenerated(moduleFile, artifactId, groupId, version)
     assertArtifactGenerated(javadocJar, artifactId, groupId, version)
     assertArtifactGenerated(sourcesJar, artifactId, groupId, version)
   }

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
@@ -47,7 +47,7 @@ open class MavenPublishPluginExtension(project: Project) {
    * Allows to promote repositories without connecting to the nexus instance console.
    * @since 0.9.0
    */
-  var nexusOptions = NexusOptions(project)
+  var nexusOptions = NexusOptions.fromProject(project)
 
   /**
    * Allows to promote repositories without connecting to the nexus instance console.

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/CloseAndReleaseRepositoryTask.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/CloseAndReleaseRepositoryTask.kt
@@ -1,10 +1,12 @@
 package com.vanniktech.maven.publish.nexus
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 
 open class CloseAndReleaseRepositoryTask : DefaultTask() {
 
+  @Input
   lateinit var nexusOptions: NexusOptions
 
   @SuppressWarnings("unused")

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/CloseAndReleaseRepositoryTask.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/CloseAndReleaseRepositoryTask.kt
@@ -1,12 +1,12 @@
 package com.vanniktech.maven.publish.nexus
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
 
 open class CloseAndReleaseRepositoryTask : DefaultTask() {
 
-  @Input
+  @Nested
   lateinit var nexusOptions: NexusOptions
 
   @SuppressWarnings("unused")

--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusOptions.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusOptions.kt
@@ -1,38 +1,52 @@
 package com.vanniktech.maven.publish.nexus
 
 import com.vanniktech.maven.publish.findOptionalProperty
+import org.gradle.api.tasks.Input
 import org.gradle.api.Project
 
-class NexusOptions(project: Project) {
+data class NexusOptions(
   /**
    * Base url of the REST API of the nexus instance you are using.
    * Defaults to OSSRH ("https://oss.sonatype.org/service/local/").
    * @since 0.9.0
    */
-  var baseUrl: String = OSSRH_API_BASE_URL
+  @Input
+  var baseUrl: String,
 
   /**
    * The groupId associated with your username.
    * Defaults to the GROUP Gradle Property.
    * @since 0.9.0
    */
-  var stagingProfile: String? = project.findOptionalProperty("SONATYPE_STAGING_PROFILE") ?: project.findOptionalProperty("GROUP")
+  @Input
+  var stagingProfile: String?,
 
   /**
    * The username used to access the Nexus REST API.
    * Defaults to the SONATYPE_NEXUS_USERNAME Gradle property.
    * @since 0.9.0
    */
-  var repositoryUsername: String? = project.findOptionalProperty("SONATYPE_NEXUS_USERNAME") ?: System.getenv("SONATYPE_NEXUS_USERNAME")
+  @Input
+  var repositoryUsername: String?,
 
   /**
    * The username used to access the Nexus REST API.
    * Defaults to the SONATYPE_NEXUS_PASSWORD Gradle property.
    * @since 0.9.0
    */
-  var repositoryPassword: String? = project.findOptionalProperty("SONATYPE_NEXUS_PASSWORD") ?: System.getenv("SONATYPE_NEXUS_PASSWORD")
+  @Input
+  var repositoryPassword: String?
+) {
+  companion object {
+    private const val OSSRH_API_BASE_URL = "https://oss.sonatype.org/service/local/"
 
-  private companion object {
-    const val OSSRH_API_BASE_URL = "https://oss.sonatype.org/service/local/"
+    fun fromProject(project: Project): NexusOptions {
+      return NexusOptions(
+        OSSRH_API_BASE_URL,
+        project.findOptionalProperty("SONATYPE_STAGING_PROFILE") ?: project.findOptionalProperty("GROUP"),
+        project.findOptionalProperty("SONATYPE_NEXUS_USERNAME") ?: System.getenv("SONATYPE_NEXUS_USERNAME"),
+        project.findOptionalProperty("SONATYPE_NEXUS_PASSWORD") ?: System.getenv("SONATYPE_NEXUS_PASSWORD")
+      )
+    }
   }
 }


### PR DESCRIPTION
The integration tests changed a bit because is published with metadata now. So the expected poms changes and we can generally check that a `.module` file gets created and published.