### PR TITLE
Fixing variable names in base plugin configuration in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ import com.vanniktech.maven.publish.SonatypeHost
 
 allprojects {
     plugins.withId("com.vanniktech.maven.publish.base") {
-        GROUP = "com.example.project"
-        VERSION = "1.0.3-SNAPSHOT"
+        group = "com.example.project"
+        version = "1.0.3-SNAPSHOT"
 
         mavenPublishing {
             publishToMavenCentral("DEFAULT")


### PR DESCRIPTION
"GROUP" variable name is now fixed to be "group", and "VERSION" variable name is now fixed to be "version", both in documentation.