### PR TITLE
update Dokka

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -2,8 +2,7 @@ object Version {
   const val junit = "4.13.2"
   const val assertj = "3.19.0"
   const val agp = "3.6.0"
-  const val dokka = "0.9.18"
+  const val dokka = "1.4.32"
   const val retrofit = "2.9.0"
   const val moshi = "1.12.0"
 }
-

--- a/buildSrc/src/main/kotlin/shared.gradle.kts
+++ b/buildSrc/src/main/kotlin/shared.gradle.kts
@@ -17,7 +17,8 @@ repositories {
 }
 
 
-java.sourceCompatibility = JavaVersion.VERSION_1_7
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+java.targetCompatibility = JavaVersion.VERSION_1_8
 
 // Use the kotlin version from the stdlib
 val kotlinVersion = KotlinVersion.CURRENT.toString()
@@ -29,4 +30,3 @@ configurations.all {
     force("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
   }
 }
-

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -21,7 +21,6 @@ dependencies {
   api(kotlin("stdlib"))
 
   compileOnly("org.jetbrains.dokka:dokka-gradle-plugin:${Version.dokka}")
-  compileOnly("org.jetbrains.dokka:dokka-android-gradle-plugin:${Version.dokka}")
   compileOnly(kotlin("gradle-plugin"))
   compileOnly("com.android.tools.build:gradle:${Version.agp}")
 
@@ -39,7 +38,6 @@ dependencies {
   testImplementation("com.android.tools.build:gradle:${Version.agp}")
   testImplementation(kotlin("gradle-plugin"))
   testImplementation("org.jetbrains.dokka:dokka-gradle-plugin:${Version.dokka}")
-  testImplementation("org.jetbrains.dokka:dokka-android-gradle-plugin:${Version.dokka}")
 }
 
 tasks.withType(PluginUnderTestMetadata::class.java).configureEach {

--- a/plugin/src/integrationTest/fixtures/common/gradle.properties
+++ b/plugin/src/integrationTest/fixtures/common/gradle.properties
@@ -24,3 +24,5 @@ POM_DEVELOPER_URL=https://github.com/vanniktech/
 signing.keyId=B89C4055
 signing.password=test
 signing.secretKeyRingFile=test-secring.gpg
+
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m

--- a/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_dokka_project/build.gradle
+++ b/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_dokka_project/build.gradle
@@ -32,28 +32,4 @@ kotlin {
     }
 }
 
-dokka {
-    kotlinTasks {
-        // dokka fails to retrieve sources from MPP-tasks so they must be set empty to avoid exception
-        // use sourceRoot instead (see below)
-        []
-    }
-    sourceRoot {
-        path = kotlin.sourceSets.commonMain.kotlin.srcDirs[0]
-        platforms = ["Common"]
-    }
-    if (kotlin.sourceSets.getNames().contains("jvmMain")) {
-        sourceRoot {
-            path = kotlin.sourceSets.jvmMain.kotlin.srcDirs[0]
-            platforms = ["JVM"]
-        }
-    }
-    if (kotlin.sourceSets.getNames().contains("jsMain")) {
-        sourceRoot {
-            path = kotlin.sourceSets.jsMain.kotlin.srcDirs[0]
-            platforms = ["js"]
-        }
-    }
-}
-
 apply from: "maven-publish.gradle"

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -276,9 +276,9 @@ class MavenPublishPluginIntegrationTest {
   private fun assertExpectedTasksRanSuccessfully(result: BuildResult, hasDokka: Boolean = false) {
     assertThat(result.task(":$TEST_TASK")?.outcome).isEqualTo(SUCCESS)
     if (hasDokka) {
-      assertThat(result.task(":dokka")?.outcome).isEqualTo(SUCCESS)
+      assertThat(result.task(":dokkaHtml")?.outcome).isEqualTo(SUCCESS)
     } else {
-      assertThat(result.task(":dokka")).isNull()
+      assertThat(result.task(":dokkaHtml")).isNull()
     }
   }
 


### PR DESCRIPTION
Updating Dokka is needed for updating to Gradle 7. Also needed to update the source/target compatibility to java 8 and increase the metaspace memory for ci