### PR TITLE
fix Kotlin MPP project not being configured when Android plugin is present

### DIFF
--- a/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/build.gradle
+++ b/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/build.gradle
@@ -1,0 +1,56 @@
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        google()
+    }
+
+    dependencies {
+        classpath "com.vanniktech:gradle-maven-publish-plugin:${System.getProperty("com.vanniktech.publish.version")}"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
+        classpath "com.android.tools.build:gradle:7.1.2"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.6.10"
+    }
+}
+
+apply plugin: "com.android.library"
+apply plugin: "org.jetbrains.kotlin.multiplatform"
+apply plugin: "org.jetbrains.dokka"
+apply plugin: "com.vanniktech.maven.publish"
+
+android {
+  compileSdkVersion = 31
+  namespace = "com.test"
+}
+
+kotlin {
+    jvm()
+    js("nodeJs") {
+        nodejs()
+    }
+    linuxX64("linux")
+    android {
+      publishLibraryVariants("release", "debug")
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+            }
+        }
+        jvmMain {
+            dependencies {
+            }
+        }
+        nodeJsMain {
+            dependencies {
+            }
+        }
+        linuxMain {
+            dependencies {
+            }
+        }
+    }
+}
+
+apply from: "maven-publish.gradle"

--- a/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/expected/test-artifact-1.0.0.pom
+++ b/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/expected/test-artifact-1.0.0.pom
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>test-artifact</artifactId>
+  <version>1.0.0</version>
+  <name>Gradle Maven Publish Plugin Test Artifact</name>
+  <description>Testing the Gradle Maven Publish Plugin</description>
+  <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>vanniktech</id>
+      <name>Niklas Baudy</name>
+      <url>https://github.com/vanniktech/</url>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:git://github.com/vanniktech/gradle-maven-publish-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/vanniktech/gradle-maven-publish-plugin.git</developerConnection>
+    <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  </scm>
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>1.6.10</version>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/expected/test-artifact-android-1.0.0.pom
+++ b/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/expected/test-artifact-android-1.0.0.pom
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>test-artifact-android</artifactId>
+  <version>1.0.0</version>
+  <packaging>aar</packaging>
+  <name>Gradle Maven Publish Plugin Test Artifact</name>
+  <description>Testing the Gradle Maven Publish Plugin</description>
+  <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>vanniktech</id>
+      <name>Niklas Baudy</name>
+      <url>https://github.com/vanniktech/</url>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:git://github.com/vanniktech/gradle-maven-publish-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/vanniktech/gradle-maven-publish-plugin.git</developerConnection>
+    <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  </scm>
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>1.6.10</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>1.6.10</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/expected/test-artifact-android-debug-1.0.0.pom
+++ b/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/expected/test-artifact-android-debug-1.0.0.pom
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>test-artifact-android-debug</artifactId>
+  <version>1.0.0</version>
+  <packaging>aar</packaging>
+  <name>Gradle Maven Publish Plugin Test Artifact</name>
+  <description>Testing the Gradle Maven Publish Plugin</description>
+  <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>vanniktech</id>
+      <name>Niklas Baudy</name>
+      <url>https://github.com/vanniktech/</url>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:git://github.com/vanniktech/gradle-maven-publish-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/vanniktech/gradle-maven-publish-plugin.git</developerConnection>
+    <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  </scm>
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>1.6.10</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>1.6.10</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/expected/test-artifact-jvm-1.0.0.pom
+++ b/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/expected/test-artifact-jvm-1.0.0.pom
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>test-artifact-jvm</artifactId>
+  <version>1.0.0</version>
+  <name>Gradle Maven Publish Plugin Test Artifact</name>
+  <description>Testing the Gradle Maven Publish Plugin</description>
+  <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>vanniktech</id>
+      <name>Niklas Baudy</name>
+      <url>https://github.com/vanniktech/</url>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:git://github.com/vanniktech/gradle-maven-publish-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/vanniktech/gradle-maven-publish-plugin.git</developerConnection>
+    <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  </scm>
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>1.6.10</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>1.6.10</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/expected/test-artifact-linux-1.0.0.pom
+++ b/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/expected/test-artifact-linux-1.0.0.pom
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>test-artifact-linux</artifactId>
+  <version>1.0.0</version>
+  <packaging>klib</packaging>
+  <name>Gradle Maven Publish Plugin Test Artifact</name>
+  <description>Testing the Gradle Maven Publish Plugin</description>
+  <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>vanniktech</id>
+      <name>Niklas Baudy</name>
+      <url>https://github.com/vanniktech/</url>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:git://github.com/vanniktech/gradle-maven-publish-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/vanniktech/gradle-maven-publish-plugin.git</developerConnection>
+    <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  </scm>
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>1.6.10</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/expected/test-artifact-nodejs-1.0.0.pom
+++ b/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/expected/test-artifact-nodejs-1.0.0.pom
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>test-artifact-nodejs</artifactId>
+  <version>1.0.0</version>
+  <name>Gradle Maven Publish Plugin Test Artifact</name>
+  <description>Testing the Gradle Maven Publish Plugin</description>
+  <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  <inceptionYear>2018</inceptionYear>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>vanniktech</id>
+      <name>Niklas Baudy</name>
+      <url>https://github.com/vanniktech/</url>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:git://github.com/vanniktech/gradle-maven-publish-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/vanniktech/gradle-maven-publish-plugin.git</developerConnection>
+    <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
+  </scm>
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-js</artifactId>
+      <version>1.6.10</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>1.6.10</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/src/androidMain/kotlin/com/vanniktech/maven/publish/test/ExpectedTestClass.kt
+++ b/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/src/androidMain/kotlin/com/vanniktech/maven/publish/test/ExpectedTestClass.kt
@@ -1,0 +1,15 @@
+package com.vanniktech.maven.publish.test
+
+import android.util.Log
+
+/**
+ * Just a Android actual test class with Javadoc.
+ */
+actual class ExpectedTestClass {
+  /**
+   * An actual test funtion that does something.
+   */
+  actual fun test() {
+    Log.i("test", "test")
+  }
+}

