### PR TITLE
Dokka 1.4 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,9 +74,8 @@ dependencies {
   api gradleApi()
   api "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
-  implementation "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
-  implementation "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokkaVersion"
-
+  compileOnly "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
+  compileOnly "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokkaVersion"
   compileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
   compileOnly "com.android.tools.build:gradle:$agpVersion"
 
@@ -92,6 +91,8 @@ dependencies {
   testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
   testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
   testImplementation "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+  testImplementation "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
+  testImplementation "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokkaVersion"
 
   integrationTestImplementation gradleTestKit()
   integrationTestImplementation "junit:junit:$junitVersion"

--- a/src/integrationTest/fixtures/passing_android_with_kotlin_project/build.gradle
+++ b/src/integrationTest/fixtures/passing_android_with_kotlin_project/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "com.android.library"
     id "org.jetbrains.kotlin.android"
     id "com.vanniktech.maven.publish"
+    id "org.jetbrains.dokka"
 }
 
 android {

--- a/src/integrationTest/fixtures/passing_java_library_with_kotlin_project/build.gradle
+++ b/src/integrationTest/fixtures/passing_java_library_with_kotlin_project/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "java-library"
     id "org.jetbrains.kotlin.jvm"
     id "com.vanniktech.maven.publish"
+    id "org.jetbrains.dokka"
 }
 
 repositories {

--- a/src/integrationTest/fixtures/passing_java_with_kotlin_project/build.gradle
+++ b/src/integrationTest/fixtures/passing_java_with_kotlin_project/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "java"
     id "org.jetbrains.kotlin.jvm"
     id "com.vanniktech.maven.publish"
+    id "org.jetbrains.dokka"
 }
 
 repositories {

--- a/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
@@ -3,6 +3,7 @@ package com.vanniktech.maven.publish
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.plugins.signing.SigningExtension
+import org.jetbrains.dokka.gradle.DokkaTask
 import java.util.concurrent.Callable
 
 internal fun Project.findMandatoryProperty(propertyName: String): String {
@@ -22,4 +23,13 @@ internal inline val Project.publishing: PublishingExtension
   get() = extensions.getByType(PublishingExtension::class.java)
 
 internal inline val Project.isSigningRequired: Callable<Boolean>
-  get() = Callable<Boolean> { !project.version.toString().contains("SNAPSHOT") }
+  get() = Callable { !project.version.toString().contains("SNAPSHOT") }
+
+internal fun Project.findDokkaTask(): DokkaTask {
+  val tasks = project.tasks.withType(DokkaTask::class.java)
+  return if (tasks.size == 1) {
+    tasks.first()
+  } else {
+    tasks.findByName("dokkaHtml") ?: tasks.getByName("dokka")
+  }
+}

--- a/src/main/kotlin/com/vanniktech/maven/publish/tasks/AndroidJavadocsJar.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/tasks/AndroidJavadocsJar.kt
@@ -1,8 +1,8 @@
 package com.vanniktech.maven.publish.tasks
 
+import com.vanniktech.maven.publish.findDokkaTask
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.jvm.tasks.Jar
-import org.jetbrains.dokka.gradle.DokkaTask
 
 @Suppress("UnstableApiUsage")
 open class AndroidJavadocsJar : Jar() {
@@ -11,7 +11,7 @@ open class AndroidJavadocsJar : Jar() {
     archiveClassifier.set("javadoc")
 
     if (project.plugins.hasPlugin("org.jetbrains.dokka")) {
-      val dokkaTask = project.tasks.getByName("dokka") as DokkaTask
+      val dokkaTask = project.findDokkaTask()
       dependsOn(dokkaTask)
       from(dokkaTask.outputDirectory)
     } else {

--- a/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocsJar.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocsJar.kt
@@ -1,8 +1,8 @@
 package com.vanniktech.maven.publish.tasks
 
+import com.vanniktech.maven.publish.findDokkaTask
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.jvm.tasks.Jar
-import org.jetbrains.dokka.gradle.DokkaTask
 
 @Suppress("UnstableApiUsage")
 open class JavadocsJar : Jar() {
@@ -11,7 +11,7 @@ open class JavadocsJar : Jar() {
     archiveClassifier.set("javadoc")
 
     if (project.plugins.hasPlugin("org.jetbrains.dokka")) {
-      val dokkaTask = project.tasks.getByName("dokka") as DokkaTask
+      val dokkaTask = project.findDokkaTask()
       dependsOn(dokkaTask)
       from(dokkaTask.outputDirectory)
     } else {


### PR DESCRIPTION
fixes #150 

For now the logic will be:
- if there is just one `DokkaTask` take that
- otherwise use `dokkaHtml` (one of the default tasks created in 1.4)
- and the fallback is the current `dokka` task

I want to avoid adding an option until #138 is figured out.

This also changes the dependency ok dokka to `compileOnly`. Newer versions don't have an extra Android artifact anymore and we're less coupled to it. Users that only implicitly depended on it before will see an error and need to add it manually.

Branch to show that it works with 1.4 https://github.com/vanniktech/gradle-maven-publish-plugin/compare/dokka...dokka-1.4-rc