### PR TITLE
add signAllPublications API

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.vanniktech
-VERSION_NAME=0.15.0-SNAPSHOT
+VERSION_NAME=0.15.0
 
 POM_ARTIFACT_ID=gradle-maven-publish-plugin
 POM_NAME=Gradle Maven Publish Plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.vanniktech
-VERSION_NAME=0.15.0
+VERSION_NAME=0.15.0-SNAPSHOT
 
 POM_ARTIFACT_ID=gradle-maven-publish-plugin
 POM_NAME=Gradle Maven Publish Plugin

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -32,8 +32,9 @@ abstract class MavenPublishBaseExtension(
    * # if key was created with a password
    * signingInMemoryPassword=secret
    * ```
-   * `gpg2 --export-secret-keys --armor KEY_ID` can be used to export they key for this. The in memory properties can
-   * also be provided as environment variables by prefixing them with `ORG_GRADLE_PROJECT_`, e.g.
+   * `gpg2 --export-secret-keys --armor KEY_ID` can be used to export they key for this. The exported key is taken
+   * without the first line and without the last 2 lines, all line breaks should be removed as well. The in memory
+   * properties can also be provided as environment variables by prefixing them with `ORG_GRADLE_PROJECT_`, e.g.
    * `ORG_GRADLE_PROJECT_signingInMemoryKey`.
    *
    * More information about signing as well as different ways to provide credentials

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -5,12 +5,54 @@ import org.gradle.api.Incubating
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.plugins.signing.SigningPlugin
 
 @Incubating
 @Suppress("UnnecessaryAbstractClass")
 abstract class MavenPublishBaseExtension(
   private val project: Project
 ) {
+
+  /**
+   * Automatically apply Gradle's `signing` plugin and configure all publications to be signed. If signing credentials
+   * are not configured this will fail the build unless the current version is a `SNAPSHOT`.
+   *
+   * Signing can be done using a local `secring.gpg` by setting these Gradle properties:
+   * ```
+   * signing.keyId=24875D73
+   * signing.password=secret
+   * signing.secretKeyRingFile=/Users/me/.gnupg/secring.gpg
+   * ```
+   *
+   * Alternatively an in memory key can be used by exporting an ascii-armored GPG key and setting these Gradle properties"
+   * ```
+   * signingInMemoryKey=exported_ascii_armored_key
+   * # optional
+   * signingInMemoryKeyId=24875D73
+   * # if key was created with a password
+   * signingInMemoryPassword=secret
+   * ```
+   * `gpg2 --export-secret-keys --armor KEY_ID` can be used to export they key for this. The in memory properties can
+   * also be provided as environment variables by prefixing them with `ORG_GRADLE_PROJECT_`, e.g.
+   * `ORG_GRADLE_PROJECT_signingInMemoryKey`.
+   *
+   * More information about signing as well as different ways to provide credentials
+   * can be found in the [Gradle documentation](https://docs.gradle.org/current/userguide/signing_plugin.html)
+   */
+  // TODO update in memory set up once https://github.com/gradle/gradle/issues/16056 is implemented
+  @Incubating
+  fun signAllPublications() {
+    project.plugins.apply(SigningPlugin::class.java)
+    project.gradleSigning.setRequired(project.isSigningRequired)
+    project.gradleSigning.sign(project.gradlePublishing.publications)
+
+    val inMemoryKey = project.findOptionalProperty("signingInMemoryKey")
+    if (inMemoryKey != null) {
+      val inMemoryKeyId = project.findOptionalProperty("signingInMemoryKeyId")
+      val inMemoryKeyPassword = project.findOptionalProperty("signingInMemoryKeyPassword")
+      project.gradleSigning.useInMemoryPgpKeys(inMemoryKeyId, inMemoryKey, inMemoryKeyPassword)
+    }
+  }
 
   /**
    * Configures the POM that will be published.

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -3,6 +3,7 @@ package com.vanniktech.maven.publish
 import com.vanniktech.maven.publish.legacy.configureArchivesTasks
 import com.vanniktech.maven.publish.legacy.checkProperties
 import com.vanniktech.maven.publish.legacy.configurePom
+import com.vanniktech.maven.publish.legacy.configureSigning
 import com.vanniktech.maven.publish.legacy.setCoordinates
 import org.gradle.api.JavaVersion
 import com.vanniktech.maven.publish.nexus.NexusConfigurer
@@ -11,7 +12,6 @@ import org.gradle.api.Project
 import org.gradle.api.credentials.PasswordCredentials
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.external.javadoc.StandardJavadocDocletOptions
-import org.gradle.plugins.signing.SigningPlugin
 
 open class MavenPublishPlugin : Plugin<Project> {
 
@@ -23,6 +23,7 @@ open class MavenPublishPlugin : Plugin<Project> {
     p.setCoordinates()
     p.configurePom()
     p.checkProperties()
+    p.configureSigning()
     p.configureArchivesTasks()
 
     p.gradlePublishing.repositories.maven { repo ->
@@ -37,7 +38,6 @@ open class MavenPublishPlugin : Plugin<Project> {
       }
     }
 
-    configureSigning(p)
     configureJavadoc(p)
     configureDokka(p)
 
@@ -46,17 +46,6 @@ open class MavenPublishPlugin : Plugin<Project> {
     }
 
     NexusConfigurer(p)
-  }
-
-  private fun configureSigning(project: Project) {
-    project.plugins.apply(SigningPlugin::class.java)
-    project.gradleSigning.setRequired(project.isSigningRequired)
-    project.afterEvaluate {
-      if (project.isSigningRequired.call() && project.project.legacyExtension.releaseSigningEnabled) {
-        @Suppress("UnstableApiUsage")
-        project.gradleSigning.sign(project.gradlePublishing.publications)
-      }
-    }
   }
 
   private fun configureJavadoc(project: Project) {

--- a/src/main/kotlin/com/vanniktech/maven/publish/legacy/BaseSetup.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/legacy/BaseSetup.kt
@@ -2,7 +2,16 @@ package com.vanniktech.maven.publish.legacy
 
 import com.vanniktech.maven.publish.baseExtension
 import com.vanniktech.maven.publish.findOptionalProperty
+import com.vanniktech.maven.publish.legacyExtension
 import org.gradle.api.Project
+
+internal fun Project.configureSigning() {
+  afterEvaluate {
+    if (legacyExtension.releaseSigningEnabled) {
+      baseExtension.signAllPublications()
+    }
+  }
+}
 
 internal fun Project.configurePom() {
   // without afterEvaluate https://github.com/gradle/gradle/issues/12259 will happen


### PR DESCRIPTION
Part of #173 

Adds `signAllPublications()` to the base extension which will:
- add the `signing` plugin
- registers all publications to be signed
- Signing is only required if the version does not end with `SNAPSHOT`. This means that building a snapshot does not fail when no signing credentials are configured. If someone wants to create non snapshots builds without signing they can wrap the call to `signAllPublications()` in an `if` condition.
- If there is an Gradle property called `signingInMemoryKey` it will automatically set up in memory signing using that property as well as `signingInMemoryKeyId` and `signingInMemoryPassword`. The latter 2 properties are optional depending on whether you want to explicitly specify a key id and whether your key requires a password. With this all you need to do is provide 3-5 properties/env-vars on CI for all the secrets (2 for sonatype, 1-3 for signing).

Other changes:
- Main plugin uses the new API to set up signing considering it's `releaseSigningEnabled` option
