### PR TITLE
add task to create staging repository

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
@@ -25,12 +25,7 @@ enum class SonatypeHost(
       }
       "$rootUrl/content/repositories/snapshots/"
     } else {
-      val id = stagingRepositoryId.orNull
-      if (id != null) {
-        "$rootUrl/service/local/staging/deployByRepositoryId/$id/"
-      } else {
-        "$rootUrl/service/local/staging/deploy/maven2/"
-      }
+      "$rootUrl/service/local/staging/deployByRepositoryId/${stagingRepositoryId.get()}/"
     }
   }
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
@@ -1,0 +1,64 @@
+package com.vanniktech.maven.publish.sonatype
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
+
+internal abstract class CreateSonatypeRepositoryTask : DefaultTask() {
+
+  @get:Internal
+  abstract val projectGroup: Property<String>
+
+  @get:Internal
+  abstract val versionIsSnapshot: Property<Boolean>
+
+  @get:Internal
+  abstract val stagingRepositoryId: Property<String>
+
+  @get:Internal
+  abstract val buildService: Property<SonatypeRepositoryBuildService>
+
+  @TaskAction
+  fun createStagingRepository() {
+    if (versionIsSnapshot.get()) {
+      return
+    }
+
+    val service = this.buildService.get()
+
+    // if repository was already create in this build this is a no-op
+    val currentStagingRepositoryId = service.stagingRepositoryId
+    if (currentStagingRepositoryId != null) {
+      stagingRepositoryId.set(currentStagingRepositoryId)
+      return
+    }
+
+    val id = service.nexus.createRepositoryForGroup(projectGroup.get())
+
+    service.stagingRepositoryId = id
+    stagingRepositoryId.set(id)
+  }
+
+  companion object {
+    private const val NAME = "createStagingRepository"
+
+    fun TaskContainer.registerCreateRepository(
+      projectGroup: Provider<String>,
+      versionIsSnapshot: Provider<Boolean>,
+      buildService: Provider<SonatypeRepositoryBuildService>,
+    ): TaskProvider<CreateSonatypeRepositoryTask> {
+      return register(NAME, CreateSonatypeRepositoryTask::class.java) {
+        it.description = "Create a staging repository on Sonatype OSS"
+        it.group = "release"
+        it.projectGroup.set(projectGroup)
+        it.versionIsSnapshot.set(versionIsSnapshot)
+        it.buildService.set(buildService)
+        it.usesService(buildService)
+      }
+    }
+  }
+}

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
@@ -30,7 +30,7 @@ internal abstract class CreateSonatypeRepositoryTask : DefaultTask() {
 
     val service = this.buildService.get()
 
-    // if repository was already create in this build this is a no-op
+    // if repository was already created in this build this is a no-op
     val currentStagingRepositoryId = service.stagingRepositoryId
     if (currentStagingRepositoryId != null) {
       stagingRepositoryId.set(currentStagingRepositoryId)

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
@@ -21,6 +21,17 @@ internal abstract class SonatypeRepositoryBuildService : BuildService<SonatypeRe
     password = parameters.repositoryPassword.get(),
   )
 
+  // should only be accessed from CreateSonatypeRepositoryTask
+  // for all other use cases use MavenPublishBaseExtension
+  // the id of the staging repository that was created during this build
+  var stagingRepositoryId: String? = null
+    set(value) {
+      if (field != null) {
+        throw IllegalStateException("stagingRepositoryId was already set")
+      }
+      field = value
+    }
+
   // should only be accessed from CloseAndReleaseSonatypeRepositoryTask
   // indicates whether we already closed a staging repository to avoid doing it more than once in a build
   var repositoryClosed: Boolean = false


### PR DESCRIPTION
The new `createStagingRepository` task will make the neccessary calls to create a staging repo on Sonatype and then stores the id of that in both the build service and and a property that is used to compute the url to publish to. When the build service already contains an id the task will just set that on the property so that we only create a single repository for the whole build. In the case of snapshots the task will just return immediately. The Gradle publish tasks depend on the new task so that it's automatically running before we upload anything. 

With this just running `./gradlew publish` or `./gradlew publish*ToMavenCentralRepository`will automatically create a staging repo and upload all artifacts to that one repo.

One note is that `closeAndReleaseRepository` is not integrated with this yet. So you need a second Gradle invocation (`./gradlew closeAndReleaseRepository`) to do that.
