### PR TITLE
add methods for sonatype urls to SonatypeHost

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
@@ -10,5 +10,25 @@ enum class SonatypeHost(
   internal val rootUrl: String
 ) {
   DEFAULT("https://oss.sonatype.org"),
-  S01("https://s01.oss.sonatype.org"),
+  S01("https://s01.oss.sonatype.org");
+  
+  internal fun apiBaseUrl(): String {
+    return "$rootUrl/service/local/"
+  }
+
+  internal fun publishingUrl(snapshot: Boolean, stagingRepositoryId: Provider<String>): String {
+    return if (snapshot) {
+      if (stagingRepositoryId.isPresent) {
+        throw IllegalArgumentException("Staging repositories are not supported for SNAPSHOT versions.")
+      }
+      "$rootUrl/content/repositories/snapshots/"
+    } else {
+      val id = stagingRepositoryId.orNull
+      if (id != null) {
+        "$rootUrl/service/local/staging/deployByRepositoryId/$id/"
+      } else {
+        "$rootUrl/service/local/staging/deploy/maven2/"
+      }
+    }
+  }
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
@@ -1,5 +1,7 @@
 package com.vanniktech.maven.publish
 
+import org.gradle.api.provider.Provider
+
 /**
  * Describes the various hosts for Sonatype OSSRH. Depending on when a user signed up with Sonatype
  * they have to use different hosts.
@@ -11,7 +13,7 @@ enum class SonatypeHost(
 ) {
   DEFAULT("https://oss.sonatype.org"),
   S01("https://s01.oss.sonatype.org");
-  
+
   internal fun apiBaseUrl(): String {
     return "$rootUrl/service/local/"
   }


### PR DESCRIPTION
I will start using these instead of having them spread in the project in follow ups. The logic for these is the same as it is right now.