### PR TITLE
Gate automatic maven central enablement behind a property

### DIFF
--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -20,9 +20,15 @@ open class MavenPublishPlugin : Plugin<Project> {
     p.setCoordinates()
     p.configurePom()
     p.checkProperties()
-    p.configureMavenCentral()
+
+    val enableCentral = p.findOptionalProperty("mavenPublish.automaticallyConfigureMavenCentral")
+      ?.toBoolean()
+      ?: true
+    if (enableCentral) {
+      p.configureMavenCentral()
+    }
     p.configureSigning()
-    p.configureArchivesTasks()
+    p.configureArchivesTasks(enableCentral)
     p.configurePlatform()
   }
 }

--- a/src/main/kotlin/com/vanniktech/maven/publish/legacy/Tasks.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/legacy/Tasks.kt
@@ -2,13 +2,15 @@ package com.vanniktech.maven.publish.legacy
 
 import org.gradle.api.Project
 
-internal fun Project.configureArchivesTasks() {
-  tasks.register("uploadArchives") { task ->
-    val publishTaskName = "publishAllPublicationsToMavenCentralRepository"
-    task.dependsOn(tasks.named(publishTaskName))
+internal fun Project.configureArchivesTasks(enableCentral: Boolean) {
+  if (enableCentral) {
+    tasks.register("uploadArchives") { task ->
+      val publishTaskName = "publishAllPublicationsToMavenCentralRepository"
+      task.dependsOn(tasks.named(publishTaskName))
 
-    task.doLast {
-      logger.warn("The task ${task.name} is deprecated use publish or $publishTaskName instead.")
+      task.doLast {
+        logger.warn("The task ${task.name} is deprecated use publish or $publishTaskName instead.")
+      }
     }
   }
   tasks.register("installArchives") { task ->

--- a/src/test/kotlin/com/vanniktech/maven/publish/MavenPublishPluginTest.kt
+++ b/src/test/kotlin/com/vanniktech/maven/publish/MavenPublishPluginTest.kt
@@ -90,6 +90,8 @@ class MavenPublishPluginTest {
     if (centralEnabled) {
       assertThat(uploadArchives).isNotNull()
     } else {
+      assertThat(project.tasks.findByName("publishAllPublicationsToMavenCentralRepository"))
+        .isNull()
       assertThat(uploadArchives).isNull()
     }
 

--- a/src/test/kotlin/com/vanniktech/maven/publish/MavenPublishPluginTest.kt
+++ b/src/test/kotlin/com/vanniktech/maven/publish/MavenPublishPluginTest.kt
@@ -60,6 +60,12 @@ class MavenPublishPluginTest {
     assert(project)
   }
 
+  @Test fun disableAutomaticCentralConfiguration() {
+    project.extensions.extraProperties.set("mavenPublish.automaticallyConfigureMavenCentral", "false")
+    project.plugins.apply("kotlin")
+    assert(project, false)
+  }
+
   private fun prepareAndroidLibraryProject(project: Project) {
     val extension = project.extensions.getByType(LibraryExtension::class.java)
     extension.compileSdkVersion(27)
@@ -70,7 +76,7 @@ class MavenPublishPluginTest {
   }
 
   // This does not assert anything but it's a good start.
-  private fun assert(project: Project) {
+  private fun assert(project: Project, centralEnabled: Boolean = true) {
     project.plugins.apply(MavenPublishPlugin::class.java)
 
     (project as DefaultProject).evaluate()
@@ -81,7 +87,11 @@ class MavenPublishPluginTest {
     assertThat(project.version).isNotNull()
 
     val uploadArchives = project.tasks.findByName("uploadArchives")
-    assertThat(uploadArchives).isNotNull()
+    if (centralEnabled) {
+      assertThat(uploadArchives).isNotNull()
+    } else {
+      assertThat(uploadArchives).isNull()
+    }
 
     val installArchives = project.tasks.findByName("installArchives")
     assertThat(installArchives).isNotNull()


### PR DESCRIPTION
This allows projects not using central to disable this behavior as needed. This gates it behind a boolean `mavenPublish.automaticallyConfigureMavenCentral` property