### PR TITLE
use worker API for CreateSonatypeRepositoryTask

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -62,7 +62,17 @@ abstract class MavenPublishBaseExtension(
 
     val versionIsSnapshot = version.map { it.endsWith("-SNAPSHOT") }
     val createRepository = project.tasks.registerCreateRepository(groupId, versionIsSnapshot, buildService)
-    val stagingRepositoryId = createRepository.flatMap { it.stagingRepositoryId }
+    val stagingRepositoryId = buildService.map {
+      requireNotNull(it.stagingRepositoryId) {
+        @Suppress("UnstableApiUsage")
+        if (project.gradle.startParameter.isConfigurationCacheRequested) {
+          "Publishing releases to Maven Central is not supported yet with configuration caching enabled, because of " +
+            "this missing Gradle feature: https://github.com/gradle/gradle/issues/22779"
+        } else {
+          "The staging repository was not created yet. Please open a bug with a build scan or build logs and stacktrace"
+        }
+      }
+    }
 
     project.gradlePublishing.repositories.maven { repo ->
       repo.name = "mavenCentral"

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
@@ -1,5 +1,6 @@
 package com.vanniktech.maven.publish.sonatype
 
+import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
@@ -7,6 +8,10 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.gradle.workers.WorkQueue
+import org.gradle.workers.WorkerExecutor
 
 internal abstract class CreateSonatypeRepositoryTask : DefaultTask() {
 
@@ -17,30 +22,47 @@ internal abstract class CreateSonatypeRepositoryTask : DefaultTask() {
   abstract val versionIsSnapshot: Property<Boolean>
 
   @get:Internal
-  abstract val stagingRepositoryId: Property<String>
-
-  @get:Internal
   abstract val buildService: Property<SonatypeRepositoryBuildService>
+
+  @Inject
+  abstract fun getWorkerExecutor(): WorkerExecutor?
 
   @TaskAction
   fun createStagingRepository() {
-    if (versionIsSnapshot.get()) {
-      return
+    val workQueue: WorkQueue = getWorkerExecutor()!!.noIsolation()
+    workQueue.submit(CreateStagingRepository::class.java) {
+      requireNotNull(it)
+      it.projectGroup.set(projectGroup)
+      it.versionIsSnapshot.set(versionIsSnapshot)
+      it.buildService.set(buildService)
     }
 
-    val service = this.buildService.get()
+  }
 
-    // if repository was already created in this build this is a no-op
-    val currentStagingRepositoryId = service.stagingRepositoryId
-    if (currentStagingRepositoryId != null) {
-      stagingRepositoryId.set(currentStagingRepositoryId)
-      return
+  internal interface CreateStagingRepositoryParameters : WorkParameters {
+    val projectGroup: Property<String>
+    val versionIsSnapshot: Property<Boolean>
+    val buildService: Property<SonatypeRepositoryBuildService>
+  }
+
+  abstract class CreateStagingRepository : WorkAction<CreateStagingRepositoryParameters?> {
+    override fun execute() {
+      val parameters = requireNotNull(parameters)
+      if (parameters.versionIsSnapshot.get()) {
+        return
+      }
+
+      val service = parameters.buildService.get()
+
+      // if repository was already created in this build this is a no-op
+      val currentStagingRepositoryId = service.stagingRepositoryId
+      if (currentStagingRepositoryId != null) {
+        return
+      }
+
+      val id = service.nexus.createRepositoryForGroup(parameters.projectGroup.get())
+      service.stagingRepositoryId = id
     }
-
-    val id = service.nexus.createRepositoryForGroup(projectGroup.get())
-
-    service.stagingRepositoryId = id
-    stagingRepositoryId.set(id)
   }
 
   companion object {
@@ -62,3 +84,4 @@ internal abstract class CreateSonatypeRepositoryTask : DefaultTask() {
     }
   }
 }
+

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
@@ -25,11 +25,11 @@ internal abstract class CreateSonatypeRepositoryTask : DefaultTask() {
   abstract val buildService: Property<SonatypeRepositoryBuildService>
 
   @Inject
-  abstract fun getWorkerExecutor(): WorkerExecutor?
+  abstract fun getWorkerExecutor(): WorkerExecutor
 
   @TaskAction
   fun createStagingRepository() {
-    val workQueue: WorkQueue = getWorkerExecutor()!!.noIsolation()
+    val workQueue: WorkQueue = getWorkerExecutor().noIsolation()
     workQueue.submit(CreateStagingRepository::class.java) {
       requireNotNull(it)
       it.projectGroup.set(projectGroup)


### PR DESCRIPTION
Closes #516. I've limited it to the `CreateSonatypeRepositoryTask` because the closeAndRelease and the drop tasks are usually executed in separate Gradle invocations on their own. The automatic close and release is not running in a task and only runs after everything else in the build it completed, so workers can't be applied to it and wouldn't change anything here.

Build scan showing that tasks of the same project are now executed in parallel to CreateSonatypeRepositoryTask:
<img width="1084" alt="Screenshot 2023-02-19 at 11 54 00" src="https://user-images.githubusercontent.com/1358105/219943556-27d98620-963b-4b30-9574-cc558a5af33e.png">

Slightly better erorr message with config caching enabled:
```
* What went wrong:
Configuration cache state could not be cached: field `repository` of `org.gradle.api.publish.maven.tasks.PublishToMavenRepository$PublishSpec` bean found in field `value` of `org.gradle.internal.Try$Success` bean found in field `result` of `org.gradle.internal.serialization.Cached$Fixed` bean found in field `spec` of task `:nexus:publishMavenPublicationToMavenCentralRepository` of type `org.gradle.api.publish.maven.tasks.PublishToMavenRepository`: error writing value of type 'org.gradle.api.publish.maven.tasks.PublishToMavenRepository$RepositorySpec$Configured'
> Publishing releases to Maven Central is not supported yet with configuration caching enabled, because of this missing Gradle feature: https://github.com/gradle/gradle/issues/22779
```