### PR TITLE
update OkHttp to 4.10

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -3,6 +3,7 @@ object Version {
   const val assertj = "3.19.0"
   const val agp = "7.1.0"
   const val dokka = "1.6.10"
+  const val okhttp = "4.10.0"
   const val retrofit = "2.9.0"
   const val moshi = "1.13.0"
 }

--- a/nexus/build.gradle.kts
+++ b/nexus/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
   add("kapt", "com.squareup.moshi:moshi-kotlin-codegen:${Version.moshi}")
 
+  implementation("com.squareup.okhttp3:okhttp:${Version.okhttp}")
   implementation("com.squareup.moshi:moshi:${Version.moshi}")
   implementation("com.squareup.retrofit2:retrofit:${Version.retrofit}")
   implementation("com.squareup.retrofit2:converter-moshi:${Version.retrofit}")


### PR DESCRIPTION
When I was doing some test uploads to sonatype I got a notification that the version of okhttp that we transitively depended on has a vulnerability.