### PR TITLE
provide an option to not publish the default repository

### DIFF
--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
@@ -21,7 +21,7 @@ abstract class MavenPublishPluginExtension(
    *
    * @Since 0.15.0
    */
-  var sonatypeHost: SonatypeHost = SonatypeHost.DEFAULT
+  var sonatypeHost: SonatypeHost? = SonatypeHost.DEFAULT
 
   /**
    * The Android library variant that should be published. Projects not using any product flavors, that just want

--- a/src/main/kotlin/com/vanniktech/maven/publish/legacy/BaseSetup.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/legacy/BaseSetup.kt
@@ -19,7 +19,7 @@ import org.jetbrains.dokka.gradle.DokkaTask
 
 internal fun Project.configureMavenCentral() {
   afterEvaluate {
-    baseExtension.publishToMavenCentral(legacyExtension.sonatypeHost)
+    legacyExtension.sonatypeHost?.let { baseExtension.publishToMavenCentral(it) }
   }
 }
 


### PR DESCRIPTION
the plugin add a default maven repository even I add the repository according to the doc:

You can add additional repositories to publish to using the standard Gradle APIs:

```groovy
publishing {
    repositories {
        maven {
            def releasesRepoUrl = "$buildDir/repos/releases"
            def snapshotsRepoUrl = "$buildDir/repos/snapshots"
            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
        }
    }
}
```

In company, the library may never publish to public repository. if I execute `publish` task, it  will publish the default maven repository too.