### PR TITLE
drop repository when build fails

### DIFF
--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
@@ -235,6 +235,20 @@ class Nexus(
     println("Repository $repositoryId released")
   }
 
+  fun dropStagingRepository(repositoryId: String) {
+    val response = service.dropRepository(
+      TransitionRepositoryInput(
+        TransitionRepositoryInputData(
+          stagedRepositoryIds = listOf(repositoryId)
+        )
+      )
+    ).execute()
+
+    if (!response.isSuccessful) {
+      throw IOException("Cannot drop repository: ${response.errorBody()?.string()}")
+    }
+  }
+
   companion object {
     private const val PROGRESS_1 = "\u2839"
     private const val PROGRESS_2 = "\u2838"

--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusService.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusService.kt
@@ -32,4 +32,7 @@ internal interface NexusService {
 
   @POST("staging/bulk/promote")
   fun releaseRepository(@Body input: TransitionRepositoryInput): Call<Unit>
+
+  @POST("staging/bulk/drop")
+  fun dropRepository(@Body input: TransitionRepositoryInput): Call<Unit>
 }


### PR DESCRIPTION
Makes an attempt to drop the created staging repository in case of build failures. This is on a best effort basis and a failure to drop the repo will be silently ignored.

closes #406 