### PR TITLE
clean up Nexus closeAndReleaseRepository

### DIFF
--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/CloseAndReleaseRepositoryTask.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/CloseAndReleaseRepositoryTask.kt
@@ -20,7 +20,7 @@ open class CloseAndReleaseRepositoryTask : DefaultTask() {
   @Option(option = "repository", description = "Specify which staging repository to close and release.")
   @Input
   @Optional
-  var stagingRepository: String? = null
+  var manualStagingRepositoryId: String? = null
 
   @TaskAction
   fun closeAndReleaseRepository() {
@@ -34,6 +34,17 @@ open class CloseAndReleaseRepositoryTask : DefaultTask() {
       "Please set a value for nexus.repositoryPassword"
     }
 
-    Nexus(baseUrl, repositoryUsername, repositoryPassword, stagingRepository).closeAndReleaseRepository()
+    val nexus = Nexus(
+      baseUrl = baseUrl,
+      username = repositoryUsername,
+      password = repositoryPassword,
+    )
+
+    val manualStagingRepositoryId = this.manualStagingRepositoryId
+    if (manualStagingRepositoryId != null) {
+      nexus.closeAndReleaseRepositoryById(manualStagingRepositoryId)
+    } else {
+      nexus.closeAndReleaseCurrentRepository()
+    }
   }
 }


### PR DESCRIPTION
- separate `closeAndReleaseRepository` into `closeAndReleaseRepositoryById` which uses the id passed to the task from the command line and `closeAndReleaseCurrentRepository` which will load the available repos and close it if there is only one
- `closeAndReleaseRepositoryById` will now explicitly load the given repo instead of loading all and filtering, for that it is using the same api call that we already have for checking the status while closing it
- make `Nexus` public, I'm planning to move the `CloseAndReleaseRepositoryTask` back to the plugin module so that the nexus artifact does not contain any Gradle bits