### PR TITLE
fix artifact id in Kotlin MPP projects

### DIFF
--- a/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -179,6 +179,38 @@ class MavenPublishPluginIntegrationTest(
     assertPomContentMatches(linuxArtifactId)
   }
 
+  @Test fun kotlinMppArtifactIdReplacementWorksCorrectly1() {
+    setupFixture("passing_kotlin_mpp_project", "foo")
+
+    val result = executeGradleCommands(uploadArchivesTargetTaskName, "--info", "--stacktrace", "-PPOM_ARTIFACT_ID=foo-bar")
+
+    assertThat(result.task(":$uploadArchivesTargetTaskName")?.outcome).isEqualTo(SUCCESS)
+    assertThat(result.task(":dokka")?.outcome).isEqualTo(SUCCESS)
+
+    assertExpectedCommonArtifactsGenerated(artifactId = "foo-bar", artifactExtension = "module")
+    assertExpectedCommonArtifactsGenerated(artifactId = "foo-bar-metadata")
+    assertExpectedCommonArtifactsGenerated(artifactId = "foo-bar-jvm")
+    assertExpectedCommonArtifactsGenerated(artifactId = "foo-bar-nodejs")
+    assertExpectedCommonArtifactsGenerated(artifactExtension = "klib", artifactId = "foo-bar-linux")
+
+
+  }
+
+  @Test fun kotlinMppArtifactIdReplacementWorksCorrectly2() {
+    setupFixture("passing_kotlin_mpp_project", "foo")
+
+    val result = executeGradleCommands(uploadArchivesTargetTaskName, "--info", "--stacktrace",  "-PPOM_ARTIFACT_ID=bar-foo")
+
+    assertThat(result.task(":$uploadArchivesTargetTaskName")?.outcome).isEqualTo(SUCCESS)
+    assertThat(result.task(":dokka")?.outcome).isEqualTo(SUCCESS)
+
+    assertExpectedCommonArtifactsGenerated(artifactId = "bar-foo", artifactExtension = "module")
+    assertExpectedCommonArtifactsGenerated(artifactId = "bar-foo-metadata")
+    assertExpectedCommonArtifactsGenerated(artifactId = "bar-foo-jvm")
+    assertExpectedCommonArtifactsGenerated(artifactId = "bar-foo-nodejs")
+    assertExpectedCommonArtifactsGenerated(artifactExtension = "klib", artifactId = "bar-foo-linux")
+  }
+
   @Test
   fun generatesArtifactsAndDocumentationOnKotlinJsProject() {
     setupFixture("passing_kotlin_js_project")
@@ -229,9 +261,9 @@ class MavenPublishPluginIntegrationTest(
   /**
    * Copies test fixture into temp directory under test.
    */
-  private fun setupFixture(fixtureName: String) {
+  private fun setupFixture(fixtureName: String, projectName: String = fixtureName) {
     repoFolder = testProjectDir.newFolder("repo")
-    projectFolder = testProjectDir.newFolder(fixtureName)
+    projectFolder = testProjectDir.newFolder(projectName)
     expectedFolder = projectFolder.resolve(EXPECTED_DIR)
 
     File("$FIXTURES/common").copyRecursively(projectFolder)

--- a/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -192,14 +192,12 @@ class MavenPublishPluginIntegrationTest(
     assertExpectedCommonArtifactsGenerated(artifactId = "foo-bar-jvm")
     assertExpectedCommonArtifactsGenerated(artifactId = "foo-bar-nodejs")
     assertExpectedCommonArtifactsGenerated(artifactExtension = "klib", artifactId = "foo-bar-linux")
-
-
   }
 
   @Test fun kotlinMppArtifactIdReplacementWorksCorrectly2() {
     setupFixture("passing_kotlin_mpp_project", "foo")
 
-    val result = executeGradleCommands(uploadArchivesTargetTaskName, "--info", "--stacktrace",  "-PPOM_ARTIFACT_ID=bar-foo")
+    val result = executeGradleCommands(uploadArchivesTargetTaskName, "--info", "--stacktrace", "-PPOM_ARTIFACT_ID=bar-foo")
 
     assertThat(result.task(":$uploadArchivesTargetTaskName")?.outcome).isEqualTo(SUCCESS)
     assertThat(result.task(":dokka")?.outcome).isEqualTo(SUCCESS)

--- a/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -4,7 +4,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -38,12 +37,8 @@ class MavenPublishPluginIntegrationTest(
   @get:Rule val testProjectDir: TemporaryFolder = TemporaryFolder()
 
   private lateinit var repoFolder: File
-
-  @Before fun setUp() {
-    repoFolder = testProjectDir.newFolder("repo")
-
-    File("$FIXTURES/common").listFiles()?.forEach { it.copyRecursively(testProjectDir.root.resolve(it.name)) }
-  }
+  private lateinit var projectFolder: File
+  private lateinit var expectedFolder: File
 
   @Test fun generatesArtifactsAndDocumentationOnJavaProject() {
     setupFixture("passing_java_project")
@@ -235,7 +230,12 @@ class MavenPublishPluginIntegrationTest(
    * Copies test fixture into temp directory under test.
    */
   private fun setupFixture(fixtureName: String) {
-    File("$FIXTURES/$fixtureName").copyRecursively(testProjectDir.root, overwrite = true)
+    repoFolder = testProjectDir.newFolder("repo")
+    projectFolder = testProjectDir.newFolder(fixtureName)
+    expectedFolder = projectFolder.resolve(EXPECTED_DIR)
+
+    File("$FIXTURES/common").copyRecursively(projectFolder)
+    File("$FIXTURES/$fixtureName").copyRecursively(projectFolder, overwrite = true)
   }
 
   private fun assertExpectedTasksRanSuccessfully(result: BuildResult) {
@@ -288,7 +288,7 @@ class MavenPublishPluginIntegrationTest(
     val resolvedPomFile = artifactFolder.resolve(pomFileName)
     val content = resolvedPomFile.readText()
 
-    val expectedContent = testProjectDir.root.resolve(EXPECTED_DIR).resolve(pomFileName).readText()
+    val expectedContent = expectedFolder.resolve(pomFileName).readText()
     assertThat(content).isEqualToNormalizingWhitespace(expectedContent)
   }
 
@@ -306,7 +306,7 @@ class MavenPublishPluginIntegrationTest(
 
     val content = sourcesJar.getInputStream(entry)?.reader()?.buffered()?.readText()
 
-    val expected = testProjectDir.root.resolve(srcRoot).resolve(file)
+    val expected = projectFolder.resolve(srcRoot).resolve(file)
     val expectedContent = expected.readText()
 
     assertThat(content).describedAs(file).isNotBlank()
@@ -319,7 +319,7 @@ class MavenPublishPluginIntegrationTest(
   }
 
   private fun executeGradleCommands(vararg commands: String) = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
+      .withProjectDir(projectFolder)
       .withArguments(*commands, "-Ptest.releaseRepository=$repoFolder")
       .withPluginClasspath()
     .forwardOutput()


### PR DESCRIPTION

Fixes #191.

In #180 I changed the artifact id logic to not run in `afterEvaluate`. However mpp projects write over our artifact id again so for those I kept the `afterEvaluate`. The issue is that for some of the publication our artifact id survives until afterEvaluate. The common and the metadata publications have the intended id while jvm/android/js/native are back to the original. If the new artifact id contains the `project.name` then we run into #191.  
Let's say the project name is `foo` and our artifact id is `foo-bar`. Initially the ids are `foo`, `foo-metadata` and `foo-jvm`. We update that to `foo-bar`, `foo-bar-metadata` and `foo-bar-jvm`. Then Kotlin changes it to `foo-bar`, `foo-bar-metadata` and `foo-jvm`. Now in after evaluate we replace `foo` with `foo-bar` again which is why we get `foo-bar-bar`, `foo-bar-bar-metadata` and `foo-bar-jvm`.

To fix this the afterEvaluate is now per publication and only changes the artifact id if it is not the one we set initially.


This is targeting `0.14.2-release` to do another bugfix release. I will merge that branch into master after the release.