### PR TITLE
replace afterEvaluate for snapshots with provider

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -44,14 +44,8 @@ abstract class MavenPublishBaseExtension(
 
     project.gradlePublishing.repositories.maven { repo ->
       repo.name = "mavenCentral"
-      repo.setUrl("${host.rootUrl}/service/local/staging/deploy/maven2/")
+      repo.setUrl(sonatypeHost.map { it.publishingUrl(project.versionIsSnapshot, stagingRepositoryId) })
       repo.credentials(PasswordCredentials::class.java)
-
-      project.afterEvaluate {
-        if (it.version.toString().endsWith("SNAPSHOT")) {
-          repo.setUrl("${host.rootUrl}/content/repositories/snapshots/")
-        }
-      }
     }
 
     project.rootExtension.configureCloseAndReleaseTask(
@@ -94,7 +88,7 @@ abstract class MavenPublishBaseExtension(
     signing.finalizeValue()
 
     project.plugins.apply(SigningPlugin::class.java)
-    project.gradleSigning.setRequired(Callable { !project.version.toString().contains("SNAPSHOT") })
+    project.gradleSigning.setRequired(Callable { !project.versionIsSnapshot })
     project.gradleSigning.sign(project.gradlePublishing.publications)
 
     val inMemoryKey = project.findOptionalProperty("signingInMemoryKey")

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
@@ -8,6 +8,9 @@ import org.gradle.plugins.signing.SigningExtension
 
 internal fun Project.findOptionalProperty(propertyName: String) = findProperty(propertyName)?.toString()
 
+internal val Project.versionIsSnapshot: Boolean
+  get() = version.toString().endsWith("-SNAPSHOT")
+
 internal inline val Project.baseExtension: MavenPublishBaseExtension
   get() = extensions.getByType(MavenPublishBaseExtension::class.java)
 


### PR DESCRIPTION
After digging a bit inside Gradle sources I found out that the `Object` that `setUrl` expects can be a provider which means that we can lazily create it. This gets rid of the `afterEvaluate` for determining whether we need to user the snapshot url and it also enables us to set `stagingRepositoryId` from inside a task that runs before publishing and creates the staging repo (this will happen in a follow up)