### PR TITLE
Create nexus lazily to avoid an error when properties aren't set

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
@@ -19,11 +19,13 @@ internal abstract class SonatypeRepositoryBuildService : BuildService<SonatypeRe
     val automaticRelease: Property<Boolean>
   }
 
-  val nexus = Nexus(
-    baseUrl = parameters.sonatypeHost.get().apiBaseUrl(),
-    username = parameters.repositoryUsername.get(),
-    password = parameters.repositoryPassword.get(),
-  )
+  val nexus by lazy {
+    Nexus(
+      baseUrl = parameters.sonatypeHost.get().apiBaseUrl(),
+      username = parameters.repositoryUsername.get(),
+      password = parameters.repositoryPassword.get(),
+    )
+  }
 
   // should only be accessed from CreateSonatypeRepositoryTask
   // for all other use cases use MavenPublishBaseExtension


### PR DESCRIPTION
Fixes https://github.com/vanniktech/gradle-maven-publish-plugin/issues/381#issuecomment-1236436712

The other way to do it would be to make `Nexus` (and all subsequent types) take `Provider<String>` instead of `String`