### PR TITLE
make finding a staging profile more lenient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 0.23.2 **UNRELEASED**
 
-- Fix signing when using the final Gradle 8.0 release. 
+- Fix signing when using the final Gradle 8.0 release.
+- Finding a matching staging profile in Sonatype is more lenient. If there is just one that one will always be used.
+  The plugin will also fallback to any staging profile that has a matching prefix with the group id.
 - As a workaround for an issue in Gradle that causes invalid module metadata for `java-test-fixtures` projects, `project.group`
   and `project.version` are now being set again for those projects. [#490](https://github.com/vanniktech/gradle-maven-publish-plugin/pull/490)
 

--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
@@ -48,12 +48,24 @@ class Nexus(
       throw IllegalArgumentException("No staging profiles found in account $username. Make sure you called \"./gradlew publish\".")
     }
 
-    val candidateProfiles = allProfiles.filter { group == it.name || group.startsWith(it.name) }
+    if (allProfiles.size == 1) {
+      return allProfiles[0]
+    }
+
+    var candidateProfiles = allProfiles.filter { group == it.name }
+
+    if (candidateProfiles.isEmpty()) {
+      candidateProfiles = allProfiles.filter { group.startsWith(it.name) }
+    }
+
+    if (candidateProfiles.isEmpty()) {
+      candidateProfiles = allProfiles.filter { group.commonPrefixWith(it.name).isNotEmpty() }
+    }
 
     if (candidateProfiles.isEmpty()) {
       throw IllegalArgumentException(
         "No matching staging profile found in account $username. It is expected that the account contains a staging " +
-          "profile that matches or is the start of $group." +
+          "profile that matches or is the start of $group. " +
           "Available profiles are: ${allProfiles.joinToString(separator = ", ") { it.name }}"
       )
     }

--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
@@ -52,15 +52,9 @@ class Nexus(
       return allProfiles[0]
     }
 
-    var candidateProfiles = allProfiles.filter { group == it.name }
-
-    if (candidateProfiles.isEmpty()) {
-      candidateProfiles = allProfiles.filter { group.startsWith(it.name) }
-    }
-
-    if (candidateProfiles.isEmpty()) {
-      candidateProfiles = allProfiles.filter { group.commonPrefixWith(it.name).isNotEmpty() }
-    }
+    val candidateProfiles = allProfiles.filter { group == it.name }
+      .ifEmpty { allProfiles.filter { group.startsWith(it.name) } }
+      .ifEmpty { allProfiles.filter { group.commonPrefixWith(it.name).isNotEmpty() } }
 
     if (candidateProfiles.isEmpty()) {
       throw IllegalArgumentException(


### PR DESCRIPTION
Closes #496 

The logic is now:
- if there is just one profile always use that regardless of whether the name matches
- profile that equals the group id
- profile that is a prefix for the group id
- profile that shares a prefix with the group id