### PR TITLE
add base plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,10 @@ gradlePlugin {
       id = 'com.vanniktech.maven.publish'
       implementationClass = 'com.vanniktech.maven.publish.MavenPublishPlugin'
     }
+    mavenPublishBasePlugin {
+      id = 'com.vanniktech.maven.publish.base'
+      implementationClass = 'com.vanniktech.maven.publish.MavenPublishBasePlugin'
+    }
   }
 }
 

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -19,7 +19,7 @@ open class MavenPublishBaseExtension(
    */
   @Incubating
   fun pom(configure: Action<in MavenPom>) {
-    project.publishing.publications.withType(MavenPublication::class.java).configureEach {
+    project.gradlePublishing.publications.withType(MavenPublication::class.java).configureEach {
       it.pom(configure)
     }
   }

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -1,0 +1,26 @@
+package com.vanniktech.maven.publish
+
+import org.gradle.api.Action
+import org.gradle.api.Incubating
+import org.gradle.api.Project
+import org.gradle.api.publish.maven.MavenPom
+import org.gradle.api.publish.maven.MavenPublication
+
+@Incubating
+open class MavenPublishBaseExtension(
+  private val project: Project
+) {
+
+  /**
+   * Configures the POM that will be published.
+   *
+   * See the [Gradle publishing guide](https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom)
+   * for how to use it.
+   */
+  @Incubating
+  fun pom(configure: Action<in MavenPom>) {
+    project.publishing.publications.withType(MavenPublication::class.java).configureEach {
+      it.pom(configure)
+    }
+  }
+}

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBasePlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBasePlugin.kt
@@ -1,0 +1,24 @@
+package com.vanniktech.maven.publish
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.util.VersionNumber
+import org.gradle.api.publish.maven.plugins.MavenPublishPlugin as GradleMavenPublishPlugin
+
+open class MavenPublishBasePlugin : Plugin<Project> {
+
+  override fun apply(project: Project) {
+    val gradleVersion = VersionNumber.parse(project.gradle.gradleVersion)
+    if (gradleVersion < VersionNumber(MINIMUM_GRADLE_MAJOR, MINIMUM_GRADLE_MINOR, MINIMUM_GRADLE_MICRO, null)) {
+      throw IllegalArgumentException("You need Gradle version 6.6.0 or higher")
+    }
+
+    project.plugins.apply(GradleMavenPublishPlugin::class.java)
+  }
+
+  private companion object {
+    const val MINIMUM_GRADLE_MAJOR = 6
+    const val MINIMUM_GRADLE_MINOR = 6
+    const val MINIMUM_GRADLE_MICRO = 0
+  }
+}

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBasePlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBasePlugin.kt
@@ -14,6 +14,8 @@ open class MavenPublishBasePlugin : Plugin<Project> {
     }
 
     project.plugins.apply(GradleMavenPublishPlugin::class.java)
+
+    project.extensions.create("mavenPublishing", MavenPublishBaseExtension::class.java, project)
   }
 
   private companion object {

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
@@ -9,46 +9,11 @@ import com.vanniktech.maven.publish.tasks.JavadocsJar
 import com.vanniktech.maven.publish.tasks.SourcesJar
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.plugin.devel.GradlePluginDevelopmentExtension
 
 @Suppress("TooManyFunctions")
 internal class MavenPublishConfigurer(
-  private val project: Project,
-  private val publishPom: MavenPublishPom
+  private val project: Project
 ) {
-
-  private fun configurePom(publication: MavenPublication) {
-    @Suppress("UnstableApiUsage")
-    publication.pom { pom ->
-
-      pom.name.set(publishPom.name)
-      pom.description.set(publishPom.description)
-      pom.url.set(publishPom.url)
-      pom.inceptionYear.set(publishPom.inceptionYear)
-
-      pom.scm {
-        it.url.set(publishPom.scmUrl)
-        it.connection.set(publishPom.scmConnection)
-        it.developerConnection.set(publishPom.scmDeveloperConnection)
-      }
-
-      pom.licenses { licenses ->
-        licenses.license {
-          it.name.set(publishPom.licenseName)
-          it.url.set(publishPom.licenseUrl)
-          it.distribution.set(publishPom.licenseDistribution)
-        }
-      }
-
-      pom.developers { developers ->
-        developers.developer {
-          it.id.set(publishPom.developerId)
-          it.name.set(publishPom.developerName)
-          it.url.set(publishPom.developerUrl)
-        }
-      }
-    }
-  }
 
   fun configureGradlePluginProject() {
     val sourcesJar = project.tasks.register(SOURCES_TASK, SourcesJar::class.java)
@@ -56,16 +21,8 @@ internal class MavenPublishConfigurer(
 
     project.publishing.publications.withType(MavenPublication::class.java).all {
       if (it.name == "pluginMaven") {
-        configurePom(it)
         it.artifact(javadocsJar)
         it.artifact(sourcesJar)
-      }
-
-      project.extensions.getByType(GradlePluginDevelopmentExtension::class.java).plugins.forEach { plugin ->
-        if (it.name == "${plugin.name}PluginMarkerMaven") {
-          // keep the current group and artifact ids, they are based on the gradle plugin id
-          configurePom(it)
-        }
       }
     }
   }
@@ -74,7 +31,6 @@ internal class MavenPublishConfigurer(
     val javadocsJar = project.tasks.register(JAVADOC_TASK, JavadocsJar::class.java)
 
     project.publishing.publications.withType(MavenPublication::class.java).all {
-      configurePom(it)
       it.artifact(javadocsJar)
 
       // Source jars are only created for platforms, not the common artifact.
@@ -94,7 +50,6 @@ internal class MavenPublishConfigurer(
     // Create publication, since Kotlin/JS doesn't provide one by default.
     // https://youtrack.jetbrains.com/issue/KT-41582
     project.publishing.publications.create("mavenJs", MavenPublication::class.java) {
-      configurePom(it)
       it.from(project.components.getByName("kotlin"))
       it.artifact(project.tasks.named("kotlinSourcesJar"))
       it.artifact(javadocsJar)
@@ -103,9 +58,7 @@ internal class MavenPublishConfigurer(
 
   fun configureAndroidArtifacts() {
     val publications = project.publishing.publications
-    publications.create(PUBLICATION_NAME, MavenPublication::class.java) { publication ->
-      configurePom(publication)
-    }
+    publications.create(PUBLICATION_NAME, MavenPublication::class.java)
 
     val publication = project.publishing.publications.getByName(PUBLICATION_NAME) as MavenPublication
 
@@ -121,9 +74,7 @@ internal class MavenPublishConfigurer(
 
   fun configureJavaArtifacts() {
     val publications = project.publishing.publications
-    publications.create(PUBLICATION_NAME, MavenPublication::class.java) { publication ->
-      configurePom(publication)
-    }
+    publications.create(PUBLICATION_NAME, MavenPublication::class.java)
 
     val publication = project.publishing.publications.getByName(PUBLICATION_NAME) as MavenPublication
 

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
@@ -19,7 +19,7 @@ internal class MavenPublishConfigurer(
     val sourcesJar = project.tasks.register(SOURCES_TASK, SourcesJar::class.java)
     val javadocsJar = project.tasks.register(JAVADOC_TASK, JavadocsJar::class.java)
 
-    project.publishing.publications.withType(MavenPublication::class.java).all {
+    project.gradlePublishing.publications.withType(MavenPublication::class.java).all {
       if (it.name == "pluginMaven") {
         it.artifact(javadocsJar)
         it.artifact(sourcesJar)
@@ -30,7 +30,7 @@ internal class MavenPublishConfigurer(
   fun configureKotlinMppProject() {
     val javadocsJar = project.tasks.register(JAVADOC_TASK, JavadocsJar::class.java)
 
-    project.publishing.publications.withType(MavenPublication::class.java).all {
+    project.gradlePublishing.publications.withType(MavenPublication::class.java).all {
       it.artifact(javadocsJar)
 
       // Source jars are only created for platforms, not the common artifact.
@@ -49,7 +49,7 @@ internal class MavenPublishConfigurer(
 
     // Create publication, since Kotlin/JS doesn't provide one by default.
     // https://youtrack.jetbrains.com/issue/KT-41582
-    project.publishing.publications.create("mavenJs", MavenPublication::class.java) {
+    project.gradlePublishing.publications.create("mavenJs", MavenPublication::class.java) {
       it.from(project.components.getByName("kotlin"))
       it.artifact(project.tasks.named("kotlinSourcesJar"))
       it.artifact(javadocsJar)
@@ -57,12 +57,12 @@ internal class MavenPublishConfigurer(
   }
 
   fun configureAndroidArtifacts() {
-    val publications = project.publishing.publications
+    val publications = project.gradlePublishing.publications
     publications.create(PUBLICATION_NAME, MavenPublication::class.java)
 
-    val publication = project.publishing.publications.getByName(PUBLICATION_NAME) as MavenPublication
+    val publication = project.gradlePublishing.publications.getByName(PUBLICATION_NAME) as MavenPublication
 
-    publication.from(project.components.getByName(project.publishExtension.androidVariantToPublish))
+    publication.from(project.components.getByName(project.legacyExtension.androidVariantToPublish))
 
     val androidSourcesJar = project.tasks.register("androidSourcesJar", AndroidSourcesJar::class.java)
     publication.artifact(androidSourcesJar)
@@ -73,10 +73,10 @@ internal class MavenPublishConfigurer(
   }
 
   fun configureJavaArtifacts() {
-    val publications = project.publishing.publications
+    val publications = project.gradlePublishing.publications
     publications.create(PUBLICATION_NAME, MavenPublication::class.java)
 
-    val publication = project.publishing.publications.getByName(PUBLICATION_NAME) as MavenPublication
+    val publication = project.gradlePublishing.publications.getByName(PUBLICATION_NAME) as MavenPublication
 
     publication.from(project.components.getByName("java"))
 

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -8,23 +8,16 @@ import com.vanniktech.maven.publish.nexus.NexusConfigurer
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.credentials.PasswordCredentials
-import org.gradle.api.publish.maven.plugins.MavenPublishPlugin as GradleMavenPublishPlugin
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.external.javadoc.StandardJavadocDocletOptions
 import org.gradle.plugins.signing.SigningPlugin
-import org.gradle.util.VersionNumber
 
 open class MavenPublishPlugin : Plugin<Project> {
 
   override fun apply(p: Project) {
+    p.plugins.apply(MavenPublishBasePlugin::class.java)
+
     p.extensions.create("mavenPublish", MavenPublishPluginExtension::class.java, p)
-
-    val gradleVersion = VersionNumber.parse(p.gradle.gradleVersion)
-    if (gradleVersion < VersionNumber(MINIMUM_GRADLE_MAJOR, MINIMUM_GRADLE_MINOR, MINIMUM_GRADLE_MICRO, null)) {
-      throw IllegalArgumentException("You need gradle version 6.6.0 or higher")
-    }
-
-    p.plugins.apply(GradleMavenPublishPlugin::class.java)
 
     val pom = MavenPublishPom.fromProject(p)
     p.setCoordinates(pom)
@@ -100,10 +93,6 @@ open class MavenPublishPlugin : Plugin<Project> {
   }
 
   companion object {
-    const val MINIMUM_GRADLE_MAJOR = 6
-    const val MINIMUM_GRADLE_MINOR = 6
-    const val MINIMUM_GRADLE_MICRO = 0
-
     const val PLUGIN_DOKKA = "org.jetbrains.dokka"
   }
 }

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -1,7 +1,9 @@
 package com.vanniktech.maven.publish
 
+import com.vanniktech.maven.publish.legacy.MavenPublishPom
 import com.vanniktech.maven.publish.legacy.configureArchivesTasks
 import com.vanniktech.maven.publish.legacy.checkProperties
+import com.vanniktech.maven.publish.legacy.configurePom
 import com.vanniktech.maven.publish.legacy.setCoordinates
 import org.gradle.api.JavaVersion
 import com.vanniktech.maven.publish.nexus.NexusConfigurer
@@ -21,6 +23,7 @@ open class MavenPublishPlugin : Plugin<Project> {
 
     val pom = MavenPublishPom.fromProject(p)
     p.setCoordinates(pom)
+    p.configurePom(pom)
     p.checkProperties()
     p.configureArchivesTasks()
 
@@ -41,7 +44,7 @@ open class MavenPublishPlugin : Plugin<Project> {
     configureDokka(p)
 
     p.afterEvaluate { project ->
-      configurePublishing(project, pom)
+      configurePublishing(project)
     }
 
     NexusConfigurer(p)
@@ -80,8 +83,8 @@ open class MavenPublishPlugin : Plugin<Project> {
   }
 
   @Suppress("Detekt.ComplexMethod")
-  private fun configurePublishing(project: Project, pom: MavenPublishPom) {
-    val configurer = MavenPublishConfigurer(project, pom)
+  private fun configurePublishing(project: Project) {
+    val configurer = MavenPublishConfigurer(project)
     when {
       project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") -> configurer.configureKotlinMppProject()
       project.plugins.hasPlugin("java-gradle-plugin") -> configurer.configureGradlePluginProject()

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -27,7 +27,7 @@ open class MavenPublishPlugin : Plugin<Project> {
     p.checkProperties()
     p.configureArchivesTasks()
 
-    p.publishing.repositories.maven { repo ->
+    p.gradlePublishing.repositories.maven { repo ->
       repo.name = "mavenCentral"
       repo.setUrl("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
       repo.credentials(PasswordCredentials::class.java)
@@ -52,11 +52,11 @@ open class MavenPublishPlugin : Plugin<Project> {
 
   private fun configureSigning(project: Project) {
     project.plugins.apply(SigningPlugin::class.java)
-    project.signing.setRequired(project.isSigningRequired)
+    project.gradleSigning.setRequired(project.isSigningRequired)
     project.afterEvaluate {
-      if (project.isSigningRequired.call() && project.project.publishExtension.releaseSigningEnabled) {
+      if (project.isSigningRequired.call() && project.project.legacyExtension.releaseSigningEnabled) {
         @Suppress("UnstableApiUsage")
-        project.signing.sign(project.publishing.publications)
+        project.gradleSigning.sign(project.gradlePublishing.publications)
       }
     }
   }

--- a/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
@@ -16,6 +16,9 @@ internal fun Project.findOptionalProperty(propertyName: String) = findProperty(p
 internal inline val Project.publishExtension: MavenPublishPluginExtension
   get() = project.extensions.getByType(MavenPublishPluginExtension::class.java)
 
+internal inline val Project.baseExtension: MavenPublishBaseExtension
+  get() = project.extensions.getByType(MavenPublishBaseExtension::class.java)
+
 internal inline val Project.signing: SigningExtension
   get() = extensions.getByType(SigningExtension::class.java)
 

--- a/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
@@ -6,23 +6,18 @@ import org.gradle.plugins.signing.SigningExtension
 import org.jetbrains.dokka.gradle.DokkaTask
 import java.util.concurrent.Callable
 
-internal fun Project.findMandatoryProperty(propertyName: String): String {
-  val value = this.findOptionalProperty(propertyName)
-  return requireNotNull(value) { "Please define \"$propertyName\" in your gradle.properties file" }
-}
-
 internal fun Project.findOptionalProperty(propertyName: String) = findProperty(propertyName)?.toString()
 
-internal inline val Project.publishExtension: MavenPublishPluginExtension
+internal inline val Project.legacyExtension: MavenPublishPluginExtension
   get() = project.extensions.getByType(MavenPublishPluginExtension::class.java)
 
 internal inline val Project.baseExtension: MavenPublishBaseExtension
   get() = project.extensions.getByType(MavenPublishBaseExtension::class.java)
 
-internal inline val Project.signing: SigningExtension
+internal inline val Project.gradleSigning: SigningExtension
   get() = extensions.getByType(SigningExtension::class.java)
 
-internal inline val Project.publishing: PublishingExtension
+internal inline val Project.gradlePublishing: PublishingExtension
   get() = extensions.getByType(PublishingExtension::class.java)
 
 internal inline val Project.isSigningRequired: Callable<Boolean>

--- a/src/main/kotlin/com/vanniktech/maven/publish/legacy/Coordinates.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/legacy/Coordinates.kt
@@ -1,6 +1,6 @@
 package com.vanniktech.maven.publish.legacy
 
-import com.vanniktech.maven.publish.publishing
+import com.vanniktech.maven.publish.gradlePublishing
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.MavenPublication
 
@@ -23,7 +23,7 @@ internal fun Project.setCoordinates(pom: MavenPublishPom) {
  * replaced instead of just set.
  */
 private fun Project.setArtifactId(artifactId: String) {
-  publishing.publications.withType(MavenPublication::class.java).configureEach { publication ->
+  gradlePublishing.publications.withType(MavenPublication::class.java).configureEach { publication ->
     // skip the plugin marker artifact which has it's own artifact id based on the plugin id
     if (!publication.name.endsWith("PluginMarkerMaven")) {
       publication.artifactId = publication.artifactId.replace(this@setArtifactId.name, artifactId)

--- a/src/main/kotlin/com/vanniktech/maven/publish/legacy/Coordinates.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/legacy/Coordinates.kt
@@ -1,6 +1,5 @@
 package com.vanniktech.maven.publish.legacy
 
-import com.vanniktech.maven.publish.MavenPublishPom
 import com.vanniktech.maven.publish.publishing
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.MavenPublication

--- a/src/main/kotlin/com/vanniktech/maven/publish/legacy/MavenPublishPom.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/legacy/MavenPublishPom.kt
@@ -1,5 +1,6 @@
-package com.vanniktech.maven.publish
+package com.vanniktech.maven.publish.legacy
 
+import com.vanniktech.maven.publish.findOptionalProperty
 import org.gradle.api.Project
 
 internal data class MavenPublishPom(

--- a/src/main/kotlin/com/vanniktech/maven/publish/legacy/Pom.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/legacy/Pom.kt
@@ -1,0 +1,35 @@
+package com.vanniktech.maven.publish.legacy
+
+import com.vanniktech.maven.publish.baseExtension
+import org.gradle.api.Project
+
+internal fun Project.configurePom(publishPom: MavenPublishPom) {
+  baseExtension.pom { pom ->
+    pom.name.set(publishPom.name)
+    pom.description.set(publishPom.description)
+    pom.url.set(publishPom.url)
+    pom.inceptionYear.set(publishPom.inceptionYear)
+
+    pom.scm {
+      it.url.set(publishPom.scmUrl)
+      it.connection.set(publishPom.scmConnection)
+      it.developerConnection.set(publishPom.scmDeveloperConnection)
+    }
+
+    pom.licenses { licenses ->
+      licenses.license {
+        it.name.set(publishPom.licenseName)
+        it.url.set(publishPom.licenseUrl)
+        it.distribution.set(publishPom.licenseDistribution)
+      }
+    }
+
+    pom.developers { developers ->
+      developers.developer {
+        it.id.set(publishPom.developerId)
+        it.name.set(publishPom.developerName)
+        it.url.set(publishPom.developerUrl)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This starts the implementation of the new APIs from #173.

- add a new `com.vanniktech.maven.publish.base` plugin
  - applies Gradle's `maven-publish`
  - makes the Gradle version check
  - creates the base extension
- adds a new extension
  - It's called `mavenPublishing`, because we already have `mavenPublish` in the old/current plugin. I eventually see the old extension going away. The name is based on the default `publishing` extension name from Gradle.
  - marked as incubation for now
  - has an API for configuring the POM, fixes #171 
  - other APIs will be added later on

The old/current plugin was updated to apply the base plugin. It will also apply the Gradle property POM values using the new API from base extension, instead of duplicating that logic.