### PR TITLE
Fix key password property name in documentation and publication action

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -25,7 +25,7 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_PRIVATE_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
 
       - name: Publish release
         run: ./gradlew closeAndReleaseRepository --no-daemon --no-parallel

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ signingInMemoryKey=exported_ascii_armored_key
 # Optional.
 signingInMemoryKeyId=24875D73
 # If key was created with a password.
-signingInMemoryPassword=secret
+signingInMemoryKeyPassword=secret
 ```
 
 These properties can also be provided as environment variables by prefixing them with `ORG_GRADLE_PROJECT_`

--- a/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -91,7 +91,7 @@ abstract class MavenPublishBaseExtension(
    * # optional
    * signingInMemoryKeyId=24875D73
    * # if key was created with a password
-   * signingInMemoryPassword=secret
+   * signingInMemoryKeyPassword=secret
    * ```
    * `gpg2 --export-secret-keys --armor KEY_ID` can be used to export they key for this. The exported key is taken
    * without the first line and without the last 2 lines, all line breaks should be removed as well. The in memory


### PR DESCRIPTION
According to [`MavenPublishBaseExtension.kt#L121`](https://github.com/vanniktech/gradle-maven-publish-plugin/blame/4b3df71b859bf5260d90542a12c991ed31d42af2/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt#L121), the Gradle property name for the in-memory signing key password is `signingInMemoryKeyPassword` (note the **Key** before "Password") whereas the documentation listed it without `Key` (i.e. as `signingInMemoryPassword`).

This documentation typo may also have been the source of confusion in #248?

I believe the `publish-release` GitHub Action is also using the wrong property name (and I suspect it would've failed on your next publication attempt?).