### PR TITLE
fix: Improve error messaging when variant cannot be found.

### DIFF
--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
@@ -62,7 +62,11 @@ internal class MavenPublishConfigurer(
 
     val publication = project.gradlePublishing.publications.getByName(PUBLICATION_NAME) as MavenPublication
 
-    publication.from(project.components.getByName(project.legacyExtension.androidVariantToPublish))
+    project.legacyExtension.androidVariantToPublish.let { variant ->
+      project.components.findByName(variant)?.let {
+        publication.from(it)
+      } ?: throw MissingVariantException(variant)
+    }
 
     val androidSourcesJar = project.tasks.register("androidSourcesJar", AndroidSourcesJar::class.java)
     publication.artifact(androidSourcesJar)
@@ -91,6 +95,12 @@ internal class MavenPublishConfigurer(
       publication.artifact(goovydocsJar)
     }
   }
+
+  class MissingVariantException(name: String) : RuntimeException(
+    "Invalid MavenPublish Configuration. Unable to find variant to publish named $name." +
+    " Try setting the 'androidVariantToPublish' property in the mavenPublish" +
+    " extension object to something that matches the variant that ought to be published."
+  )
 
   companion object {
     const val PUBLICATION_NAME = "maven"


### PR DESCRIPTION
Addresses the other half of https://github.com/vanniktech/gradle-maven-publish-plugin/issues/215