### PR TITLE
temporarily switch back to single variant publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Unless another variant is specified by setting the `ANDROID_VARIANT_TO_PUBLISH`
 Gradle property the `release` variant will be published.
 
 To continue publishing multi variant libraries you can use the
-[base plugin](https://issuetracker.google.com/issues/197636221).
+[base plugin](https://github.com/vanniktech/gradle-maven-publish-plugin#base-plugin).
 
 **Removals**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,59 @@
 # Change Log
 
+Version 0.21.0 *(UNRELEASED)*
+---------------------------------
+
+**Behavior changes**
+
+The `com.vanniktech.maven.publish` stops adding Maven Central (Sonatype OSS) as a
+publishing target and will not enable GPG signing by default. To continue publishing to maven central and signing artifacts either add this to your Groovy build files:
+```gradle
+mavenPublishing {
+  publishToMavenCentral() // use publishToMavenCentral("S01") for publishing through s01.oss.sonatype.org
+  enableReleaseSigning()
+}
+```
+the following to your kts build files:
+```kotlin
+mavenPublishing {
+  publishToMavenCentral() // use publishToMavenCentral(SonatypeHost.S01) for publishing through s01.oss.sonatype.org
+  enableReleaseSigning()
+}
+```
+or the following to your `gradle.properties`:
+```properties
+SONATYPE_HOST=DEFAULT
+# SONATYPE_HOST=S01 for publishing through s01.oss.sonatype.org
+RELEASE_SIGNING_ENABLED=true
+```
+
+The base plugin is unaffected by these changes because it already has this behavior.
+
+**Android variant publishing**
+
+Since version 0.19.0 the plugin was publishing a multi variant library by
+default for Android projects. Due to [a bug in Android Studio](https://issuetracker.google.com/issues/197636221)
+that will cause it to not find the sources for libraries published this way the
+plugin will temporarily revert to publishing single variant libraries again.
+Unless another variant is specified by setting the `ANDROID_VARIANT_TO_PUBLISH`
+Gradle property the `release` variant will be published.
+
+To continue publishing multi variant libraries you can use the
+[base plugin](https://issuetracker.google.com/issues/197636221).
+
+**Removals**
+
+The deprecated `mavenPublish` extension has been removed. Take a look at the
+changelog for 0.20.0 for replacements.
+
+
 Version 0.20.0 *(2022-06-02)*
 ---------------------------------
 
 **Upcoming behavior change**
 
-In the next release after this the `com.vanniktech.maven.publish` will stop adding Maven Central (Sonatype OSS) as a 
-publishing target and will not enable GPG signing by default. If you are curretly relying on this behavior the plugin
+In the next release after this the `com.vanniktech.maven.publish` will stop adding Maven Central (Sonatype OSS) as a
+publishing target and will not enable GPG signing by default. If you are currently relying on this behavior the plugin
 will print a warning during configuration phase. To continue publishing to maven central and signing artifacts either
 add this to your build files:
 ```gradle
@@ -28,7 +75,7 @@ The base plugin is unaffected by these changes because it already has this behav
 
 The old `mavenPublish` extension has been deprecated.
 
-If you were using it to set `sonatypeHost` to `S01` use 
+If you were using it to set `sonatypeHost` to `S01` use
 ```gradle
 mavenPublishing {
   publishToMavenCentral("S01")

--- a/plugin/src/integrationTest/fixtures/passing_android_project/expected/test-artifact-1.0.0.pom
+++ b/plugin/src/integrationTest/fixtures/passing_android_project/expected/test-artifact-1.0.0.pom
@@ -10,7 +10,7 @@
   <groupId>com.example</groupId>
   <artifactId>test-artifact</artifactId>
   <version>1.0.0</version>
-  <packaging>pom</packaging>
+  <packaging>aar</packaging>
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>

--- a/plugin/src/integrationTest/fixtures/passing_android_with_kotlin_project/expected/test-artifact-1.0.0.pom
+++ b/plugin/src/integrationTest/fixtures/passing_android_with_kotlin_project/expected/test-artifact-1.0.0.pom
@@ -10,7 +10,7 @@
   <groupId>com.example</groupId>
   <artifactId>test-artifact</artifactId>
   <version>1.0.0</version>
-  <packaging>pom</packaging>
+  <packaging>aar</packaging>
   <name>Gradle Maven Publish Plugin Test Artifact</name>
   <description>Testing the Gradle Maven Publish Plugin</description>
   <url>https://github.com/vanniktech/gradle-maven-publish-plugin/</url>
@@ -40,7 +40,6 @@
       <artifactId>kotlin-stdlib-jdk8</artifactId>
       <version>1.6.10</version>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
   </dependencies>
 </project>

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest.kt
@@ -102,8 +102,7 @@ class MavenPublishPluginIntegrationTest {
     val result = executeGradleCommands(TEST_TASK, "--stacktrace")
 
     assertExpectedTasksRanSuccessfully(result)
-    assertExpectedCommonArtifactsGenerated("aar", qualifier = "debug")
-    assertExpectedCommonArtifactsGenerated("aar", qualifier = "release")
+    assertExpectedCommonArtifactsGenerated("aar")
     assertPomContentMatches()
   }
 
@@ -134,8 +133,7 @@ class MavenPublishPluginIntegrationTest {
     val result = executeGradleCommands(TEST_TASK, "--stacktrace")
 
     assertExpectedTasksRanSuccessfully(result)
-    assertExpectedCommonArtifactsGenerated("aar", qualifier = "debug")
-    assertExpectedCommonArtifactsGenerated("aar", qualifier = "release")
+    assertExpectedCommonArtifactsGenerated("aar")
     assertPomContentMatches()
   }
 

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -75,7 +75,8 @@ private fun Project.configurePlatform() {
     // multiplatform projects that use Android
     androidComponents.finalizeDsl {
       if (!plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")) {
-        baseExtension.configure(AndroidMultiVariantLibrary())
+        val variant = project.findOptionalProperty("ANDROID_VARIANT_TO_PUBLISH") ?: "release"
+        baseExtension.configure(AndroidSingleVariantLibrary(variant))
       }
     }
   }
@@ -126,7 +127,7 @@ private fun Project.javaVersion(): JavaVersion {
     val extension = project.extensions.findByType(JavaPluginExtension::class.java)
     if (extension != null) {
       val toolchain = extension.toolchain
-      val version = toolchain.languageVersion.forUseAtConfigurationTime().get().asInt()
+      val version = toolchain.languageVersion.get().asInt()
       return JavaVersion.toVersion(version)
     }
   } catch (t: Throwable) {


### PR DESCRIPTION
Workaround for https://issuetracker.google.com/issues/197636221 which seems like it will take a few more month to be fixed.