### PR TITLE
migrate java-gradle-plugin issue, update pom workaround

### DIFF
--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest2.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginIntegrationTest2.kt
@@ -64,6 +64,36 @@ class MavenPublishPluginIntegrationTest2 {
   }
 
   @TestParameterInjectorTest
+  fun javaGradlePluginProject() {
+    val project = javaGradlePluginProjectSpec()
+    val result = project.run(fixtures, testProjectDir, testOptions)
+
+    assertThat(result).outcome().succeeded()
+    assertThat(result).artifact("jar").exists()
+    assertThat(result).artifact("jar").isSignedIfNeeded()
+    assertThat(result).pom().exists()
+    assertThat(result).pom().isSignedIfNeeded()
+    assertThat(result).pom().matchesExpectedPom()
+    assertThat(result).module().exists()
+    assertThat(result).module().isSignedIfNeeded()
+    assertThat(result).sourcesJar().exists()
+    assertThat(result).sourcesJar().isSignedIfNeeded()
+    assertThat(result).sourcesJar().containsAllSourceFiles()
+    assertThat(result).javadocJar().exists()
+    assertThat(result).javadocJar().isSignedIfNeeded()
+
+    val pluginId = "com.example.test-plugin"
+    val pluginMarkerSpec = project.copy(group = pluginId, artifactId = "$pluginId.gradle.plugin")
+    val pluginMarkerResult = result.copy(projectSpec = pluginMarkerSpec)
+    assertThat(pluginMarkerResult).pom().exists()
+    assertThat(pluginMarkerResult).pom().isSignedIfNeeded()
+    assertThat(pluginMarkerResult).pom().matchesExpectedPom(
+      "pom",
+      PomDependency("com.example", "test-artifact", "1.0.0", null)
+    )
+  }
+
+  @TestParameterInjectorTest
   fun javaLibraryWithToolchainProject() {
     val project = javaLibraryProjectSpec().copy(
       buildFileExtra = """

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/Pom.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/Pom.kt
@@ -6,7 +6,7 @@ import org.apache.maven.model.License
 import org.apache.maven.model.Model
 import org.apache.maven.model.Scm
 
-data class PomDependency(val groupId: String, val artifactId: String, val version: String, val scope: String)
+data class PomDependency(val groupId: String, val artifactId: String, val version: String, val scope: String?)
 
 fun kotlinStdlibJdk(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", "kotlin-stdlib-jdk8", version.value, "compile")
 fun kotlinStdlibJs(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", "kotlin-stdlib-js", version.value, "compile")

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecs.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecs.kt
@@ -2,6 +2,7 @@ package com.vanniktech.maven.publish
 
 val javaPlugin = PluginSpec("java")
 val javaLibraryPlugin = PluginSpec("java-library")
+val javaGradlePluginPlugin = PluginSpec("java-gradle-plugin")
 val kotlinJvmPlugin = PluginSpec("org.jetbrains.kotlin.jvm")
 val kotlinMultiplatformPlugin = PluginSpec("org.jetbrains.kotlin.multiplatform")
 val kotlinJsPlugin = PluginSpec("org.jetbrains.kotlin.js")
@@ -51,6 +52,30 @@ fun javaLibraryProjectSpec() = ProjectSpec(
   sourceFiles = listOf(
     SourceFile("main", "java", "com/vanniktech/maven/publish/test/JavaTestClass.java"),
   )
+)
+
+fun javaGradlePluginProjectSpec() = ProjectSpec(
+  plugins = listOf(
+    javaGradlePluginPlugin,
+  ),
+  group = "com.example",
+  artifactId = "test-artifact",
+  version = "1.0.0",
+  properties = defaultProperties,
+  sourceFiles = listOf(
+    SourceFile("main", "java", "com/vanniktech/maven/publish/test/JavaTestClass.java"),
+  ),
+  buildFileExtra = """
+    gradlePlugin {
+        plugins {
+            mavenPublishPlugin {
+                // the id here should be different from the group id and artifact id
+                id = 'com.example.test-plugin'
+                implementationClass = 'com.vanniktech.maven.publish.test.TestPlugin'
+            }
+        }
+    }
+  """.trimIndent()
 )
 
 fun kotlinJvmProjectSpec(version: KotlinVersion) = ProjectSpec(

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -53,7 +53,7 @@ enum class KotlinVersion(val value: String) {
 
 enum class GradleVersion(val value: String) {
   // minimum supported
-  GRADLE_7_2("7.2"),
+  GRADLE_7_3("7.3"),
   // stable
   GRADLE_7_6("7.6"),
   // preview
@@ -62,6 +62,7 @@ enum class GradleVersion(val value: String) {
 
   companion object {
     // aliases for the skipped version to be able to reference the correct one in AgpVersion
+    val GRADLE_7_2 = GRADLE_7_3
     val GRADLE_7_4 = GRADLE_7_6
     val GRADLE_7_5 = GRADLE_7_6
   }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -147,7 +147,10 @@ abstract class MavenPublishBaseExtension(
   @Incubating
   fun pom(configure: Action<in MavenPom>) {
     project.mavenPublications {
-      it.pom(configure)
+      // without afterEvaluate https://github.com/gradle/gradle/issues/12259 will happen
+      project.afterEvaluate {
+        pom(configure)
+      }
     }
   }
 
@@ -159,84 +162,81 @@ abstract class MavenPublishBaseExtension(
     pomFromProperties.set(true)
     pomFromProperties.finalizeValue()
 
-    // without afterEvaluate https://github.com/gradle/gradle/issues/12259 will happen
-    project.afterEvaluate {
-      pom { pom ->
-        val name = project.findOptionalProperty("POM_NAME")
-        if (name != null) {
-          pom.name.set(name)
-        }
-        val description = project.findOptionalProperty("POM_DESCRIPTION")
-        if (description != null) {
-          pom.description.set(description)
-        }
-        val url = project.findOptionalProperty("POM_URL")
-        if (url != null) {
-          pom.url.set(url)
-        }
-        val inceptionYear = project.findOptionalProperty("POM_INCEPTION_YEAR")
-        if (inceptionYear != null) {
-          pom.inceptionYear.set(inceptionYear)
-        }
+    pom { pom ->
+      val name = project.findOptionalProperty("POM_NAME")
+      if (name != null) {
+        pom.name.set(name)
+      }
+      val description = project.findOptionalProperty("POM_DESCRIPTION")
+      if (description != null) {
+        pom.description.set(description)
+      }
+      val url = project.findOptionalProperty("POM_URL")
+      if (url != null) {
+        pom.url.set(url)
+      }
+      val inceptionYear = project.findOptionalProperty("POM_INCEPTION_YEAR")
+      if (inceptionYear != null) {
+        pom.inceptionYear.set(inceptionYear)
+      }
 
-        val issueManagementSystem = project.findOptionalProperty("POM_ISSUE_SYSTEM")
-        val issueManagementUrl = project.findOptionalProperty("POM_ISSUE_URL")
-        if (issueManagementSystem != null || issueManagementUrl != null) {
-          pom.issueManagement {
-            it.system.set(issueManagementSystem)
-            it.url.set(issueManagementUrl)
+      val issueManagementSystem = project.findOptionalProperty("POM_ISSUE_SYSTEM")
+      val issueManagementUrl = project.findOptionalProperty("POM_ISSUE_URL")
+      if (issueManagementSystem != null || issueManagementUrl != null) {
+        pom.issueManagement {
+          it.system.set(issueManagementSystem)
+          it.url.set(issueManagementUrl)
+        }
+      }
+
+      val scmUrl = project.findOptionalProperty("POM_SCM_URL")
+      val scmConnection = project.findOptionalProperty("POM_SCM_CONNECTION")
+      val scmDeveloperConnection = project.findOptionalProperty("POM_SCM_DEV_CONNECTION")
+      if (scmUrl != null || scmConnection != null || scmDeveloperConnection != null) {
+        pom.scm {
+          it.url.set(scmUrl)
+          it.connection.set(scmConnection)
+          it.developerConnection.set(scmDeveloperConnection)
+        }
+      }
+
+      val licenceName = project.findOptionalProperty("POM_LICENCE_NAME")
+      val licenceUrl = project.findOptionalProperty("POM_LICENCE_URL")
+      val licenceDistribution = project.findOptionalProperty("POM_LICENCE_DIST")
+      if (licenceName != null || licenceUrl != null || licenceDistribution != null) {
+        pom.licenses { licences ->
+          licences.license {
+            it.name.set(licenceName)
+            it.url.set(licenceUrl)
+            it.distribution.set(licenceDistribution)
           }
         }
+      }
 
-        val scmUrl = project.findOptionalProperty("POM_SCM_URL")
-        val scmConnection = project.findOptionalProperty("POM_SCM_CONNECTION")
-        val scmDeveloperConnection = project.findOptionalProperty("POM_SCM_DEV_CONNECTION")
-        if (scmUrl != null || scmConnection != null || scmDeveloperConnection != null) {
-          pom.scm {
-            it.url.set(scmUrl)
-            it.connection.set(scmConnection)
-            it.developerConnection.set(scmDeveloperConnection)
+      val licenseName = project.findOptionalProperty("POM_LICENSE_NAME")
+      val licenseUrl = project.findOptionalProperty("POM_LICENSE_URL")
+      val licenseDistribution = project.findOptionalProperty("POM_LICENSE_DIST")
+      if (licenseName != null || licenseUrl != null || licenseDistribution != null) {
+        pom.licenses { licenses ->
+          licenses.license {
+            it.name.set(licenseName)
+            it.url.set(licenseUrl)
+            it.distribution.set(licenseDistribution)
           }
         }
+      }
 
-        val licenceName = project.findOptionalProperty("POM_LICENCE_NAME")
-        val licenceUrl = project.findOptionalProperty("POM_LICENCE_URL")
-        val licenceDistribution = project.findOptionalProperty("POM_LICENCE_DIST")
-        if (licenceName != null || licenceUrl != null || licenceDistribution != null) {
-          pom.licenses { licences ->
-            licences.license {
-              it.name.set(licenceName)
-              it.url.set(licenceUrl)
-              it.distribution.set(licenceDistribution)
-            }
-          }
-        }
-
-        val licenseName = project.findOptionalProperty("POM_LICENSE_NAME")
-        val licenseUrl = project.findOptionalProperty("POM_LICENSE_URL")
-        val licenseDistribution = project.findOptionalProperty("POM_LICENSE_DIST")
-        if (licenseName != null || licenseUrl != null || licenseDistribution != null) {
-          pom.licenses { licenses ->
-            licenses.license {
-              it.name.set(licenseName)
-              it.url.set(licenseUrl)
-              it.distribution.set(licenseDistribution)
-            }
-          }
-        }
-
-        val developerId = project.findOptionalProperty("POM_DEVELOPER_ID")
-        val developerName = project.findOptionalProperty("POM_DEVELOPER_NAME")
-        val developerUrl = project.findOptionalProperty("POM_DEVELOPER_URL")
-        val developerEmail = project.findOptionalProperty("POM_DEVELOPER_EMAIL")
-        if (developerId != null || developerName != null || developerUrl != null) {
-          pom.developers { developers ->
-            developers.developer {
-              it.id.set(developerId)
-              it.name.set(developerName)
-              it.url.set(developerUrl)
-              it.email.set(developerEmail)
-            }
+      val developerId = project.findOptionalProperty("POM_DEVELOPER_ID")
+      val developerName = project.findOptionalProperty("POM_DEVELOPER_NAME")
+      val developerUrl = project.findOptionalProperty("POM_DEVELOPER_URL")
+      val developerEmail = project.findOptionalProperty("POM_DEVELOPER_EMAIL")
+      if (developerId != null || developerName != null || developerUrl != null) {
+        pom.developers { developers ->
+          developers.developer {
+            it.id.set(developerId)
+            it.name.set(developerName)
+            it.url.set(developerUrl)
+            it.email.set(developerEmail)
           }
         }
       }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -146,10 +146,10 @@ abstract class MavenPublishBaseExtension(
    */
   @Incubating
   fun pom(configure: Action<in MavenPom>) {
-    project.mavenPublications {
+    project.mavenPublications { publication ->
       // without afterEvaluate https://github.com/gradle/gradle/issues/12259 will happen
       project.afterEvaluate {
-        pom(configure)
+        publication.pom(configure)
       }
     }
   }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBasePlugin.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBasePlugin.kt
@@ -36,6 +36,6 @@ open class MavenPublishBasePlugin : Plugin<Project> {
   }
 
   private companion object {
-    val MIN_GRADLE_VERSION: GradleVersion = GradleVersion.version("7.2")
+    val MIN_GRADLE_VERSION: GradleVersion = GradleVersion.version("7.3")
   }
 }


### PR DESCRIPTION
With the new test I noticed that setting the name/description on the plugin marker did not work on the plugin marker for
- Gradle 7.2 when configuring through properties
- any Gradle version when configuring through the DSL

To fix that I moved the afterEvaluate that we had in `pomFromGradleProperties` to `pom` so that it covers both and I bumped the minimum Gradle version to 7.3. 

Since this pr contains functional changes I will delete the original gradle plugin test in a follow up.