### PR TITLE
increase timeouts for nexus API calls

### DIFF
--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
@@ -1,6 +1,7 @@
 package com.vanniktech.maven.publish.nexus
 
 import java.io.IOException
+import java.util.concurrent.TimeUnit
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -14,6 +15,9 @@ internal class Nexus(
   private val service by lazy {
     val okHttpClient = OkHttpClient.Builder()
       .addInterceptor(NexusOkHttpInterceptor(username, password))
+      .connectTimeout(30, TimeUnit.SECONDS)
+      .readTimeout(30, TimeUnit.SECONDS)
+      .writeTimeout(30, TimeUnit.SECONDS)
       .build()
     val retrofit = Retrofit.Builder()
       .addConverterFactory(MoshiConverterFactory.create())

--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
@@ -16,9 +16,9 @@ internal class Nexus(
   private val service by lazy {
     val okHttpClient = OkHttpClient.Builder()
       .addInterceptor(NexusOkHttpInterceptor(username, password))
-      .connectTimeout(30, TimeUnit.SECONDS)
-      .readTimeout(30, TimeUnit.SECONDS)
-      .writeTimeout(30, TimeUnit.SECONDS)
+      .connectTimeout(60, TimeUnit.SECONDS)
+      .readTimeout(60, TimeUnit.SECONDS)
+      .writeTimeout(60, TimeUnit.SECONDS)
       .build()
     val retrofit = Retrofit.Builder()
       .addConverterFactory(MoshiConverterFactory.create())

--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
@@ -2,6 +2,7 @@ package com.vanniktech.maven.publish.nexus
 
 import java.io.IOException
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -118,6 +119,8 @@ internal class Nexus(
           break
         }
       } catch (e: IOException) {
+        System.err.println("Exception trying to get repository status: ${e.message}")
+      } catch (e: TimeoutException) {
         System.err.println("Exception trying to get repository status: ${e.message}")
       }
     }


### PR DESCRIPTION
We know that it can time out and I don't think increasing these values has any downside.

closes #170 