### PR TITLE
update dependencies

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Upload release
         run: ./gradlew uploadArchives --no-daemon --no-parallel
         env:
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          ORG_GRADLE_PROJECT_SIGNING_PRIVATE_KEY: ${{ secrets.SIGNING_PRIVATE_KEY }}
-          ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryPassword: ${{ secrets.SIGNING_PASSWORD }}
 
       - name: Publish release
         run: ./gradlew closeAndReleaseRepository --no-daemon --no-parallel
         env:
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -27,5 +27,5 @@ jobs:
         run: ./gradlew uploadArchives --no-daemon --no-parallel
         if: endsWith(env.VERSION_NAME, '-SNAPSHOT')
         env:
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
-  ext.kotlinVersion = '1.4.30'
-  ext.junitVersion = '4.13'
-  ext.assertjVersion = '3.15.0'
+  ext.kotlinVersion = '1.4.32'
+  ext.junitVersion = '4.13.2'
+  ext.assertjVersion = '3.19.0'
   ext.agpVersion = '3.6.0'
   ext.dokkaVersion = '0.9.18'
-  ext.retrofitVersion = '2.7.1'
-  ext.moshiVersion = '1.11.0'
+  ext.retrofitVersion = '2.9.0'
+  ext.moshiVersion = '1.12.0'
 
   repositories {
     mavenCentral()
@@ -15,11 +15,9 @@ buildscript {
 
   dependencies {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-    classpath 'com.gradle.publish:plugin-publish-plugin:0.11.0'
-    classpath 'com.github.ben-manes:gradle-versions-plugin:0.27.0'
-    classpath 'com.vanniktech:gradle-code-quality-tools-plugin:0.19.0'
-    classpath 'com.vanniktech:gradle-android-junit-jacoco-plugin:0.15.0'
-    classpath 'com.vanniktech:gradle-maven-publish-plugin:0.12.0'
+    classpath 'com.github.ben-manes:gradle-versions-plugin:0.38.0'
+    classpath 'com.vanniktech:gradle-code-quality-tools-plugin:0.20.0'
+    classpath 'com.vanniktech:gradle-maven-publish-plugin:0.15.1'
   }
 }
 
@@ -29,17 +27,15 @@ apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'com.vanniktech.code.quality.tools'
-apply plugin: 'com.vanniktech.android.junit.jacoco'
 apply plugin: "com.vanniktech.maven.publish"
-apply plugin: 'com.gradle.plugin-publish'
 apply from: "gradle/integration-test.gradle"
 
 codeQualityTools {
   ktlint {
-    toolVersion = '0.31.0'
+    toolVersion = '0.40.0'
   }
   detekt {
-    toolVersion = '1.0.0'
+    toolVersion = '1.16.0'
   }
   pmd {
     enabled = false
@@ -105,28 +101,9 @@ dependencies {
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 
-signing {
-  if (project.hasProperty('SIGNING_PRIVATE_KEY') && project.hasProperty('SIGNING_PASSWORD')) {
-    useInMemoryPgpKeys(project.getProperty('SIGNING_PRIVATE_KEY'), project.getProperty('SIGNING_PASSWORD'))
-  }
-}
-
-pluginBundle {
-  website = POM_URL
-  vcsUrl = POM_SCM_URL
-
-  plugins {
-    mavenPublishPlugin {
-      displayName = POM_NAME
-      tags = ['gradle', 'android', 'kotlin', 'maven', 'publish', 'library']
-      description = POM_DESCRIPTION
-    }
-  }
-}
-
 wrapper {
-  gradleVersion = '5.4.1'
-  distributionType = Wrapper.DistributionType.ALL
+  gradleVersion = '7.0'
+  distributionType = Wrapper.DistributionType.BIN
 }
 
 configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
   dependencies {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.38.0'
-    classpath 'com.vanniktech:gradle-code-quality-tools-plugin:0.20.0'
+    classpath 'com.vanniktech:gradle-code-quality-tools-plugin:0.19.0'
     classpath 'com.vanniktech:gradle-maven-publish-plugin:0.15.1'
   }
 }
@@ -32,7 +32,7 @@ apply from: "gradle/integration-test.gradle"
 
 codeQualityTools {
   ktlint {
-    toolVersion = '0.40.0'
+    toolVersion = '0.31.0'
   }
   detekt {
     toolVersion = '1.16.0'
@@ -102,7 +102,7 @@ dependencies {
 sourceCompatibility = JavaVersion.VERSION_1_7
 
 wrapper {
-  gradleVersion = '7.0'
+  gradleVersion = '6.8.3'
   distributionType = Wrapper.DistributionType.BIN
 }
 

--- a/code_quality_tools/detekt.yml
+++ b/code_quality_tools/detekt.yml
@@ -1,5 +1,3 @@
-failFast: true
-
 potential-bugs:
   UnsafeCast:
     active: false # We know what we're doing.
@@ -7,8 +5,6 @@ potential-bugs:
     active: false # We know what we're doing.
 
 style:
-  TopLevelPropertyNaming:
-    active: false
   MaxLineLength:
     active: false
   DataClassShouldBeImmutable:
@@ -40,4 +36,6 @@ comments:
   UndocumentedPublicFunction:
     active: false
   CommentOverPrivateFunction:
+    active: false
+  UndocumentedPublicProperty:
     active: false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -11,17 +11,6 @@ import java.io.File
 import java.util.zip.ZipFile
 
 class MavenPublishPluginIntegrationTest {
-  companion object {
-    const val FIXTURES = "src/integrationTest/fixtures"
-    const val EXPECTED_DIR = "expected"
-
-    const val TEST_GROUP = "com.example"
-    const val TEST_VERSION_NAME = "1.0.0"
-    const val TEST_POM_ARTIFACT_ID = "test-artifact"
-
-    const val TEST_TASK = "publishAllPublicationsToTestFolderRepository"
-  }
-
   @get:Rule val testProjectDir: TemporaryFolder = TemporaryFolder()
 
   private lateinit var repoFolder: File
@@ -363,4 +352,15 @@ class MavenPublishPluginIntegrationTest {
       .withPluginClasspath()
     .forwardOutput()
       .build()
+
+  companion object {
+    const val FIXTURES = "src/integrationTest/fixtures"
+    const val EXPECTED_DIR = "expected"
+
+    const val TEST_GROUP = "com.example"
+    const val TEST_VERSION_NAME = "1.0.0"
+    const val TEST_POM_ARTIFACT_ID = "test-artifact"
+
+    const val TEST_TASK = "publishAllPublicationsToTestFolderRepository"
+  }
 }

--- a/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -347,11 +347,11 @@ class MavenPublishPluginIntegrationTest {
   }
 
   private fun executeGradleCommands(vararg commands: String) = GradleRunner.create()
-      .withProjectDir(projectFolder)
-      .withArguments(*commands, "-Ptest.releaseRepository=$repoFolder")
-      .withPluginClasspath()
+    .withProjectDir(projectFolder)
+    .withArguments(*commands, "-Ptest.releaseRepository=$repoFolder")
+    .withPluginClasspath()
     .forwardOutput()
-      .build()
+    .build()
 
   companion object {
     const val FIXTURES = "src/integrationTest/fixtures"

--- a/src/main/kotlin/com/vanniktech/maven/publish/legacy/BaseSetup.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/legacy/BaseSetup.kt
@@ -96,6 +96,7 @@ internal fun Project.configurePom() {
   }
 }
 
+@Suppress("ComplexMethod")
 internal fun Project.configurePlatform() {
   afterEvaluate {
 


### PR DESCRIPTION
Updated most dependencies and removed some obsolete plugins. I've kept dokka where it is because it runs out of memory on CI often when using newer versions. AGP is kept on an older release because that's the minimum we need.