### PR TITLE
workaround AndroidJavadoc task failing on newer jdks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        java_version: [1.8]
+        java_version: [1.8, 11]
 
     steps:
       - name: Checkout

--- a/src/main/kotlin/com/vanniktech/maven/publish/tasks/AndroidJavadocs.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/tasks/AndroidJavadocs.kt
@@ -36,7 +36,7 @@ open class AndroidJavadocs : Javadoc() {
     // Workaround for the following error when running on on JDK 9+
     // "The code being documented uses modules but the packages defined in ... are in the unnamed module."
     if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
-      options.addStringOption("-release", "8");
+      options.addStringOption("-release", "8")
     }
   }
 }

--- a/src/main/kotlin/com/vanniktech/maven/publish/tasks/AndroidJavadocs.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/tasks/AndroidJavadocs.kt
@@ -1,6 +1,7 @@
 package com.vanniktech.maven.publish.tasks
 
 import com.android.build.gradle.LibraryExtension
+import org.gradle.api.JavaVersion
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.external.javadoc.StandardJavadocDocletOptions
 import java.io.File
@@ -31,5 +32,11 @@ open class AndroidJavadocs : Javadoc() {
     val options = options as StandardJavadocDocletOptions
     options.links("https://developer.android.com/reference")
     options.links("https://docs.oracle.com/javase/8/docs/api/")
+
+    // Workaround for the following error when running on on JDK 9+
+    // "The code being documented uses modules but the packages defined in ... are in the unnamed module."
+    if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
+      options.addStringOption("-release", "8");
+    }
   }
 }


### PR DESCRIPTION
This makes it possible to use the plugin on 9+. I couldn't add 14 to Github Actions because jacoco fails then, will look at that separately