--- a/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/src/commonMain/kotlin/com/vanniktech/maven/publish/test/ExpectedTestClass.kt
+++ b/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/src/commonMain/kotlin/com/vanniktech/maven/publish/test/ExpectedTestClass.kt
@@ -1,0 +1,11 @@
+package com.vanniktech.maven.publish.test
+
+/**
+ * Just an expected test class with Javadoc.
+ */
+expect class ExpectedTestClass {
+  /**
+   * An expected test funtion that does something.
+   */
+  fun test()
+}

--- a/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/src/jvmMain/kotlin/com/vanniktech/maven/publish/test/ExpectedTestClass.kt
+++ b/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/src/jvmMain/kotlin/com/vanniktech/maven/publish/test/ExpectedTestClass.kt
@@ -1,0 +1,13 @@
+package com.vanniktech.maven.publish.test
+
+/**
+ * Just a jvm actual test class with Javadoc.
+ */
+actual class ExpectedTestClass {
+  /**
+   * An actual test funtion that does something.
+   */
+  actual fun test() {
+    JavaTestClass.main(arrayOf())
+  }
+}

--- a/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/src/jvmMain/kotlin/com/vanniktech/maven/publish/test/JavaTestClass.java
+++ b/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/src/jvmMain/kotlin/com/vanniktech/maven/publish/test/JavaTestClass.java
@@ -1,0 +1,15 @@
+package com.vanniktech.maven.publish.test;
+
+/**
+ * Just a test class with Javadoc.
+ */
+public class JavaTestClass {
+  /**
+   * Main method which does something.
+   *
+   * @param args Command-line arguments passed to the program.
+   */
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/src/jvmMain/kotlin/com/vanniktech/maven/publish/test/TestClass.kt
+++ b/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/src/jvmMain/kotlin/com/vanniktech/maven/publish/test/TestClass.kt
@@ -1,0 +1,15 @@
+package com.vanniktech.maven.publish.test
+
+/**
+ * Just a test class with Javadoc.
+ */
+object TestClass {
+  /**
+   * Main method which does something.
+   *
+   * @param args Command-line arguments passed to the program.
+   */
+  fun main(args: Array<String?>?) {
+    System.out.println("Hello World!")
+  }
+}

--- a/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/src/linuxMain/kotlin/com/vanniktech/maven/publish/test/ExpectedTestClass.kt
+++ b/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/src/linuxMain/kotlin/com/vanniktech/maven/publish/test/ExpectedTestClass.kt
@@ -1,0 +1,11 @@
+package com.vanniktech.maven.publish.test
+
+/**
+ * Just a linux actual test class with Javadoc.
+ */
+actual class ExpectedTestClass {
+  /**
+   * An actual test funtion that does something.
+   */
+  actual fun test() { }
+}

--- a/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/src/nodeJsMain/kotlin/com/vanniktech/maven/publish/test/ExpectedTestClass.kt
+++ b/plugin/src/integrationTest/fixtures/passing_kotlin_mpp_with_android_dokka_project/src/nodeJsMain/kotlin/com/vanniktech/maven/publish/test/ExpectedTestClass.kt
@@ -1,0 +1,11 @@
+package com.vanniktech.maven.publish.test
+
+/**
+ * Just a nodejs actual test class with Javadoc.
+ */
+actual class ExpectedTestClass {
+  /**
+   * An actual test funtion that does something.
+   */
+  actual fun test() { }
+}

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -258,8 +258,6 @@ class MavenPublishPluginIntegrationTest {
     assertExpectedCommonArtifactsGenerated()
     assertPomContentMatches()
 
-    repoFolder.walkTopDown().forEach { println(it.path) }
-
     val androidArtifactId = "$TEST_POM_ARTIFACT_ID-android"
     assertExpectedCommonArtifactsGenerated(artifactId = androidArtifactId, artifactExtension = "aar")
     // TODO dependency sorting is unstable - the other variants only have 1 and are enough to see that the pom is correct

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -177,7 +177,7 @@ class MavenPublishPluginIntegrationTest {
   @Test fun generatesArtifactsAndDocumentationOnKotlinMppProject() {
     setupFixture("passing_kotlin_mpp_project")
 
-    val result = executeGradleCommands(TEST_TASK, "--stacktrace", "--stacktrace")
+    val result = executeGradleCommands(TEST_TASK, "--stacktrace")
 
     assertExpectedTasksRanSuccessfully(result)
 
@@ -226,7 +226,7 @@ class MavenPublishPluginIntegrationTest {
   @Test fun generatesArtifactsAndDocumentationOnKotlinMppWithDokkaProject() {
     setupFixture("passing_kotlin_mpp_with_dokka_project")
 
-    val result = executeGradleCommands(TEST_TASK, "--stacktrace", "--stacktrace")
+    val result = executeGradleCommands(TEST_TASK, "--stacktrace")
 
     assertExpectedTasksRanSuccessfully(result, hasDokka = true)
 
@@ -251,7 +251,7 @@ class MavenPublishPluginIntegrationTest {
   @Test fun generatesArtifactsAndDocumentationOnKotlinMppWithAndroidDokkaProject() {
     setupFixture("passing_kotlin_mpp_with_android_dokka_project")
 
-    val result = executeGradleCommands(TEST_TASK, "--stacktrace", "--stacktrace")
+    val result = executeGradleCommands(TEST_TASK, "--stacktrace")
 
     assertExpectedTasksRanSuccessfully(result, hasDokka = true)
 
@@ -286,7 +286,7 @@ class MavenPublishPluginIntegrationTest {
   @Test
   fun generatesArtifactsAndDocumentationOnKotlinJsProject() {
     setupFixture("passing_kotlin_js_project")
-    val result = executeGradleCommands(TEST_TASK, "--stacktrace", "--stacktrace")
+    val result = executeGradleCommands(TEST_TASK, "--stacktrace")
 
     assertExpectedTasksRanSuccessfully(result)
     assertExpectedCommonArtifactsGenerated()
@@ -296,7 +296,7 @@ class MavenPublishPluginIntegrationTest {
   @Test fun generatesArtifactsAndDocumentationOnGradlePluginProject() {
     setupFixture("passing_java_gradle_plugin_project")
 
-    val result = executeGradleCommands(TEST_TASK, "--stacktrace", "--stacktrace")
+    val result = executeGradleCommands(TEST_TASK, "--stacktrace")
 
     assertThat(result.task(":$TEST_TASK")?.outcome).isEqualTo(SUCCESS)
     assertExpectedCommonArtifactsGenerated()
@@ -438,6 +438,7 @@ class MavenPublishPluginIntegrationTest {
   private fun executeGradleCommands(vararg commands: String) = GradleRunner.create()
     .withProjectDir(projectFolder)
     .withArguments(*commands, "-Ptest.releaseRepository=$repoFolder")
+    .withDebug(true)
     .forwardOutput()
     .build()
 

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -248,6 +248,43 @@ class MavenPublishPluginIntegrationTest {
     assertPomContentMatches(linuxArtifactId)
   }
 
+  @Test fun generatesArtifactsAndDocumentationOnKotlinMppWithAndroidDokkaProject() {
+    setupFixture("passing_kotlin_mpp_with_android_dokka_project")
+
+    val result = executeGradleCommands(TEST_TASK, "--stacktrace", "--stacktrace")
+
+    assertExpectedTasksRanSuccessfully(result, hasDokka = true)
+
+    assertExpectedCommonArtifactsGenerated()
+    assertPomContentMatches()
+
+    repoFolder.walkTopDown().forEach { println(it.path) }
+
+    val androidArtifactId = "$TEST_POM_ARTIFACT_ID-android"
+    assertExpectedCommonArtifactsGenerated(artifactId = androidArtifactId, artifactExtension = "aar")
+    // TODO dependency sorting is unstable - the other variants only have 1 and are enough to see that the pom is correct
+    // assertPomContentMatches(androidArtifactId)
+
+    val androidDebugArtifactId = "$TEST_POM_ARTIFACT_ID-android-debug"
+    assertExpectedCommonArtifactsGenerated(artifactId = androidDebugArtifactId, artifactExtension = "aar")
+    // TODO dependency sorting is unstable - the other variants only have 1 and are enough to see that the pom is correct
+    // assertPomContentMatches(androidDebugArtifactId)
+
+    val jvmArtifactId = "$TEST_POM_ARTIFACT_ID-jvm"
+    assertExpectedCommonArtifactsGenerated(artifactId = jvmArtifactId)
+    // TODO dependency sorting is unstable - the other variants only have 1 and are enough to see that the pom is correct
+    // assertPomContentMatches(jvmArtifactId)
+
+    val nodejsArtifactId = "$TEST_POM_ARTIFACT_ID-nodejs"
+    assertExpectedCommonArtifactsGenerated(artifactId = nodejsArtifactId)
+    // TODO dependency sorting is unstable - the main variant only has 1 and is enough to see that the pom is correct
+    // assertPomContentMatches(nodejsArtifactId)
+
+    val linuxArtifactId = "$TEST_POM_ARTIFACT_ID-linux"
+    assertExpectedCommonArtifactsGenerated(artifactExtension = "klib", artifactId = linuxArtifactId)
+    assertPomContentMatches(linuxArtifactId)
+  }
+
   @Test
   fun generatesArtifactsAndDocumentationOnKotlinJsProject() {
     setupFixture("passing_kotlin_js_project")

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/legacy/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/legacy/Platform.kt
@@ -38,8 +38,8 @@ internal fun Project.configurePlatform() {
 
 internal fun Project.configureNotAndroidNotMppPlatform() {
   when {
-    plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") -> return // handled separately
-    plugins.hasPlugin("com.android.library") -> return // handled separately
+    plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") -> return // Handled separately.
+    plugins.hasPlugin("com.android.library") -> return // Handled separately.
     plugins.hasPlugin("java-gradle-plugin") ->
       baseExtension.configure(GradlePlugin(defaultJavaDocOption() ?: javadoc()))
     plugins.hasPlugin("org.jetbrains.kotlin.jvm") ->

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/legacy/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/legacy/Platform.kt
@@ -23,21 +23,23 @@ import org.gradle.external.javadoc.StandardJavadocDocletOptions
 import org.jetbrains.dokka.gradle.DokkaTask
 
 internal fun Project.configurePlatform() {
-  afterEvaluate {
-    if (!plugins.hasPlugin("com.android.library")) {
-      configureNotAndroidPlatform()
-    }
+  plugins.withId("org.jetbrains.kotlin.multiplatform") {
+    baseExtension.configure(KotlinMultiplatform(defaultJavaDocOption() ?: JavadocJar.Empty()))
   }
 
   plugins.withId("com.android.library") {
     configureAndroidPlatform()
   }
+
+  afterEvaluate {
+    configureNotAndroidNotMppPlatform()
+  }
 }
 
-internal fun Project.configureNotAndroidPlatform() {
+internal fun Project.configureNotAndroidNotMppPlatform() {
   when {
-    plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") ->
-      baseExtension.configure(KotlinMultiplatform(defaultJavaDocOption() ?: JavadocJar.Empty()))
+    plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") -> return // handled separately
+    plugins.hasPlugin("com.android.library") -> return // handled separately
     plugins.hasPlugin("java-gradle-plugin") ->
       baseExtension.configure(GradlePlugin(defaultJavaDocOption() ?: javadoc()))
     plugins.hasPlugin("org.jetbrains.kotlin.jvm") ->


### PR DESCRIPTION
The check for `configureNotAndroidPlatform` would also apply for MPP projects that do apply the Android plugin. Because of that no javadoc jars would be created. As a solution I moved the multiplatform project to a general `plugins.withId`. The general block that we have in `afterEvaluate` will explicitly not handle it anymore and I also moved the check to not handle Android into that again. Maybe we can move the others to `plugins.withId` too but I'm not sure yet if that would cause issues in some combinations.

Closes #333 