### PR TITLE
Enable Kotlin/JS publication

### DIFF
--- a/src/integrationTest/fixtures/passing_kotlin_js_project/build.gradle
+++ b/src/integrationTest/fixtures/passing_kotlin_js_project/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "org.jetbrains.kotlin.js"
+    id "org.jetbrains.dokka"
     id "com.vanniktech.maven.publish"
 }
 
@@ -8,8 +9,28 @@ repositories {
     jcenter()
 }
 
+kotlin() {
+    target {
+        nodejs {
+
+        }
+    }
+}
+
 dependencies {
-    api "org.jetbrains.kotlin:kotlin-stdlib-js:1.3.61"
+    api "org.jetbrains.kotlin:kotlin-stdlib-js:1.3.72"
+}
+
+dokka {
+    kotlinTasks {
+        // dokka fails to retrieve sources from MPP-tasks so they must be set empty to avoid exception
+        // use sourceRoot instead (see below)
+        []
+    }
+    sourceRoot {
+        path = kotlin.sourceSets.main.kotlin.srcDirs[0]
+        platforms = ["JS"]
+    }
 }
 
 apply from: "maven-publish.gradle"

--- a/src/integrationTest/fixtures/passing_kotlin_js_project/build.gradle
+++ b/src/integrationTest/fixtures/passing_kotlin_js_project/build.gradle
@@ -23,8 +23,8 @@ dependencies {
 
 dokka {
     kotlinTasks {
-        // dokka fails to retrieve sources from MPP-tasks so they must be set empty to avoid exception
-        // use sourceRoot instead (see below)
+        // Dokka fails to retrieve sources from MPP-tasks so they must be set empty to avoid exception.
+        // Use sourceRoot instead as configured below.
         []
     }
     sourceRoot {

--- a/src/integrationTest/fixtures/passing_kotlin_js_project/build.gradle
+++ b/src/integrationTest/fixtures/passing_kotlin_js_project/build.gradle
@@ -25,6 +25,7 @@ dokka {
     kotlinTasks {
         // Dokka fails to retrieve sources from MPP-tasks so they must be set empty to avoid exception.
         // Use sourceRoot instead as configured below.
+        // https://discuss.kotlinlang.org/t/how-to-configure-dokka-for-kotlin-multiplatform/9834
         []
     }
     sourceRoot {

--- a/src/integrationTest/fixtures/passing_kotlin_js_project/expected/test-artifact-1.0.0.pom
+++ b/src/integrationTest/fixtures/passing_kotlin_js_project/expected/test-artifact-1.0.0.pom
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <!-- This module was also published with a richer model, Gradle metadata,  -->
   <!-- which should be used instead. Do not delete the following line which  -->
   <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
@@ -35,8 +36,8 @@
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-jdk8</artifactId>
-      <version>1.3.61</version>
+      <artifactId>kotlin-stdlib-js</artifactId>
+      <version>1.3.72</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/src/integrationTest/fixtures/passing_kotlin_js_project/src/main/kotlin/com/vanniktech/maven/publish/test/TestClass.kt
+++ b/src/integrationTest/fixtures/passing_kotlin_js_project/src/main/kotlin/com/vanniktech/maven/publish/test/TestClass.kt
@@ -11,6 +11,6 @@ object TestClass {
    */
   @Suppress("UnusedPrivateMember")
   fun main(args: Array<String?>?) {
-    System.out.println("Hello World!")
+    println("Hello World!")
   }
 }

--- a/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -4,7 +4,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
-import org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -195,6 +195,19 @@ class MavenPublishPluginIntegrationTest(
     assertPomContentMatches(linuxArtifactId)
   }
 
+  @Test
+  fun generatesArtifactsAndDocumentationOnKotlinJsProject() {
+    setupFixture("passing_kotlin_js_project")
+    val result = executeGradleCommands(uploadArchivesTargetTaskName, "--info", "--stacktrace")
+
+    assertThat(result.task(":$uploadArchivesTargetTaskName")?.outcome).isEqualTo(SUCCESS)
+    assertThat(result.task(":dokka")?.outcome).isEqualTo(SUCCESS)
+
+    assertExpectedCommonArtifactsGenerated()
+    assertExpectedCommonArtifactsGenerated(artifactExtension = "module")
+    assertPomContentMatches()
+  }
+
   @Test fun generatesArtifactsAndDocumentationOnGradlePluginProject() {
     setupFixture("passing_java_gradle_plugin_project")
 

--- a/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -131,16 +131,6 @@ class MavenPublishPluginIntegrationTest(
     assertSourceJarContainsFile("com/vanniktech/maven/publish/test/TestClass.kt", "src/main/java")
   }
 
-  @Test fun doesNotFailOnKotlinJsProject() {
-    setupFixture("passing_kotlin_js_project")
-
-    val result = executeGradleCommands(uploadArchivesTargetTaskName, "publish", "build", "--info")
-
-    assertThat(result.task(":$uploadArchivesTargetTaskName")?.outcome).isEqualTo(UP_TO_DATE)
-    assertThat(result.task(":publish")?.outcome).isEqualTo(UP_TO_DATE)
-    assertThat(result.task(":build")?.outcome).isEqualTo(SUCCESS)
-  }
-
   @Test fun generatesArtifactsAndDocumentationOnAndroidProject() {
     setupFixture("passing_android_project")
 

--- a/src/main/kotlin/com/vanniktech/maven/publish/Configurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/Configurer.kt
@@ -9,6 +9,8 @@ internal interface Configurer {
 
   fun configureKotlinMppProject()
 
+  fun configureKotlinJsProject()
+
   fun configureGradlePluginProject()
 
   fun configureAndroidArtifacts()

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
@@ -135,6 +135,19 @@ internal class MavenPublishConfigurer(
     }
   }
 
+  override fun configureKotlinJsProject() {
+    val javadocsJar = project.tasks.register(JAVADOC_TASK, JavadocsJar::class.java)
+
+    // Create publication, since Kotlin/JS doesn't provide one by default
+    // https://youtrack.jetbrains.com/issue/KT-41582
+    project.publishing.publications.create("mavenJs", MavenPublication::class.java) {
+      configurePom(it, artifactId = it.artifactId.replace(project.name, publishPom.artifactId))
+      it.from(project.components.getByName("kotlin"))
+      it.artifact(project.tasks.named("kotlinSourcesJar"))
+      it.artifact(javadocsJar)
+    }
+  }
+
   override fun configureAndroidArtifacts() {
     val publications = project.publishing.publications
     publications.create(PUBLICATION_NAME, MavenPublication::class.java) { publication ->

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
@@ -138,7 +138,7 @@ internal class MavenPublishConfigurer(
   override fun configureKotlinJsProject() {
     val javadocsJar = project.tasks.register(JAVADOC_TASK, JavadocsJar::class.java)
 
-    // Create publication, since Kotlin/JS doesn't provide one by default
+    // Create publication, since Kotlin/JS doesn't provide one by default.
     // https://youtrack.jetbrains.com/issue/KT-41582
     project.publishing.publications.create("mavenJs", MavenPublication::class.java) {
       configurePom(it, artifactId = it.artifactId.replace(project.name, publishPom.artifactId))

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -78,7 +78,7 @@ open class MavenPublishPlugin : Plugin<Project> {
     }
   }
 
-  @Suppress("ComplexMethod")
+  @Suppress("Detekt.ComplexMethod")
   private fun configurePublishing(project: Project, configurer: Configurer) {
     when {
       project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") -> configurer.configureKotlinMppProject()

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -78,17 +78,15 @@ open class MavenPublishPlugin : Plugin<Project> {
     }
   }
 
+  @Suppress("ComplexMethod")
   private fun configurePublishing(project: Project, configurer: Configurer) {
-    if (project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")) {
-      configurer.configureKotlinMppProject()
-    } else if (project.plugins.hasPlugin("java-gradle-plugin")) {
-      configurer.configureGradlePluginProject()
-    } else if (project.plugins.hasPlugin("com.android.library")) {
-      configurer.configureAndroidArtifacts()
-    } else if (project.plugins.hasPlugin("java") || project.plugins.hasPlugin("java-library")) {
-      configurer.configureJavaArtifacts()
-    } else {
-      project.logger.warn("No compatible plugin found in project ${project.name} for publishing")
+    when {
+      project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") -> configurer.configureKotlinMppProject()
+      project.plugins.hasPlugin("java-gradle-plugin") -> configurer.configureGradlePluginProject()
+      project.plugins.hasPlugin("com.android.library") -> configurer.configureAndroidArtifacts()
+      project.plugins.hasPlugin("java") || project.plugins.hasPlugin("java-library") -> configurer.configureJavaArtifacts()
+      project.plugins.hasPlugin("org.jetbrains.kotlin.js") -> configurer.configureKotlinJsProject()
+      else -> project.logger.warn("No compatible plugin found in project ${project.name} for publishing")
     }
   }
 


### PR DESCRIPTION
This enables the publication of Kotlin/JS libraries by explicitly creating the maven publication. (Based on a note here: https://youtrack.jetbrains.com/issue/KT-41582) 