### PR TITLE
retrieve activity messages when closing repository fails

### DIFF
--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusModel.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusModel.kt
@@ -29,6 +29,15 @@ internal data class Repository(
 )
 
 @JsonClass(generateAdapter = true)
+internal data class RepositoryEventProperty(val name: String, val value: String)
+
+@JsonClass(generateAdapter = true)
+internal data class RepositoryEvent(val name: String, val properties: List<RepositoryEventProperty>)
+
+@JsonClass(generateAdapter = true)
+internal data class RepositoryActivity(val name: String, val events: List<RepositoryEvent>)
+
+@JsonClass(generateAdapter = true)
 internal data class ProfileRepositoriesResponse(val data: List<Repository>)
 
 @JsonClass(generateAdapter = true)

--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusService.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusService.kt
@@ -27,6 +27,9 @@ internal interface NexusService {
   @GET("staging/repository/{repositoryId}")
   fun getRepository(@Path("repositoryId") repositoryId: String): Call<Repository>
 
+  @GET("staging/repository/{repositoryId}/activity")
+  fun getRepositoryActivity(@Path("repositoryId") repositoryId: String): Call<List<RepositoryActivity>>
+
   @POST("staging/bulk/close")
   fun closeRepository(@Body input: TransitionRepositoryInput): Call<Unit>
 


### PR DESCRIPTION
With this the plugin will try to retrieve the error messages when closing failed and then print them. In case retrieving them doesn't work it falls back the current error message that directs users to the sonatype website. 

```
* What went wrong:
Failed to stop service 'sonatype-repository-build-service'.
> Closing the repository failed with the following errors:
  Missing Signature: '/com/gabrielittner/maven/publish/com.gabrielittner.maven.publish.gradle.plugin/gabriel-test1/com.gabrielittner.maven.publish.gradle.plugin-gabriel-test1.pom.asc' does not exist for 'com.gabrielittner.maven.publish.gradle.plugin-gabriel-test1.pom'.
  Missing Signature: '/com/gabrielittner/maven/publish/base/com.gabrielittner.maven.publish.base.gradle.plugin/gabriel-test1/com.gabrielittner.maven.publish.base.gradle.plugin-gabriel-test1.pom.asc' does not exist for 'com.gabrielittner.maven.publish.base.gradle.plugin-gabriel-test1.pom'.
  Missing Signature: '/com/gabrielittner/test/nexus/gabriel-test1/nexus-gabriel-test1-sources.jar.asc' does not exist for 'nexus-gabriel-test1-sources.jar'.
  Missing Signature: '/com/gabrielittner/test/nexus/gabriel-test1/nexus-gabriel-test1.pom.asc' does not exist for 'nexus-gabriel-test1.pom'.
  Missing Signature: '/com/gabrielittner/test/nexus/gabriel-test1/nexus-gabriel-test1.jar.asc' does not exist for 'nexus-gabriel-test1.jar'.
  Missing Signature: '/com/gabrielittner/test/nexus/gabriel-test1/nexus-gabriel-test1-javadoc.jar.asc' does not exist for 'nexus-gabriel-test1-javadoc.jar'.
  Missing Signature: '/com/gabrielittner/test/nexus/gabriel-test1/nexus-gabriel-test1.module.asc' does not exist for 'nexus-gabriel-test1.module'.
  Missing Signature: '/com/gabrielittner/test/gradle-maven-publish-plugin/gabriel-test1/gradle-maven-publish-plugin-gabriel-test1.pom.asc' does not exist for 'gradle-maven-publish-plugin-gabriel-test1.pom'.
  Missing Signature: '/com/gabrielittner/test/gradle-maven-publish-plugin/gabriel-test1/gradle-maven-publish-plugin-gabriel-test1.module.asc' does not exist for 'gradle-maven-publish-plugin-gabriel-test1.module'.
  Missing Signature: '/com/gabrielittner/test/gradle-maven-publish-plugin/gabriel-test1/gradle-maven-publish-plugin-gabriel-test1.jar.asc' does not exist for 'gradle-maven-publish-plugin-gabriel-test1.jar'.
  Missing Signature: '/com/gabrielittner/test/gradle-maven-publish-plugin/gabriel-test1/gradle-maven-publish-plugin-gabriel-test1-javadoc.jar.asc' does not exist for 'gradle-maven-publish-plugin-gabriel-test1-javadoc.jar'.
  Missing Signature: '/com/gabrielittner/test/gradle-maven-publish-plugin/gabriel-test1/gradle-maven-publish-plugin-gabriel-test1-sources.jar.asc' does not exist for 'gradle-maven-publish-plugin-gabriel-test1-sources.jar'.
```