### PR TITLE
also setup test fixtures sources jar for Kotlin/JVM, suppress warnings

### DIFF
--- a/plugin/src/integrationTest/fixtures2/src/testFixtures/kotlin/com/vanniktech/maven/publish/test/TestFixtureKotlinClass.kt
+++ b/plugin/src/integrationTest/fixtures2/src/testFixtures/kotlin/com/vanniktech/maven/publish/test/TestFixtureKotlinClass.kt
@@ -1,0 +1,6 @@
+package com.vanniktech.maven.publish.test
+
+/**
+ * Just a test fixture class in Kotlin.
+ */
+public class TestFixtureKotlinClass

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -439,7 +439,6 @@ private fun setupTestFixtures(project: Project, sourcesJar: Boolean) {
       it.suppressPomMetadataWarningsFor("testFixturesApiElements")
       it.suppressPomMetadataWarningsFor("testFixturesRuntimeElements")
       it.suppressPomMetadataWarningsFor("testFixturesSourcesElements")
-
     }
   }
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -430,7 +430,6 @@ private fun setupTestFixtures(project: Project, sourcesJar: Boolean) {
     if (sourcesJar) {
       // TODO: remove after https://github.com/gradle/gradle/issues/20539 is resolved
       project.serviceOf<JvmModelingServices>().createJvmVariant("testFixtures") {
-        it.exposesApi()
         it.withSourcesJar().published()
       }
     }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -57,14 +57,7 @@ data class JavaLibrary @JvmOverloads constructor(
       it.withJavadocJar { project.javadocJarTask(javadocJar) }
     }
 
-    if (sourcesJar) {
-      // TODO: remove after https://github.com/gradle/gradle/issues/20539 is resolved
-      project.plugins.withId("java-test-fixtures") {
-        project.serviceOf<JvmModelingServices>().createJvmVariant("testFixtures") {
-          it.withSourcesJar().published()
-        }
-      }
-    }
+    setupTestFixtures(project, sourcesJar)
   }
 }
 
@@ -278,6 +271,8 @@ data class KotlinJvm @JvmOverloads constructor(
       it.withSourcesJar { project.javaSourcesJar(sourcesJar) }
       it.withJavadocJar { project.javadocJarTask(javadocJar) }
     }
+
+    setupTestFixtures(project, sourcesJar)
   }
 }
 
@@ -427,6 +422,26 @@ private fun MavenPublication.withJavadocJar(factory: () -> TaskProvider<*>?) {
   val task = factory()
   if (task != null) {
     artifact(task)
+  }
+}
+
+private fun setupTestFixtures(project: Project, sourcesJar: Boolean) {
+  project.plugins.withId("java-test-fixtures") {
+    if (sourcesJar) {
+      // TODO: remove after https://github.com/gradle/gradle/issues/20539 is resolved
+      project.serviceOf<JvmModelingServices>().createJvmVariant("testFixtures") {
+        it.exposesApi()
+        it.withSourcesJar().published()
+      }
+    }
+
+    // test fixtures can't be mapped to the POM because there is no equivalent concept in Maven
+    project.mavenPublications {
+      it.suppressPomMetadataWarningsFor("testFixturesApiElements")
+      it.suppressPomMetadataWarningsFor("testFixturesRuntimeElements")
+      it.suppressPomMetadataWarningsFor("testFixturesSourcesElements")
+
+    }
   }
 }
 


### PR DESCRIPTION
Forgot that Kotlin/JVM projects are configured separately from java/java-library when I added the workaround to publish sources for test fixtures. It is now applied to both of them.

Also added supressions for the following warnings that always appear when publishing a project with test fixtures, regardless of the sources. They happen because there is no concept like a test fixture dependency in Maven so it can't be reflected in the POM.
```
Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetadataWarningsFor(variant)'):
  - Variant testFixturesApiElements:
      - Declares capability :eithernet-test-fixtures:unspecified which cannot be mapped to Maven
  - Variant testFixturesRuntimeElements:
      - Declares capability :eithernet-test-fixtures:unspecified which cannot be mapped to Maven
These issues indicate information that is lost in the published 'pom' metadata file, which may be an issue if the published library is consumed by an old Gradle version or Apache Maven.
The 'module' metadata file, which is used by Gradle 6+ is not affected.
```