### PR TITLE
fix legacy Android setup in mpp projects

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/legacy/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/legacy/Platform.kt
@@ -54,7 +54,7 @@ internal fun Project.configureNotAndroidPlatform() {
 
 internal fun Project.configureAndroidPlatform() {
   if (hasWorkingNewAndroidPublishingApi()) {
-    // afterEvaluate is too late but we can't run this synchronously because we shouldn't call the APIs for
+    // afterEvaluate is too late, but we can't run this synchronously because we shouldn't call the APIs for
     // multiplatform projects that use Android
     androidComponents.finalizeDsl {
       if (!plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")) {
@@ -68,9 +68,11 @@ internal fun Project.configureAndroidPlatform() {
     }
   } else {
     afterEvaluate {
-      // release was the old default value before it was changed to null for AGP 7.1+
-      val variant = legacyExtension.androidVariantToPublish ?: "release"
-      baseExtension.configure(AndroidLibrary(defaultJavaDocOption() ?: javadoc(), variant = variant))
+      if (!plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")) {
+        // release was the old default value before it was changed to null for AGP 7.1+
+        val variant = legacyExtension.androidVariantToPublish ?: "release"
+        baseExtension.configure(AndroidLibrary(defaultJavaDocOption() ?: javadoc(), variant = variant))
+      }
     }
   }
 }


### PR DESCRIPTION
This fixes publishing Kotlin Multiplatform projects that apply an Android plugin < 7.1.2. In 0.18.0 and earlier Android publishing was configured in the same when as all other plugins and had lower priority than Kotlin MPP ([see here](https://github.com/vanniktech/gradle-maven-publish-plugin/commit/a91b7655b99ddf3ac8e7f281b0f856fa3b3046bd#diff-f099650db8c1c47f7c5a8a1cbae50bad884723e41109ec858b0f0b9a04e15f8cL29-L32)). The changes for the new Android API moved it out of that when. The code path for the new API had a check to not do anything for multiplatform, but the code path for older AGP versions was missing this which resulted in the Kotlin MPP publication being overridden. This restores the 0.18.0 behavior of not calling the Android APIs in a mpp project.

I will separately look at the issue of MPP + AGP >= 7.1.2 (#333)