### PR TITLE
add property for SonatypeHost, move base calls directly to plugin

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -1,26 +1,40 @@
 package com.vanniktech.maven.publish
 
 import com.vanniktech.maven.publish.legacy.checkProperties
-import com.vanniktech.maven.publish.legacy.configureMavenCentral
 import com.vanniktech.maven.publish.legacy.configurePlatform
-import com.vanniktech.maven.publish.legacy.configurePom
-import com.vanniktech.maven.publish.legacy.configureSigning
 import com.vanniktech.maven.publish.legacy.setCoordinates
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.plugins.signing.SigningPlugin
 
 open class MavenPublishPlugin : Plugin<Project> {
 
-  override fun apply(p: Project) {
-    p.plugins.apply(MavenPublishBasePlugin::class.java)
+  override fun apply(project: Project) {
+    project.plugins.apply(MavenPublishBasePlugin::class.java)
+    val baseExtension = project.baseExtension
 
-    p.extensions.create("mavenPublish", MavenPublishPluginExtension::class.java, p)
+    // Apply signing immediately. It is also applied by `signAllPublications` but the afterEvaluate means
+    // that it's APIs are not available for consumers without also using afterEvaluate.
+    project.plugins.apply(SigningPlugin::class.java)
 
-    p.setCoordinates()
-    p.configurePom()
-    p.checkProperties()
-    p.configureMavenCentral()
-    p.configureSigning()
-    p.configurePlatform()
+    val extension = project.extensions.create("mavenPublish", MavenPublishPluginExtension::class.java, project)
+
+    project.setCoordinates()
+    project.checkProperties()
+
+    project.afterEvaluate {
+      val sonatypeHost = extension.sonatypeHost
+      if (sonatypeHost != null) {
+        baseExtension.publishToMavenCentral(sonatypeHost)
+      }
+
+      if (extension.releaseSigningEnabled) {
+        baseExtension.signAllPublications()
+      }
+
+      baseExtension.pomFromGradleProperties()
+
+      project.configurePlatform()
+    }
   }
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
@@ -18,7 +18,7 @@ abstract class MavenPublishPluginExtension(
    *
    * @Since 0.15.0
    */
-  var sonatypeHost: SonatypeHost? = SonatypeHost.DEFAULT
+  var sonatypeHost: SonatypeHost? = defaultSonatypeHost()
 
   /**
    * The Android library variant that should be published. Projects not using any product flavors, that just want
@@ -36,4 +36,17 @@ abstract class MavenPublishPluginExtension(
    * @Since 0.9.0
    */
   var releaseSigningEnabled: Boolean = project.findOptionalProperty("RELEASE_SIGNING_ENABLED")?.toBoolean() ?: true
+
+  private fun defaultSonatypeHost(): SonatypeHost? {
+    val property = project.findOptionalProperty("SONATYPE_HOST")
+    if (property != null) {
+      return if (property.isBlank()) {
+        null
+      } else {
+        SonatypeHost.valueOf(property)
+      }
+    }
+
+    return SonatypeHost.DEFAULT
+  }
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/legacy/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/legacy/Platform.kt
@@ -14,52 +14,27 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.external.javadoc.StandardJavadocDocletOptions
-import org.gradle.plugins.signing.SigningPlugin
 import org.jetbrains.dokka.gradle.DokkaTask
 
-internal fun Project.configureMavenCentral() {
-  afterEvaluate {
-    legacyExtension.sonatypeHost?.let { baseExtension.publishToMavenCentral(it) }
-  }
-}
-
-internal fun Project.configureSigning() {
-  // Apply signing immediately. It is also applied by `signAllPublications` but the afterEvaluate means
-  // that it's APIs are not available for consumers without also using afterEvaluate.
-  plugins.apply(SigningPlugin::class.java)
-
-  afterEvaluate {
-    if (legacyExtension.releaseSigningEnabled) {
-      baseExtension.signAllPublications()
-    }
-  }
-}
-
-internal fun Project.configurePom() {
-  baseExtension.pomFromGradleProperties()
-}
-
 internal fun Project.configurePlatform() {
-  afterEvaluate {
-    when {
-      plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") ->
-        baseExtension.configure(KotlinMultiplatform(defaultJavaDocOption() ?: JavadocJar.Empty()))
-      plugins.hasPlugin("org.jetbrains.kotlin.jvm") ->
-        baseExtension.configure(KotlinJvm(defaultJavaDocOption() ?: javadoc()))
-      plugins.hasPlugin("org.jetbrains.kotlin.js") ->
-        baseExtension.configure(KotlinJs(defaultJavaDocOption() ?: JavadocJar.Empty()))
-      plugins.hasPlugin("java-gradle-plugin") ->
-        baseExtension.configure(GradlePlugin(defaultJavaDocOption() ?: javadoc()))
-      plugins.hasPlugin("com.android.library") -> {
-        val variant = legacyExtension.androidVariantToPublish
-        baseExtension.configure(AndroidLibrary(defaultJavaDocOption() ?: javadoc(), variant = variant))
-      }
-      plugins.hasPlugin("java-library") ->
-        baseExtension.configure(JavaLibrary(defaultJavaDocOption() ?: javadoc()))
-      plugins.hasPlugin("java") ->
-        baseExtension.configure(JavaLibrary(defaultJavaDocOption() ?: javadoc()))
-      else -> logger.warn("No compatible plugin found in project $name for publishing")
+  when {
+    plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") ->
+      baseExtension.configure(KotlinMultiplatform(defaultJavaDocOption() ?: JavadocJar.Empty()))
+    plugins.hasPlugin("org.jetbrains.kotlin.jvm") ->
+      baseExtension.configure(KotlinJvm(defaultJavaDocOption() ?: javadoc()))
+    plugins.hasPlugin("org.jetbrains.kotlin.js") ->
+      baseExtension.configure(KotlinJs(defaultJavaDocOption() ?: JavadocJar.Empty()))
+    plugins.hasPlugin("java-gradle-plugin") ->
+      baseExtension.configure(GradlePlugin(defaultJavaDocOption() ?: javadoc()))
+    plugins.hasPlugin("com.android.library") -> {
+      val variant = legacyExtension.androidVariantToPublish
+      baseExtension.configure(AndroidLibrary(defaultJavaDocOption() ?: javadoc(), variant = variant))
     }
+    plugins.hasPlugin("java-library") ->
+      baseExtension.configure(JavaLibrary(defaultJavaDocOption() ?: javadoc()))
+    plugins.hasPlugin("java") ->
+      baseExtension.configure(JavaLibrary(defaultJavaDocOption() ?: javadoc()))
+    else -> logger.warn("No compatible plugin found in project $name for publishing")
   }
 }
 


### PR DESCRIPTION
This adds a way to set `SONATYPE_HOST` as a Gradle property for consistency. 

I've also moved some of the logic of the main plugin back into that class, when it's just about calling the base extension properly. So the legacy package only contains actual legacy code.