### PR TITLE
update to min Gradle 6.6

### DIFF
--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -19,7 +19,7 @@ open class MavenPublishPlugin : Plugin<Project> {
 
     val gradleVersion = VersionNumber.parse(p.gradle.gradleVersion)
     if (gradleVersion < VersionNumber(MINIMUM_GRADLE_MAJOR, MINIMUM_GRADLE_MINOR, MINIMUM_GRADLE_MICRO, null)) {
-      throw IllegalArgumentException("You need gradle version 4.10.1 or higher")
+      throw IllegalArgumentException("You need gradle version 6.6.0 or higher")
     }
 
     p.plugins.apply(GradleMavenPublishPlugin::class.java)
@@ -33,7 +33,7 @@ open class MavenPublishPlugin : Plugin<Project> {
     configureDokka(p)
 
     p.afterEvaluate { project ->
-      val configurer = MavenPublishConfigurer(p, pom, extension.targets)
+      val configurer = MavenPublishConfigurer(p, pom)
 
       extension.targets.all {
         checkNotNull(it.releaseRepositoryUrl) {
@@ -106,9 +106,9 @@ open class MavenPublishPlugin : Plugin<Project> {
   }
 
   companion object {
-    const val MINIMUM_GRADLE_MAJOR = 4
-    const val MINIMUM_GRADLE_MINOR = 10
-    const val MINIMUM_GRADLE_MICRO = 1
+    const val MINIMUM_GRADLE_MAJOR = 6
+    const val MINIMUM_GRADLE_MINOR = 6
+    const val MINIMUM_GRADLE_MICRO = 0
 
     const val PLUGIN_DOKKA = "org.jetbrains.dokka"
   }


### PR DESCRIPTION
This allows us to register artifacts using task providers, so that we don't need to set up the task dependencies manually anymore.