### PR TITLE
change how closeAndReleaseRepository is created to avoid ClassCastException

### DIFF
--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusConfigurer.kt
@@ -2,16 +2,20 @@ package com.vanniktech.maven.publish.nexus
 
 import com.vanniktech.maven.publish.MavenPublishPluginExtension
 import org.gradle.api.Project
+import org.gradle.api.UnknownTaskException
 
 class NexusConfigurer(project: Project) {
   init {
     val mavenPublishPluginExtension = project.extensions.getByType(MavenPublishPluginExtension::class.java)
 
-    // create on rootProject so that it only exists once
-    // there is no maybeRegister https://github.com/gradle/gradle/issues/6243
-    val task = project.rootProject.tasks.maybeCreate("closeAndReleaseRepository", CloseAndReleaseRepositoryTask::class.java)
-    task.description = "Closes and releases an artifacts repository in Nexus"
-    task.group = "release"
-    task.nexusOptions = mavenPublishPluginExtension.nexusOptions
+    try {
+      project.rootProject.tasks.named("closeAndReleaseRepository")
+    } catch (e: UnknownTaskException) {
+      project.rootProject.tasks.register("closeAndReleaseRepository", CloseAndReleaseRepositoryTask::class.java) {
+        it.description = "Closes and releases an artifacts repository in Nexus"
+        it.group = "release"
+        it.nexusOptions = mavenPublishPluginExtension.nexusOptions
+      }
+    }
   }
 }


### PR DESCRIPTION
I'm not sure why the crash was happening, but this avoids it by avoiding the cast entirely. The task is now also created lazily. I've tested it locally on Kotlinpoet with an `includeBuild`.

Closes #156 