### PR TITLE
improve sharding set up by running all variants by default

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -70,11 +70,11 @@ val integrationTest by tasks.registering(Test::class) {
   jvmArgs("--add-opens", "java.base/java.util=ALL-UNNAMED")
 
   systemProperty("com.vanniktech.publish.version", version.toString())
-  systemProperty("testConfigMethod", System.getProperty("testConfigMethod", "DSL"))
+  systemProperty("testConfigMethod", System.getProperty("testConfigMethod"))
 
   beforeTest(
     closureOf<TestDescriptor> {
-      logger.lifecycle("Running test: $this")
+      logger.lifecycle("Running test: ${this.className} ${this.displayName}")
     }
   )
 }

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest2.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest2.kt
@@ -12,7 +12,8 @@ class MavenPublishPluginIntegrationTest2 {
   @TempDir
   lateinit var testProjectDir: Path
 
-  private val config: TestOptions.Config = TestOptions.Config.valueOf(System.getProperty("testConfigMethod"))
+  @TestParameter(valuesProvider = TestOptionsConfigProvider::class)
+  lateinit var config: TestOptions.Config
 
   @TestParameter
   lateinit var signing: TestOptions.Signing

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptionsConfigProvider.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptionsConfigProvider.kt
@@ -1,0 +1,14 @@
+package com.vanniktech.maven.publish
+
+import com.google.common.collect.ImmutableList
+import com.google.testing.junit.testparameterinjector.junit5.TestParameter.TestParameterValuesProvider
+
+internal class TestOptionsConfigProvider : TestParameterValuesProvider {
+  override fun provideValues(): ImmutableList<TestOptions.Config?> {
+    val property = System.getProperty("testConfigMethod")
+    if (property.isNotBlank()) {
+      return ImmutableList.of(TestOptions.Config.valueOf(property))
+    }
+    return ImmutableList.copyOf(TestOptions.Config.values())
+  }
+}


### PR DESCRIPTION
Changes the default to be to run all variants of the test instead of having a default value for the system property. This makes running a specific test method locally nicer. Since the parameters goes through `TestParameter` again it means also that the test name includes which config is used.

Also changed the Gradle test output from
```
Running test: Test minimalPomProject()[1](com.vanniktech.maven.publish.MavenPublishPluginIntegrationTest2)
```
to
```
Running test: com.vanniktech.maven.publish.MavenPublishPluginIntegrationTest2 minimalPomProject[PROPERTIES,NO_SIGNING,GRADLE_7_2]
```