### PR TITLE
automatically close the created repository and optionally also release it

### DIFF
--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
@@ -135,8 +135,17 @@ class Nexus(
     return repository
   }
 
-  private fun closeStagingRepository(stagingRepository: Repository): String {
+  private fun closeStagingRepository(stagingRepository: Repository) {
     val repositoryId = stagingRepository.repositoryId
+
+    if (stagingRepository.type == "closed") {
+      if (stagingRepository.transitioning) {
+        waitForClose(stagingRepository.repositoryId)
+      } else {
+        println("Repository $repositoryId already closed")
+      }
+      return
+    }
 
     if (stagingRepository.type != "open") {
       throw IllegalArgumentException("Repository $repositoryId is of type '${stagingRepository.type}' and not 'open'")
@@ -149,8 +158,7 @@ class Nexus(
     }
 
     waitForClose(repositoryId)
-
-    return repositoryId
+    println("Repository $repositoryId closed")
   }
 
   private fun waitForClose(repositoryId: String) {
@@ -190,7 +198,18 @@ class Nexus(
     }
   }
 
-  private fun releaseStagingRepository(repositoryId: String) {
+  fun closeCurrentStagingRepository(): String {
+    val stagingRepository = findStagingRepository()
+    closeStagingRepository(stagingRepository)
+    return stagingRepository.repositoryId
+  }
+
+  fun closeStagingRepository(repositoryId: String) {
+    val stagingRepository = getStagingRepository(repositoryId)
+    closeStagingRepository(stagingRepository)
+  }
+
+  fun releaseStagingRepository(repositoryId: String) {
     println("Releasing repository: $repositoryId")
     val response = service.releaseRepository(
       TransitionRepositoryInput(
@@ -206,21 +225,6 @@ class Nexus(
     }
 
     println("Repository $repositoryId released")
-  }
-
-  private fun closeAndReleaseRepository(stagingRepository: Repository) {
-    closeStagingRepository(stagingRepository)
-    releaseStagingRepository(stagingRepository.repositoryId)
-  }
-
-  fun closeAndReleaseCurrentRepository() {
-    val stagingRepository = findStagingRepository()
-    closeAndReleaseRepository(stagingRepository)
-  }
-
-  fun closeAndReleaseRepositoryById(repositoryId: String) {
-    val stagingRepository = getStagingRepository(repositoryId)
-    closeAndReleaseRepository(stagingRepository)
   }
 
   companion object {

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -18,8 +18,9 @@ open class MavenPublishPlugin : Plugin<Project> {
     project.setCoordinates()
 
     val sonatypeHost = project.findOptionalProperty("SONATYPE_HOST")
-    if (sonatypeHost != null && sonatypeHost.isNotBlank()) {
-      baseExtension.publishToMavenCentral(SonatypeHost.valueOf(sonatypeHost))
+    if (!sonatypeHost.isNullOrBlank()) {
+      val automaticRelease = project.findOptionalProperty("SONATYPE_AUTOMATIC_RELEASE").toBoolean()
+      baseExtension.publishToMavenCentral(SonatypeHost.valueOf(sonatypeHost), automaticRelease)
     }
     val releaseSigning = project.findOptionalProperty("RELEASE_SIGNING_ENABLED")?.toBoolean()
     if (releaseSigning == true) {

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CloseAndReleaseSonatypeRepositoryTask.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CloseAndReleaseSonatypeRepositoryTask.kt
@@ -32,9 +32,11 @@ internal abstract class CloseAndReleaseSonatypeRepositoryTask : DefaultTask() {
 
     val manualStagingRepositoryId = this.manualStagingRepositoryId
     if (manualStagingRepositoryId != null) {
-      service.nexus.closeAndReleaseRepositoryById(manualStagingRepositoryId)
+      service.nexus.closeStagingRepository(manualStagingRepositoryId)
+      service.nexus.releaseStagingRepository(manualStagingRepositoryId)
     } else {
-      service.nexus.closeAndReleaseCurrentRepository()
+      val id = service.nexus.closeCurrentStagingRepository()
+      service.nexus.releaseStagingRepository(id)
     }
 
     service.repositoryClosed = true

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
@@ -7,12 +7,16 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.api.services.BuildServiceRegistry
+import org.gradle.tooling.events.FinishEvent
+import org.gradle.tooling.events.OperationCompletionListener
+import org.gradle.tooling.events.task.TaskFailureResult
 
-internal abstract class SonatypeRepositoryBuildService : BuildService<SonatypeRepositoryBuildService.Params> {
+internal abstract class SonatypeRepositoryBuildService : BuildService<SonatypeRepositoryBuildService.Params>, AutoCloseable, OperationCompletionListener {
   internal interface Params : BuildServiceParameters {
     val sonatypeHost: Property<SonatypeHost>
     val repositoryUsername: Property<String>
     val repositoryPassword: Property<String>
+    val automaticRelease: Property<Boolean>
   }
 
   val nexus = Nexus(
@@ -36,6 +40,28 @@ internal abstract class SonatypeRepositoryBuildService : BuildService<SonatypeRe
   // indicates whether we already closed a staging repository to avoid doing it more than once in a build
   var repositoryClosed: Boolean = false
 
+  var buildHasFailure: Boolean = false
+
+  override fun onFinish(event: FinishEvent) {
+    if (event.result is TaskFailureResult) {
+      buildHasFailure = true
+    }
+  }
+
+  override fun close() {
+    if (buildHasFailure) {
+      return
+    }
+
+    val stagingRepositoryId = this.stagingRepositoryId
+    if (stagingRepositoryId != null) {
+      nexus.closeStagingRepository(stagingRepositoryId)
+      if (parameters.automaticRelease.get()) {
+        nexus.releaseStagingRepository(stagingRepositoryId)
+      }
+    }
+  }
+
   companion object {
     private const val NAME = "sonatype-repository-build-service"
 
@@ -43,12 +69,14 @@ internal abstract class SonatypeRepositoryBuildService : BuildService<SonatypeRe
       sonatypeHost: Provider<SonatypeHost>,
       repositoryUsername: Provider<String>,
       repositoryPassword: Provider<String>,
+      automaticRelease: Boolean,
     ): Provider<SonatypeRepositoryBuildService> {
       return registerIfAbsent(NAME, SonatypeRepositoryBuildService::class.java) {
         it.maxParallelUsages.set(1)
         it.parameters.sonatypeHost.set(sonatypeHost)
         it.parameters.repositoryUsername.set(repositoryUsername)
         it.parameters.repositoryPassword.set(repositoryPassword)
+        it.parameters.automaticRelease.set(automaticRelease)
       }
     }
   }


### PR DESCRIPTION
This will automatically close the repository that we created at the end of the build and based on a Gradle property or a parameter in the DSL also release it automatically. I think we don't need an option to control the automatic closing, each build will create a new repository anyways so there shouldn't be anything added after the fact. If there is a valid use case for it we can still make it optional later. Releasing on the other hand is a bigger step so I decided to make it opt-in. Even if you want to use it it allows for something like only enabling it on CI by setting an env var.

The closing and releasing is not done through the `closeAndReleaseRepository` task. The issue with the task is that it would need to wait for publishing in all other subprojects to finish so we would need cross project dependencies. One solution would have been the root plugin that we had before which would at least simplify it to only the root project task having to wait for all projects to finish publishing, but I also had some other issues that plugin. The solution is to trigger this from the build service. When a build service implements `AutoCloseable` Gradle will call `close` when the build service is no longer needed. Implementing `OperationCompletionListener` and registering it will make it so that we can detect that no task failed (in that case close and release is not run) and will make it so that the build service is needed for the whole build which means that `close` is only called after the last task finished. The `close` implementation then checks if a staging repo was created and then does the close and release operations.

I'm not 100% sure yet about the future of the close and release task. For now I made a small change to the nexus code so that running it on an already close repo will simply release it instead of printing an error that it is not open. So it can be used to then release it manually if automatic releasing isn't enabled. It could also be used to manually retry closing and releasing the already created staging repo if it failed. So it probably continue existing. One future change could be making the `--release` cli parameter required though and removing automatically finding a repo. The build will print the id of the repo when creating and automatically closing it, so you always know it.