### PR TITLE
fix signing setup

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -25,6 +25,7 @@ jobs:
           ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_SIGNING_PRIVATE_KEY: ${{ secrets.SIGNING_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
 
       - name: Publish release
         run: ./gradlew closeAndReleaseRepoistory --no-daemon --no-parallel

--- a/build.gradle
+++ b/build.gradle
@@ -102,8 +102,8 @@ dependencies {
 sourceCompatibility = JavaVersion.VERSION_1_7
 
 signing {
-  if (hasProperty('SIGNING_PRIVATE_KEY')) {
-    useInMemoryPgpKeys(SIGNING_PRIVATE_KEY, "")
+  if (project.hasProperty('SIGNING_PRIVATE_KEY') && project.hasProperty('SIGNING_PASSWORD')) {
+    useInMemoryPgpKeys(project.getProperty('SIGNING_PRIVATE_KEY'), project.getProperty('SIGNING_PASSWORD'))
   }
 }
 


### PR DESCRIPTION
Was missing the password and Gradle didn't like property access/checks without `project` within the signing block.

https://github.com/vanniktech/gradle-maven-publish-plugin/compare/test-signing shows that it works