### PR TITLE
API improvements for Groovy users

### DIFF
--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -20,6 +20,7 @@ abstract class MavenPublishBaseExtension(
   private var nexusOptions: NexusOptions? = null
 
   private var mavenCentral: Pair<SonatypeHost, String?>? = null
+  private var signing: Boolean? = null
   private var platform: Platform? = null
 
   /**
@@ -37,6 +38,7 @@ abstract class MavenPublishBaseExtension(
    * @param stagingRepositoryId optional parameter to upload to a specific already created staging repository
    */
   @Incubating
+  @JvmOverloads
   fun publishToMavenCentral(host: SonatypeHost, stagingRepositoryId: String? = null) {
     val mavenCentral = mavenCentral
     if (mavenCentral != null) {
@@ -127,6 +129,14 @@ abstract class MavenPublishBaseExtension(
   // TODO update in memory set up once https://github.com/gradle/gradle/issues/16056 is implemented
   @Incubating
   fun signAllPublications() {
+    val signing = signing
+    if (signing == true) {
+      // ignore subsequent calls with the same arguments
+      return
+    }
+
+    this.signing = true
+
     project.plugins.apply(SigningPlugin::class.java)
     project.gradleSigning.setRequired(project.isSigningRequired)
     project.gradleSigning.sign(project.gradlePublishing.publications)

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishConfigurer.kt
@@ -91,9 +91,9 @@ internal class MavenPublishConfigurer(
 
   private fun javadocJarTask(javadocJar: JavadocJar, android: Boolean = false): TaskProvider<*>? {
     return when (javadocJar) {
-      JavadocJar.None -> null
-      JavadocJar.Empty -> project.emptyJavadocJar()
-      JavadocJar.Javadoc -> project.plainJavadocJar(android)
+      is JavadocJar.None -> null
+      is JavadocJar.Empty -> project.emptyJavadocJar()
+      is JavadocJar.Javadoc -> project.plainJavadocJar(android)
       is JavadocJar.Dokka -> project.dokkaJavadocJar(javadocJar)
     }
   }

--- a/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -32,7 +32,7 @@ sealed class Platform {
  * }
  ```
  */
-data class JavaLibrary(
+data class JavaLibrary @JvmOverloads constructor(
   override val javadocJar: JavadocJar,
   override val sourcesJar: Boolean = true
 ) : Platform()
@@ -50,7 +50,7 @@ data class JavaLibrary(
  * }
 ```
  */
-data class GradlePlugin(
+data class GradlePlugin @JvmOverloads constructor(
   override val javadocJar: JavadocJar,
   override val sourcesJar: Boolean = true
 ) : Platform()
@@ -74,7 +74,7 @@ data class GradlePlugin(
  * ```
  * This does not include javadoc and sources jars because there are no APIs for that available.
  */
-data class AndroidLibrary(
+data class AndroidLibrary @JvmOverloads constructor(
   override val javadocJar: JavadocJar,
   override val sourcesJar: Boolean = true,
   val variant: String = "release"
@@ -89,7 +89,7 @@ data class AndroidLibrary(
  * `n/a`
  * This does not include javadoc jars because there are no APIs for that available.
  */
-data class KotlinMultiplatform(
+data class KotlinMultiplatform @JvmOverloads constructor(
   override val javadocJar: JavadocJar = JavadocJar.Empty
 ) : Platform() {
   // Automatically added by Kotlin MPP plugin.
@@ -112,7 +112,7 @@ data class KotlinMultiplatform(
  * ```
  * This does not include javadoc jars because there are no APIs for that available.
   */
-data class KotlinJvm(
+data class KotlinJvm @JvmOverloads constructor(
   override val javadocJar: JavadocJar = JavadocJar.Empty,
   override val sourcesJar: Boolean = true
 ) : Platform()
@@ -133,7 +133,8 @@ data class KotlinJvm(
  * ```
  * This does not include javadoc jars because there are no APIs for that available.
  */
-data class KotlinJs(
+
+data class KotlinJs @JvmOverloads constructor(
   override val javadocJar: JavadocJar = JavadocJar.Empty,
   override val sourcesJar: Boolean = true
 ) : Platform()

--- a/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -90,7 +90,7 @@ data class AndroidLibrary @JvmOverloads constructor(
  * This does not include javadoc jars because there are no APIs for that available.
  */
 data class KotlinMultiplatform @JvmOverloads constructor(
-  override val javadocJar: JavadocJar = JavadocJar.Empty
+  override val javadocJar: JavadocJar = JavadocJar.Empty()
 ) : Platform() {
   // Automatically added by Kotlin MPP plugin.
   override val sourcesJar = false
@@ -113,7 +113,7 @@ data class KotlinMultiplatform @JvmOverloads constructor(
  * This does not include javadoc jars because there are no APIs for that available.
   */
 data class KotlinJvm @JvmOverloads constructor(
-  override val javadocJar: JavadocJar = JavadocJar.Empty,
+  override val javadocJar: JavadocJar = JavadocJar.Empty(),
   override val sourcesJar: Boolean = true
 ) : Platform()
 
@@ -135,7 +135,7 @@ data class KotlinJvm @JvmOverloads constructor(
  */
 
 data class KotlinJs @JvmOverloads constructor(
-  override val javadocJar: JavadocJar = JavadocJar.Empty,
+  override val javadocJar: JavadocJar = JavadocJar.Empty(),
   override val sourcesJar: Boolean = true
 ) : Platform()
 
@@ -146,17 +146,26 @@ sealed class JavadocJar {
   /**
    * Do not create a javadoc jar. This option is not compatible with Maven Central.
    */
-  object None : JavadocJar()
+  class None : JavadocJar() {
+    override fun equals(other: Any?): Boolean = other is None
+    override fun hashCode(): Int = this::class.hashCode()
+  }
 
   /**
    * Creates an empty javadoc jar to satisfy maven central requirements.
    */
-  object Empty : JavadocJar()
+  class Empty : JavadocJar() {
+    override fun equals(other: Any?): Boolean = other is Empty
+    override fun hashCode(): Int = this::class.hashCode()
+  }
 
   /**
    * Creates a regular javadoc jar using Gradle's default `javadoc` task.
    */
-  object Javadoc : JavadocJar()
+  class Javadoc : JavadocJar() {
+    override fun equals(other: Any?): Boolean = other is Javadoc
+    override fun hashCode(): Int = this::class.hashCode()
+  }
 
   /**
    * Creates a javadoc jar using Dokka's output. The argument is the name of the dokka task that should be used

--- a/src/main/kotlin/com/vanniktech/maven/publish/legacy/BaseSetup.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/legacy/BaseSetup.kt
@@ -95,11 +95,11 @@ internal fun Project.configurePlatform() {
 
     when {
       plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") ->
-        baseExtension.configure(KotlinMultiplatform(defaultJavaDocOption() ?: JavadocJar.Empty))
+        baseExtension.configure(KotlinMultiplatform(defaultJavaDocOption() ?: JavadocJar.Empty()))
       plugins.hasPlugin("org.jetbrains.kotlin.jvm") ->
         baseExtension.configure(KotlinJvm(defaultJavaDocOption() ?: javadoc()))
       plugins.hasPlugin("org.jetbrains.kotlin.js") ->
-        baseExtension.configure(KotlinJs(defaultJavaDocOption() ?: JavadocJar.Empty))
+        baseExtension.configure(KotlinJs(defaultJavaDocOption() ?: JavadocJar.Empty()))
       plugins.hasPlugin("java-gradle-plugin") ->
         baseExtension.configure(GradlePlugin(defaultJavaDocOption() ?: javadoc()))
       plugins.hasPlugin("com.android.library") -> {
@@ -133,7 +133,7 @@ private fun Project.javadoc(): JavadocJar {
       options.addStringOption("Xdoclint:none", "-quiet")
     }
   }
-  return JavadocJar.Javadoc
+  return JavadocJar.Javadoc()
 }
 
 private fun Project.findDokkaTask(): String {


### PR DESCRIPTION
- adds @JvmOverloads to all methods with optional parameters
- change the `JavadocJar` object instances into classes, this will make usage from Groovy more consistent by all requiring a new to instantiate and never needing `.INSTANCE`
- not actually Groovy related: allow to call `signAllPublications` more than once, I thought this would actually work automatically but Gradle fails internally if we do