### PR TITLE
fix docs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -34,8 +34,6 @@ jobs:
       - name: Copy docs
         run: |
           cp README.md docs/index.md
-          # Fix relative paths
-          sed -i 's/docs\///' docs/index.md
           # Update page time
           sed -i 's/# gradle-maven-publish-plugin/# Overview/' docs/index.md
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ and has been enhanced to add Kotlin support and keep up with the latest changes.
 
 # Setup
 
-- [Publishing open source projects to Maven Central](docs/central.md)
-- [Publishing to other Maven repositories](docs/other.md)
+- [Publishing open source projects to Maven Central](https://vanniktech.github.io/gradle-maven-publish-plugin/central/)
+- [Publishing to other Maven repositories](https://vanniktech.github.io/gradle-maven-publish-plugin/other/)
 
 # Advantages over `maven-publish`
 
@@ -29,7 +29,7 @@ plugin directly integrate with, so why should you use this plugin?
 - **Gradle property based config**. Easily configure the plugin with Gradle properties that will apply to all
   subprojects
 
-There is also a [base plugin](docs/base.md) which removes any automatic configuration and allows for a more manual
+There is also a [base plugin](https://vanniktech.github.io/gradle-maven-publish-plugin/base/) which removes any automatic configuration and allows for a more manual
 configuration of what should be published.
 
 # License

--- a/docs/central.md
+++ b/docs/central.md
@@ -43,10 +43,12 @@ This can be done through either the DSL or by setting Gradle properties.
 === "build.gradle"
 
     ```groovy
+    import com.vanniktech.maven.publish.SonatypeHost
+
     mavenPublishing {
-      publishToMavenCentral("DEFAULT")
+      publishToMavenCentral(SonatypeHost.DEFAULT)
       // or when publishing to https://s01.oss.sonatype.org
-      publishToMavenCentral("S01")
+      publishToMavenCentral(SonatypeHost.S01)
 
       signAllPublications()
     }
@@ -55,6 +57,8 @@ This can be done through either the DSL or by setting Gradle properties.
 === "build.gradle.kts"
 
     ```kotlin
+    import com.vanniktech.maven.publish.SonatypeHost
+
     mavenPublishing {
       publishToMavenCentral(SonatypeHost.DEFAULT)
       // or when publishing to https://s01.oss.sonatype.org
@@ -250,16 +254,20 @@ by adding an extra parameter in the DSL or setting a Gradle property
 === "build.gradle"
 
     ```groovy
+    import com.vanniktech.maven.publish.SonatypeHost
+
     mavenPublishing {
-      publishToMavenCentral("DEFAULT", true)
+      publishToMavenCentral(SonatypeHost.DEFAULT, true)
       // or when publishing to https://s01.oss.sonatype.org
-      publishToMavenCentral("S01", true)
+      publishToMavenCentral(SonatypeHost.S01, true)
     }
     ```
 
 === "build.gradle.kts"
 
     ```kotlin
+    import com.vanniktech.maven.publish.SonatypeHost
+
     mavenPublishing {
       publishToMavenCentral(SonatypeHost.DEFAULT, true)
       // or when publishing to https://s01.oss.sonatype.org


### PR DESCRIPTION
- Always link to the website pages so that the links in the readme don't go to markdown files which don't have the tabs.
- Fix the syntax for `publishToMavenCentral` in Groovy, while `publishToMavenCentral("S01")` works and automatically maps to the enum value, `publishToMavenCentral("S01", true)` will not work so I switched both of them to use the enum directly. Also added the imports to the Kotlin snippets