### PR TITLE
make stagingProfile optional

### DIFF
--- a/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusOptions.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusOptions.kt
@@ -1,6 +1,7 @@
 package com.vanniktech.maven.publish.nexus
 
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 
 open class NexusOptions {
   /**
@@ -17,6 +18,7 @@ open class NexusOptions {
    * @since 0.9.0
    */
   @Input
+  @Optional
   var stagingProfile: String? = null
 
   /**


### PR DESCRIPTION
We do support it being not set and don't set it on our own, so Gradle complains that it's not marked as optional. closes #234