### PR TITLE
deprecate old mavenPublish extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ uses Gradle properties. It's generally recommended to set them in your `gradle.p
 file.
 
 ```properties
+SONATYPE_HOST=DEFAULT
+RELEASE_SIGNING_ENABLED=true
+
 GROUP=com.test.mylibrary
 POM_ARTIFACT_ID=mylibrary-runtime
 VERSION_NAME=3.0.5
@@ -67,22 +70,19 @@ Without any further configuration the plugin has two tasks. `publish` which will
 to Maven Central (through Sonatype OSSRH) by default. To publish to the local maven repository on your
 machine (`~/.m2/repository`) there is `publishToMavenLocal`.
 
-In case you are using `s01.oss.sonatype.org` you need to configure that like this:
-```groovy
-allprojects {
-    plugins.withId("com.vanniktech.maven.publish") {
-        mavenPublish {
-            sonatypeHost = "S01"
-        }
-    }
-}
+In case you are using `s01.oss.sonatype.org` you need to change the `SONATYPE_HOST` property like this:
+```properties
+SONATYPE_HOST=S01
 ```
 
 The username and password for Sonatype OSS can be provided as Gradle properties called `mavenCentralUsername`
 and `mavenCentralPassword` to avoid having to commit them. You can also supply them as environment variables
 called `ORG_GRADLE_PROJECT_mavenCentralUsername` and `ORG_GRADLE_PROJECT_mavenCentralPassword`.
 
-To remove the default repository set `sonatypeHost` to `null`.
+To remove the default repository set `SONATYPE_HOST` to an empty string.
+```properties
+SONATYPE_HOST=
+```
 
 You can add additional repositories to publish to using the standard Gradle APIs:
 
@@ -128,16 +128,7 @@ signingInMemoryKeyPassword=secret
 
 These properties can also be provided as environment variables by prefixing them with `ORG_GRADLE_PROJECT_`
 
