### PR TITLE
remove workaround for pre Kotlin 1.4.30 MPP projects

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -142,14 +142,6 @@ data class KotlinMultiplatform @JvmOverloads constructor(
 
     project.gradlePublishing.publications.withType(MavenPublication::class.java).all {
       it.withJavadocJar { javadocJarTask }
-
-      // On Kotlin versions before 1.4.30 sources jars are only created for platforms, not the common artifact.
-      if (it.name == "kotlinMultiplatform") {
-        val sourceArtifact = it.artifacts.find { artifact -> artifact.classifier == "sources" }
-        if (sourceArtifact == null) {
-          it.withSourcesJar { project.emptySourcesJar() }
-        }
-      }
     }
   }
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -2,7 +2,6 @@ package com.vanniktech.maven.publish
 
 import com.vanniktech.maven.publish.tasks.JavadocJar.Companion.javadocJarTask
 import com.vanniktech.maven.publish.tasks.SourcesJar.Companion.androidSourcesJar
-import com.vanniktech.maven.publish.tasks.SourcesJar.Companion.emptySourcesJar
 import com.vanniktech.maven.publish.tasks.SourcesJar.Companion.javaSourcesJar
 import com.vanniktech.maven.publish.tasks.SourcesJar.Companion.kotlinSourcesJar
 import org.gradle.api.Project


### PR DESCRIPTION
closes #301 

I've tried it out on wire with a locally published version of the plugin and the issue is gone so the issue was caused by a timing issue that only happens with the base plugin. Kotlin 1.4.30 is quite old so I think it's fine to make that the minimum supported Kotlin version.