### PR TITLE
Support more POM properties

### DIFF
--- a/plugin/src/integrationTest/fixtures/full_pom_project/build.gradle
+++ b/plugin/src/integrationTest/fixtures/full_pom_project/build.gradle
@@ -1,0 +1,22 @@
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        google()
+    }
+
+    dependencies {
+        classpath "com.vanniktech:gradle-maven-publish-plugin:${System.getProperty("com.vanniktech.publish.version")}"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
+    }
+}
+
+apply plugin: "java"
+apply plugin: "org.jetbrains.kotlin.jvm"
+apply plugin: "com.vanniktech.maven.publish"
+
+apply from: "maven-publish.gradle"
+
+dependencies {
+    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.10"
+}

--- a/plugin/src/integrationTest/fixtures/full_pom_project/expected/test-artifact-1.0.0.pom
+++ b/plugin/src/integrationTest/fixtures/full_pom_project/expected/test-artifact-1.0.0.pom
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>test-artifact</artifactId>
+  <version>1.0.0</version>
+  <name>Best Dependency</name>
+  <description>This is the best dependency ever.</description>
+  <url>https://github.com/vanniktech/gradle-maven-publish-plugin</url>
+  <inceptionYear>20xx</inceptionYear>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>jaredsburrows</id>
+      <name>Jared Burrows</name>
+      <email>jaredsburrows@gmail.com</email>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:git://github.com/vanniktech/gradle-maven-publish-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/vanniktech/gradle-maven-publish-plugin.git</developerConnection>
+    <url>https://github.com/vanniktech/gradle-maven-publish-plugin</url>
+  </scm>
+  <issueManagement>
+    <system>github</system>
+    <url>https://github.com/vanniktech/gradle-maven-publish-plugin/issues</url>
+  </issueManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>1.6.10</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/plugin/src/integrationTest/fixtures/full_pom_project/gradle.properties
+++ b/plugin/src/integrationTest/fixtures/full_pom_project/gradle.properties
@@ -1,0 +1,28 @@
+GROUP=com.example
+VERSION_NAME=1.0.0
+POM_ARTIFACT_ID=test-artifact
+
+POM_NAME=Best Dependency
+POM_DESCRIPTION=This is the best dependency ever.
+POM_INCEPTION_YEAR=20xx
+POM_PACKAGING=jar
+POM_URL=https://github.com/vanniktech/gradle-maven-publish-plugin
+
+POM_ISSUE_SYSTEM=github
+POM_ISSUE_URL=https://github.com/vanniktech/gradle-maven-publish-plugin/issues
+
+POM_SCM_URL=https://github.com/vanniktech/gradle-maven-publish-plugin
+POM_SCM_CONNECTION=scm:git:git://github.com/vanniktech/gradle-maven-publish-plugin.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/vanniktech/gradle-maven-publish-plugin.git
+
+POM_LICENSE_NAME=The Apache Software License, Version 2.0
+POM_LICENSE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENSE_DIST=repo
+
+POM_DEVELOPER_ID=jaredsburrows
+POM_DEVELOPER_NAME=Jared Burrows
+POM_DEVELOPER_EMAIL=jaredsburrows@gmail.com
+
+signing.keyId=B89C4055
+signing.password=test
+signing.secretKeyRingFile=test-secring.gpg

--- a/plugin/src/integrationTest/fixtures/full_pom_project/src/main/java/com/vanniktech/maven/publish/test/TestClass.java
+++ b/plugin/src/integrationTest/fixtures/full_pom_project/src/main/java/com/vanniktech/maven/publish/test/TestClass.java
@@ -1,0 +1,15 @@
+package com.vanniktech.maven.publish.test;
+
+/**
+ * Just a test class with Javadoc.
+ */
+public final class TestClass {
+  /**
+   * Main method which does something.
+   *
+   * @param args Command-line arguments passed to the program.
+   */
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -282,6 +282,16 @@ class MavenPublishPluginIntegrationTest {
     assertPomContentMatches()
   }
 
+  @Test fun generatesArtifactsAndDocumentationOnFullPomProject() {
+    setupFixture("full_pom_project")
+
+    val result = executeGradleCommands(TEST_TASK, "--stacktrace")
+
+    assertExpectedTasksRanSuccessfully(result)
+    assertExpectedCommonArtifactsGenerated()
+    assertPomContentMatches()
+  }
+
   @Test fun generatesArtifactsAndDocumentationOnOverrideVersionGroupProject() {
     setupFixture("override_version_group_project")
 

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -168,6 +168,15 @@ abstract class MavenPublishBaseExtension(
           pom.inceptionYear.set(inceptionYear)
         }
 
+        val issueManagementSystem = project.findOptionalProperty("POM_ISSUE_SYSTEM")
+        val issueManagementUrl = project.findOptionalProperty("POM_ISSUE_URL")
+        if (issueManagementSystem != null || issueManagementUrl != null) {
+          pom.issueManagement {
+            it.system.set(issueManagementSystem)
+            it.url.set(issueManagementUrl)
+          }
+        }
+
         val scmUrl = project.findOptionalProperty("POM_SCM_URL")
         val scmConnection = project.findOptionalProperty("POM_SCM_CONNECTION")
         val scmDeveloperConnection = project.findOptionalProperty("POM_SCM_DEV_CONNECTION")
@@ -208,12 +217,14 @@ abstract class MavenPublishBaseExtension(
         val developerId = project.findOptionalProperty("POM_DEVELOPER_ID")
         val developerName = project.findOptionalProperty("POM_DEVELOPER_NAME")
         val developerUrl = project.findOptionalProperty("POM_DEVELOPER_URL")
+        val developerEmail = project.findOptionalProperty("POM_DEVELOPER_EMAIL")
         if (developerId != null || developerName != null || developerUrl != null) {
           pom.developers { developers ->
             developers.developer {
               it.id.set(developerId)
               it.name.set(developerName)
               it.url.set(developerUrl)
+              it.email.set(developerEmail)
             }
           }
         }


### PR DESCRIPTION
Closes #344

This adds support for the following:
 - `POM_ISSUE_SYSTEM`
 - `POM_ISSUE_URL`
 - `POM_DEVELOPER_EMAIL`

Reference: https://maven.apache.org/developers/conventions/code.html

@vanniktech For some reason, adding support for for writing the `packaging` does not seem to write the `POM` file, any reason why?

