### PR TITLE
update versions used in tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,13 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: JDK ${{ matrix.java_version }}
+    name: JDK ${{ matrix.java_version }}, Config ${{ matrix.test_config_method }}
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         java_version: [11, 17]
+        test_config_method: ["DSL", "PROPERTIES"]
 
     steps:
       - name: Checkout
@@ -27,4 +28,4 @@ jobs:
       - uses: gradle/gradle-build-action@v2
 
       - name: Build with Gradle
-        run: ./gradlew build --stacktrace
+        run: ./gradlew build --stacktrace -DtestConfigMethod=${{ matrix.test_config_method }}

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -66,10 +66,11 @@ val integrationTest by tasks.registering(Test::class) {
 
   useJUnitPlatform()
   testLogging.showStandardStreams = true
-  maxHeapSize = "1g"
+  maxHeapSize = "2g"
   jvmArgs("--add-opens", "java.base/java.util=ALL-UNNAMED")
 
   systemProperty("com.vanniktech.publish.version", version.toString())
+  systemProperty("testConfigMethod", System.getProperty("testConfigMethod", "DSL"))
 
   beforeTest(
     closureOf<TestDescriptor> {

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest2.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest2.kt
@@ -12,8 +12,7 @@ class MavenPublishPluginIntegrationTest2 {
   @TempDir
   lateinit var testProjectDir: Path
 
-  @TestParameter
-  lateinit var config: TestOptions.Config
+  private val config: TestOptions.Config = TestOptions.Config.valueOf(System.getProperty("testConfigMethod"))
 
   @TestParameter
   lateinit var signing: TestOptions.Signing
@@ -118,11 +117,11 @@ class MavenPublishPluginIntegrationTest2 {
     val result = project.run(fixtures, testProjectDir, testOptions)
 
     assertThat(result).outcome().succeeded()
-    assertThat(result).artifact("jar").exists()
-    assertThat(result).artifact("jar").isSignedIfNeeded()
+    assertThat(result).artifact("klib").exists()
+    assertThat(result).artifact("klib").isSignedIfNeeded()
     assertThat(result).pom().exists()
     assertThat(result).pom().isSignedIfNeeded()
-    assertThat(result).pom().matchesExpectedPom(kotlinStdlibJs(kotlinVersion))
+    assertThat(result).pom().matchesExpectedPom("klib", kotlinStdlibJs(kotlinVersion))
     assertThat(result).module().exists()
     assertThat(result).module().isSignedIfNeeded()
     assertThat(result).sourcesJar().exists()

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecs.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecs.kt
@@ -75,7 +75,7 @@ fun kotlinJsProjectSpec(version: KotlinVersion) = ProjectSpec(
   ),
   buildFileExtra = """
     kotlin {
-        js {
+        js("IR") {
             nodejs()
         }
     }
@@ -114,6 +114,14 @@ fun androidLibraryKotlinProjectSpec(agpVersion: AgpVersion, kotlinVersion: Kotli
     plugins = plainAndroidProject.plugins + kotlinAndroidPlugin.copy(version = kotlinVersion.value),
     sourceFiles = plainAndroidProject.sourceFiles + listOf(
       "src/main/kotlin" to "com/vanniktech/maven/publish/test/KotlinTestClass.kt"
-    )
+    ),
+    buildFileExtra = plainAndroidProject.buildFileExtra + """
+
+      kotlin {
+          jvmToolchain {
+              languageVersion.set(JavaLanguageVersion.of("8"))
+          }
+      }
+    """.trimIndent()
   )
 }

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -21,33 +21,43 @@ enum class AgpVersion(
   val minGradleVersion: GradleVersion,
   val firstUnsupportedGradleVersion: GradleVersion? = null,
 ) {
+  // minimum supported
   AGP_7_1(
     value = "7.1.2",
     minGradleVersion = GradleVersion.GRADLE_7_2,
     firstUnsupportedGradleVersion = GradleVersion.GRADLE_8_0,
   ),
+  // stable
   AGP_7_3(
     value = "7.3.1",
     minGradleVersion = GradleVersion.GRADLE_7_4,
   ),
+  // beta channel
   AGP_7_4(
     value = "7.4.0-rc01",
     minGradleVersion = GradleVersion.GRADLE_7_5,
   ),
+  // canary channel
   AGP_8_0(
     value = "8.0.0-alpha09",
-    minGradleVersion = GradleVersion.GRADLE_7_6,
+    minGradleVersion = GradleVersion.GRADLE_8_0,
   ),
 }
 
 enum class KotlinVersion(val value: String) {
+  // stable
   KT_1_7("1.7.20"),
+  // preview
+  KT_1_8("1.8.0-RC2"),
 }
 
 enum class GradleVersion(val value: String) {
+  // minimum supported
   GRADLE_7_2("7.2"),
+  // stable
   GRADLE_7_6("7.6"),
-  GRADLE_8_0("8.0-milestone-1"),
+  // preview
+  GRADLE_8_0("8.0-milestone-6"),
   ;
 
   companion object {

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -72,7 +72,7 @@ private fun Project.configurePlatform() {
   }
 
   plugins.withId("com.android.library") {
-    // afterEvaluate is too late but we can't run this synchronously because we shouldn't call the APIs for
+    // afterEvaluate is too late, but we can't run this synchronously because we shouldn't call the APIs for
     // multiplatform projects that use Android
     androidComponents.finalizeDsl {
       if (!plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")) {


### PR DESCRIPTION
- use latest Gradle 8 milestone
- test against Kotlin 1.8.0 rc2 
  - requires using IR for Kotlin JS which will change the created artifact type to klib
  - requires setting a toolchain version so that the KotlinCompile task's target does match the JavaCompile target
- since adding Kotlin 1.8 multiplies the number of executed tests I've changed `TestOptions.Config` to be based on a passed in system property which allows to split the tests across 2 separate Github Action jobs