-It is possible to disable signing of release artifacts directly in your build scripts (takes precedence):
-
-```groovy
-mavenPublish {
-  releaseSigningEnabled = false
-}
-```
-
-Alternatively, you can use a Gradle property which is recommended if you only want to sign certain builds
-or only build on certain machines.
+It is possible to disable signing of release artifacts by adjusting your gradle.properties like this:
 
 ```groovy
 RELEASE_SIGNING_ENABLED=false

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -14,8 +14,8 @@ abstract class MavenPublishBaseExtension(
   private val project: Project
 ) {
 
-  private var mavenCentral: Pair<SonatypeHost, String?>? = null
-  private var signing: Boolean? = null
+  internal var mavenCentral: Pair<SonatypeHost, String?>? = null
+  internal var signing: Boolean? = null
   private var pomFromProperties: Boolean? = null
   private var platform: Platform? = null
 
@@ -33,9 +33,8 @@ abstract class MavenPublishBaseExtension(
    * @param host the instance of Sonatype OSSRH to use
    * @param stagingRepositoryId optional parameter to upload to a specific already created staging repository
    */
-  @Incubating
   @JvmOverloads
-  fun publishToMavenCentral(host: SonatypeHost, stagingRepositoryId: String? = null) {
+  fun publishToMavenCentral(host: SonatypeHost = SonatypeHost.DEFAULT, stagingRepositoryId: String? = null) {
     val mavenCentral = mavenCentral
     if (mavenCentral != null) {
       // Ignore subsequent calls with the same arguments.
@@ -102,7 +101,6 @@ abstract class MavenPublishBaseExtension(
    * can be found in the [Gradle documentation](https://docs.gradle.org/current/userguide/signing_plugin.html)
    */
   // TODO update in memory set up once https://github.com/gradle/gradle/issues/16056 is implemented
-  @Incubating
   fun signAllPublications() {
     if (signing == true) {
       // ignore subsequent calls with the same arguments

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -27,19 +27,23 @@ open class MavenPublishPlugin : Plugin<Project> {
       if (sonatypeHost != null && baseExtension.mavenCentral == null) {
         // only print warning when sonatypeHost was not set through a gradle property, we will continue supporting this
         if (extension.sonatypeHostProperty() == null) {
-          when(sonatypeHost) {
-            SonatypeHost.DEFAULT -> project.logger.warn("The project is currently configured to be published to " +
-              "Maven  Central. To maintain the current behavior, you need to explicitly add SONATYPE_HOST=DEFAULT to " +
-              "your gradle.properties or add the following to your build files:\n" +
-              "mavenPublishing {" +
-              "  publishToMavenCentral()" +
-              "}")
-            SonatypeHost.S01 -> project.logger.warn("Configuring the sonatypeHost through the DSL is deprecated. " +
-              "Remove the old option and then add either SONATYPE_HOST=S01 to your gradle.properties or add the " +
-              "following to your build files:\n" +
-              "mavenPublishing {" +
-              "  publishToMavenCentral(\"S01\")" +
-              "}")
+          when (sonatypeHost) {
+            SonatypeHost.DEFAULT -> project.logger.warn(
+              "The project is currently configured to be published to " +
+                "Maven  Central. To maintain the current behavior, you need to explicitly add SONATYPE_HOST=DEFAULT to " +
+                "your gradle.properties or add the following to your build files:\n" +
+                "mavenPublishing {" +
+                "  publishToMavenCentral()" +
+                "}"
+            )
+            SonatypeHost.S01 -> project.logger.warn(
+              "Configuring the sonatypeHost through the DSL is deprecated. " +
+                "Remove the old option and then add either SONATYPE_HOST=S01 to your gradle.properties or add the " +
+                "following to your build files:\n" +
+                "mavenPublishing {" +
+                "  publishToMavenCentral(\"S01\")" +
+                "}"
+            )
           }
         }
 
@@ -49,12 +53,14 @@ open class MavenPublishPlugin : Plugin<Project> {
       // ignore old extension if new extension was already called
       if (extension.releaseSigningEnabled && baseExtension.signing == null) {
         if (extension.releaseSigningProperty() == null) {
-          project.logger.warn("The project is currently configured to be automatically sign release builds before " +
-            "publishing. To maintain the current behavior you will need to explicitly add " +
-            "RELEASE_SIGNING_ENABLED=true to your gradle.properties or add the following to your build files:\n" +
-            "mavenPublishing {" +
-            "  signAllPublications()" +
-            "}")
+          project.logger.warn(
+            "The project is currently configured to be automatically sign release builds before " +
+              "publishing. To maintain the current behavior you will need to explicitly add " +
+              "RELEASE_SIGNING_ENABLED=true to your gradle.properties or add the following to your build files:\n" +
+              "mavenPublishing {" +
+              "  signAllPublications()" +
+              "}"
+          )
         }
         baseExtension.signAllPublications()
       }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -23,11 +23,39 @@ open class MavenPublishPlugin : Plugin<Project> {
 
     project.afterEvaluate {
       val sonatypeHost = extension.sonatypeHost
-      if (sonatypeHost != null) {
+      // ignore old extension if new extension was already called
+      if (sonatypeHost != null && baseExtension.mavenCentral == null) {
+        // only print warning when sonatypeHost was not set through a gradle property, we will continue supporting this
+        if (extension.sonatypeHostProperty() == null) {
+          when(sonatypeHost) {
+            SonatypeHost.DEFAULT -> project.logger.warn("The project is currently configured to be published to " +
+              "Maven  Central. To maintain the current behavior, you need to explicitly add SONATYPE_HOST=DEFAULT to " +
+              "your gradle.properties or add the following to your build files:\n" +
+              "mavenPublishing {" +
+              "  publishToMavenCentral()" +
+              "}")
+            SonatypeHost.S01 -> project.logger.warn("Configuring the sonatypeHost through the DSL is deprecated. " +
+              "Remove the old option and then add either SONATYPE_HOST=S01 to your gradle.properties or add the " +
+              "following to your build files:\n" +
+              "mavenPublishing {" +
+              "  publishToMavenCentral(\"S01\")" +
+              "}")
+          }
+        }
+
         baseExtension.publishToMavenCentral(sonatypeHost)
       }
 
-      if (extension.releaseSigningEnabled) {
+      // ignore old extension if new extension was already called
+      if (extension.releaseSigningEnabled && baseExtension.signing == null) {
+        if (extension.releaseSigningProperty() == null) {
+          project.logger.warn("The project is currently configured to be automatically sign release builds before " +
+            "publishing. To maintain the current behavior you will need to explicitly add " +
+            "RELEASE_SIGNING_ENABLED=true to your gradle.properties or add the following to your build files:\n" +
+            "mavenPublishing {" +
+            "  signAllPublications()" +
+            "}")
+        }
         baseExtension.signAllPublications()
       }
 

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
@@ -18,6 +18,7 @@ abstract class MavenPublishPluginExtension(
    *
    * @Since 0.15.0
    */
+  @Deprecated("Set the SONATYPE_HOST Gradle property or call mavenPublishing { publishToMavenCentral(\"<VALUE>\") } instead")
   var sonatypeHost: SonatypeHost? = defaultSonatypeHost()
 
   /**
@@ -37,10 +38,19 @@ abstract class MavenPublishPluginExtension(
    *
    * @Since 0.9.0
    */
+  @Deprecated("Set the RELEASE_SIGNING_ENABLED Gradle property or call mavenPublishing { signAllPublications() } instead")
   var releaseSigningEnabled: Boolean = project.findOptionalProperty("RELEASE_SIGNING_ENABLED")?.toBoolean() ?: true
 
+  internal fun sonatypeHostProperty(): String? {
+    return project.findOptionalProperty("SONATYPE_HOST")
+  }
+
+  internal fun releaseSigningProperty(): Boolean? {
+    return project.findOptionalProperty("RELEASE_SIGNING_ENABLED")?.toBoolean()
+  }
+
   private fun defaultSonatypeHost(): SonatypeHost? {
-    val property = project.findOptionalProperty("SONATYPE_HOST")
+    val property = sonatypeHostProperty()
     if (property != null) {
       return if (property.isBlank()) {
         null

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPluginExtension.kt
@@ -39,7 +39,7 @@ abstract class MavenPublishPluginExtension(
    * @Since 0.9.0
    */
   @Deprecated("Set the RELEASE_SIGNING_ENABLED Gradle property or call mavenPublishing { signAllPublications() } instead")
-  var releaseSigningEnabled: Boolean = project.findOptionalProperty("RELEASE_SIGNING_ENABLED")?.toBoolean() ?: true
+  var releaseSigningEnabled: Boolean = releaseSigningProperty() ?: true
 
   internal fun sonatypeHostProperty(): String? {
     return project.findOptionalProperty("SONATYPE_HOST")


### PR DESCRIPTION
This deprecates the old `sonatypeHost` and `releaseSigningEnabled` properties on the DSL. It also prepares for the following release to not add maven central as a default publishing target and not to enable release signing by default anymore.

Everyone currently publishing through maven central or signing releases without explicitly configuring it will get a warning. To get rid of the warning and prepare for the new behavior 
```
SONATYPE_HOST=DEFAULT
RELEASE_SIGNING_ENABLED=true
```
(`SONATYPE_HOST=S01` if s01.sonatype.org is used) needs to be added to the Gradle properties. Alternatively it's possible to use the new extension:
```
mavenPublishing {
    publishToMavenCentral("DEFAULT")
    signAllPublications()
}
```
Those 2 methods are now also not incubating anymore.

I've already updated the README because the properties are already fully supported.
