### PR TITLE
add createRepositoryForGroup to Nexus

### DIFF
--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
@@ -24,6 +24,66 @@ internal class Nexus(
     retrofit.create(NexusService::class.java)
   }
 
+  private fun getProfiles(): List<StagingProfile>? {
+    val stagingProfilesResponse = service.getStagingProfiles().execute()
+
+    if (!stagingProfilesResponse.isSuccessful) {
+      throw IOException("Cannot get stagingProfiles for account $username: ${stagingProfilesResponse.errorBody()?.string()}")
+    }
+
+    return stagingProfilesResponse.body()?.data
+  }
+
+  private fun findStagingProfile(group: String): StagingProfile {
+    val allProfiles = getProfiles() ?: emptyList()
+
+    if (allProfiles.isEmpty()) {
+      throw IllegalArgumentException("No staging profiles found in account $username. Make sure you called \"./gradlew publish\".")
+    }
+
+    val candidateProfiles = allProfiles.filter { group == it.name || group.startsWith(it.name) }
+
+    if (candidateProfiles.isEmpty()) {
+      throw IllegalArgumentException(
+        "No matching staging profile found in account $username. It is expected that the account contains a staging " +
+          "profile that matches or is the start of $group." +
+          "Available profiles are: ${allProfiles.joinToString(separator = ", ") { it.name }}"
+      )
+    }
+
+    if (candidateProfiles.size > 1) {
+      throw IllegalArgumentException(
+        "More than 1 matching staging profile found in account $username. " +
+          "Available profiles are: ${allProfiles.joinToString(separator = ", ") { it.name }}"
+      )
+    }
+
+    return candidateProfiles[0]
+  }
+
+  private fun createStagingRepository(group: String, profile: StagingProfile): String {
+    println("Creating repository in profile: ${profile.name}")
+
+    val response = service.createRepository(profile.id, CreateRepositoryInput(CreateRepositoryInputData("Repository for $group"))).execute()
+    if (!response.isSuccessful) {
+      throw IOException("Cannot create repository: ${response.errorBody()?.string()}")
+    }
+
+    val id = response.body()?.data?.stagedRepositoryId
+    if (id == null) {
+      throw IOException("Did not receive created repository")
+    }
+
+    println("Created staging repository $id")
+
+    return id
+  }
+
+  fun createRepositoryForGroup(group: String): String {
+    val profile = findStagingProfile(group)
+    return createStagingRepository(group, profile)
+  }
+
   private fun getProfileRepositories(): List<Repository>? {
     val profileRepositoriesResponse = service.getProfileRepositories().execute()
 

--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusModel.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusModel.kt
@@ -3,6 +3,24 @@ package com.vanniktech.maven.publish.nexus
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
+internal data class StagingProfile(val id: String, val name: String)
+
+@JsonClass(generateAdapter = true)
+internal data class StagingProfilesResponse(val data: List<StagingProfile>)
+
+@JsonClass(generateAdapter = true)
+internal data class CreateRepositoryInputData(val description: String)
+
+@JsonClass(generateAdapter = true)
+internal data class CreateRepositoryInput(val data: CreateRepositoryInputData)
+
+@JsonClass(generateAdapter = true)
+internal data class CreatedRepository(val stagedRepositoryId: String)
+
+@JsonClass(generateAdapter = true)
+internal data class CreateRepositoryResponse(val data: CreatedRepository)
+
+@JsonClass(generateAdapter = true)
 internal data class Repository(val repositoryId: String, val transitioning: Boolean, val type: String)
 
 @JsonClass(generateAdapter = true)

--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusService.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusService.kt
@@ -11,6 +11,16 @@ import retrofit2.http.Path
  * -Nexus CORE API: https://repository.sonatype.org/nexus-restlet1x-plugin/default/docs/index.html
  */
 internal interface NexusService {
+
+  @GET("staging/profiles")
+  fun getStagingProfiles(): Call<StagingProfilesResponse>
+
+  @POST("staging/profiles/{profileId}/start")
+  fun createRepository(
+    @Path("profileId") stagingProfileId: String,
+    @Body input: CreateRepositoryInput
+  ): Call<CreateRepositoryResponse>
+
   @GET("staging/profile_repositories")
   fun getProfileRepositories(): Call<ProfileRepositoriesResponse>
 


### PR DESCRIPTION
This adds the capabilities for creating staging repositories to `Nexus`.  This will load the profiles of the user and will try to find one that matches the group id that we want to publish, e.g. if you want to publish `com.example.foo` it expects a profile called `com.example.foo` or `com.example`. With the id of that profile it will then create a staging repository and return its id.

Endpoint docs: https://oss.sonatype.org/nexus-staging-plugin/default/docs/index.html
