### PR TITLE
Use version catalog to manage dependencies to make renovate work again

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,16 +1,9 @@
-plugins {
-  kotlin("jvm").version("1.4.32")
-  `kotlin-dsl`
-}
+plugins { `kotlin-dsl` }
 
 dependencies {
-  implementation(kotlin("gradle-plugin"))
-  implementation("org.jlleitschuh.gradle:ktlint-gradle:11.0.0")
-  implementation("com.vanniktech:gradle-maven-publish-plugin:0.21.0")
-}
-
-repositories {
-  mavenCentral()
-  google()
-  gradlePluginPortal()
+  implementation(libs.kotlin.plugin)
+  implementation(libs.ktlint.plugin)
+  implementation(libs.maven.publish.plugin)
+  // https://github.com/gradle/gradle/issues/15383#issuecomment-779893192
+  implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -8,6 +8,7 @@ dependencyResolutionManagement {
     mavenCentral()
     gradlePluginPortal()
   }
+
   versionCatalogs {
     create("libs") {
       from(files("../gradle/libs.versions.toml"))

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,16 @@
+@file:Suppress("UnstableApiUsage")
+
+rootProject.name = "build-logic"
+
+dependencyResolutionManagement {
+  repositories {
+    google()
+    mavenCentral()
+    gradlePluginPortal()
+  }
+  versionCatalogs {
+    create("libs") {
+      from(files("../gradle/libs.versions.toml"))
+    }
+  }
+}

--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -1,9 +1,0 @@
-object Version {
-  const val junit = "4.13.2"
-  const val assertj = "3.19.0"
-  const val agp = "7.1.0"
-  const val dokka = "1.6.10"
-  const val okhttp = "4.10.0"
-  const val retrofit = "2.9.0"
-  const val moshi = "1.13.0"
-}

--- a/build-logic/src/main/kotlin/shared.gradle.kts
+++ b/build-logic/src/main/kotlin/shared.gradle.kts
@@ -1,3 +1,7 @@
+import org.gradle.accessors.dm.LibrariesForLibs
+
+val libs = the<LibrariesForLibs>()
+
 plugins {
   id("java-library")
   id("kotlin")
@@ -15,17 +19,16 @@ repositories {
   google()
 }
 
-
-java.sourceCompatibility = JavaVersion.VERSION_1_8
-java.targetCompatibility = JavaVersion.VERSION_1_8
-
-// Use the kotlin version from the stdlib
-val kotlinVersion = KotlinVersion.CURRENT.toString()
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 configurations.all {
+  // Pin the kotlin version
   resolutionStrategy {
-    force("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-    force("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
-    force("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
+    force(libs.kotlin.stdlib)
+    force(libs.kotlin.stdlib.jdk8)
+    force(libs.kotlin.reflect)
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,25 @@
+[versions]
+kotlin = "1.6.10"
+moshi = "1.13.0"
+retrofit = "2.9.0"
+
+[libraries]
+okhttp = "com.squareup.okhttp3:okhttp:4.10.0"
+dokka = "org.jetbrains.dokka:dokka-gradle-plugin:1.6.10"
+assertj = "org.assertj:assertj-core:3.19.0"
+junit = "junit:junit:4.13.2"
+
+android-plugin = "com.android.tools.build:gradle:7.1.0"
+ktlint-plugin = "org.jlleitschuh.gradle:ktlint-gradle:11.0.0"
+maven-publish-plugin = "com.vanniktech:gradle-maven-publish-plugin:0.21.0"
+
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+
+moshi = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
+moshi-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
+
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+retrofit-converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", versi
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 
-moshi = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
+moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }

--- a/nexus/build.gradle.kts
+++ b/nexus/build.gradle.kts
@@ -3,10 +3,10 @@ plugins {
 }
 
 dependencies {
-  add("kapt", "com.squareup.moshi:moshi-kotlin-codegen:${Version.moshi}")
+  kapt(libs.moshi.codegen)
 
-  implementation("com.squareup.okhttp3:okhttp:${Version.okhttp}")
-  implementation("com.squareup.moshi:moshi:${Version.moshi}")
-  implementation("com.squareup.retrofit2:retrofit:${Version.retrofit}")
-  implementation("com.squareup.retrofit2:converter-moshi:${Version.retrofit}")
+  implementation(libs.okhttp)
+  implementation(libs.moshi)
+  implementation(libs.retrofit)
+  implementation(libs.retrofit.converter.moshi)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,9 +1,6 @@
-pluginManagement {
-  repositories {
-    gradlePluginPortal()
-  }
-  @Suppress("UnstableApiUsage")
-  includeBuild("build-logic")
-}
+rootProject.name = "gradle-maven-publish-plugin"
+
 include(":plugin")
 include(":nexus")
+includeBuild("build-logic")
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
Version Catalog has become an official dependency management practice recommended by Gradle, so...

This PR also changes many string hard encodings to type-safe accessors. Please feel free to merge or close :)

---

Inspired largely by https://github.com/android/nowinandroid