### PR TITLE
detect when closing the repository failed

### DIFF
--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
@@ -8,7 +8,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
 class Nexus(
-  baseUrl: String,
+  private val baseUrl: String,
   private val username: String,
   password: String,
 ) {
@@ -177,15 +177,22 @@ class Nexus(
 
       Thread.sleep(CLOSE_WAIT_INTERVAL_MILLIS)
 
-      try {
-        val repository = getStagingRepository(repositoryId)
-        if (repository.type == "closed" && !repository.transitioning) {
-          break
-        }
+      val repository = try {
+        getStagingRepository(repositoryId)
       } catch (e: IOException) {
         System.err.println("Exception trying to get repository status: ${e.message}")
+        null
       } catch (e: TimeoutException) {
         System.err.println("Exception trying to get repository status: ${e.message}")
+        null
+      }
+
+      if (repository?.type == "closed" && !repository.transitioning) {
+        break
+      }
+      if (repository?.type == "open" && !repository.transitioning && repository.notifications > 0) {
+        val url = baseUrl.toHttpUrl().newBuilder("/#stagingRepositories").toString()
+        throw IOException("Closing the repository failed. ${repository.notifications} messages are available on $url")
       }
     }
   }

--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
@@ -3,6 +3,7 @@ package com.vanniktech.maven.publish.nexus
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory

--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusModel.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusModel.kt
@@ -21,7 +21,12 @@ internal data class CreatedRepository(val stagedRepositoryId: String)
 internal data class CreateRepositoryResponse(val data: CreatedRepository)
 
 @JsonClass(generateAdapter = true)
-internal data class Repository(val repositoryId: String, val transitioning: Boolean, val type: String)
+internal data class Repository(
+  val repositoryId: String,
+  val transitioning: Boolean,
+  val type: String,
+  val notifications: Int
+)
 
 @JsonClass(generateAdapter = true)
 internal data class ProfileRepositoriesResponse(val data: List<Repository>)


### PR DESCRIPTION
While I tested uploading with disabled signing I noticed that when the closing fails on the Sonatype side because of the missing asc files we will still wait the full 15 minutes and the fail with a timeout. The staging repository will be open but `transitioning` will now be false and `notifications` contains the number of messages on sonatype, so we detect this case and throw an error. A follow up could be to also get the actual messages with another API call