### PR TITLE
add workaround for test fixtures issue

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -23,9 +23,9 @@ abstract class MavenPublishBaseExtension(
 
   private val sonatypeHost: Property<SonatypeHost> = project.objects.property(SonatypeHost::class.java)
   private val signing: Property<Boolean> = project.objects.property(Boolean::class.java)
-  private val groupId: Property<String> = project.objects.property(String::class.java)
+  internal val groupId: Property<String> = project.objects.property(String::class.java)
     .convention(project.provider { project.group.toString() })
-  private val version: Property<String> = project.objects.property(String::class.java)
+  internal val version: Property<String> = project.objects.property(String::class.java)
     .convention(project.provider { project.version.toString() })
   private val pomFromProperties: Property<Boolean> = project.objects.property(Boolean::class.java)
   private val platform: Property<Platform> = project.objects.property(Platform::class.java)

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -6,7 +6,6 @@ import com.vanniktech.maven.publish.tasks.SourcesJar.Companion.javaSourcesJar
 import com.vanniktech.maven.publish.tasks.SourcesJar.Companion.kotlinSourcesJar
 import org.gradle.api.Project
 import org.gradle.api.plugins.jvm.internal.JvmModelingServices
-import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.TaskProvider

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -6,6 +6,7 @@ import com.vanniktech.maven.publish.tasks.SourcesJar.Companion.javaSourcesJar
 import com.vanniktech.maven.publish.tasks.SourcesJar.Companion.kotlinSourcesJar
 import org.gradle.api.Project
 import org.gradle.api.plugins.jvm.internal.JvmModelingServices
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.TaskProvider
@@ -441,11 +442,13 @@ private fun setupTestFixtures(project: Project, sourcesJar: Boolean) {
       it.suppressPomMetadataWarningsFor("testFixturesSourcesElements")
     }
 
-    // Gradle will put the project group and version into capabilities instead of using
-    // the publication, this can lead to invalid published metadata
-    // TODO remove after https://github.com/gradle/gradle/issues/23354 is resolved
-    project.group = project.baseExtension.groupId
-    project.version = project.baseExtension.version
+    project.afterEvaluate {
+      // Gradle will put the project group and version into capabilities instead of using
+      // the publication, this can lead to invalid published metadata
+      // TODO remove after https://github.com/gradle/gradle/issues/23354 is resolved
+      project.group = project.baseExtension.groupId.get()
+      project.version = project.baseExtension.version.get()
+    }
   }
 }
 

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -440,6 +440,12 @@ private fun setupTestFixtures(project: Project, sourcesJar: Boolean) {
       it.suppressPomMetadataWarningsFor("testFixturesRuntimeElements")
       it.suppressPomMetadataWarningsFor("testFixturesSourcesElements")
     }
+
+    // Gradle will put the project group and version into capabilities instead of using
+    // the publication, this can lead to invalid published metadata
+    // TODO remove after https://github.com/gradle/gradle/issues/23354 is resolved
+    project.group = project.baseExtension.groupId
+    project.version = project.baseExtension.version
   }
 }
 


### PR DESCRIPTION
This started happening now because of the change to not set project.group and version anymore. As a workaround we will start doing that again but only when the test-fixtures plugin is applied. Unfortunately there doesn't seem to be a way to modify capabilities. The only other way would be to rewrite the generated metadata file on our own but that seems a lot more error prone to me.

@ZacSweers already tested this manually in eithernet https://github.com/slackhq/EitherNet/commit/27270d75ae9bdb1e7b1479ba9ef87f30f66a32a1

Filed Gradle issue https://github.com/gradle/gradle/issues/23354