### PR TITLE
deprecate constructor that allows changing sourcesJar in Kotlin/JS projects

### DIFF
--- a/docs/base.md
+++ b/docs/base.md
@@ -236,8 +236,8 @@ For projects using the `org.jetbrains.kotlin.js` plugin.
       // - `JavadocJar.None()` don't publish this artifact
       // - `JavadocJar.Empty()` publish an emprt jar
       // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
-      // the second whether to publish a sources jar
-      configure(new KotlinJs(new JavadocJar.Dokka("dokkaHtml"), true))
+      // sources publishing is always enabled by the Kotlin/JS plugin
+      configure(new KotlinJs(new JavadocJar.Dokka("dokkaHtml")))
     }
     ```
 
@@ -248,14 +248,13 @@ For projects using the `org.jetbrains.kotlin.js` plugin.
     import com.vanniktech.maven.publish.JavadocJar
 
     mavenPublishing {
+      // sources publishing is always enabled by the Kotlin/JS plugin
       configure(KotlinJs(
         // configures the -javadoc artifact, possible values:
         // - `JavadocJar.None()` don't publish this artifact
         // - `JavadocJar.Empty()` publish an emprt jar
         // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
         javadocJar = JavadocJar.Dokka("dokkaHtml"),
-        // whether to publish a sources jar
-        sourcesJar = true,
       ))
     }
     ```

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -294,10 +294,19 @@ data class KotlinJvm @JvmOverloads constructor(
  * ```
  * This does not include javadoc jars because there are no APIs for that available.
  */
-data class KotlinJs @JvmOverloads constructor(
-  override val javadocJar: JavadocJar = JavadocJar.Empty(),
-  override val sourcesJar: Boolean = true
+data class KotlinJs @Deprecated(
+  "Disabling sources publishing for Kotlin/JS is not supported since Kotlin 1.8.20. " +
+    "Use the single or no-arg constructors instead."
+) constructor(
+  override val javadocJar: JavadocJar,
+  override val sourcesJar: Boolean,
 ) : Platform() {
+
+  @Suppress("DEPRECATION")
+  @JvmOverloads
+  constructor(
+    javadocJar: JavadocJar = JavadocJar.Empty(),
+  ) : this(javadocJar, true)
 
   override fun configure(project: Project) {
     // Create publication, since Kotlin/JS doesn't provide one by default.


### PR DESCRIPTION
Follow up to #515 which disallows setting `sourcesJar` to false in Kotlin 1.8.20. With the deprecation anyone who might be using the API will be prepared for the behavior change.