### PR TITLE
update/enforce minimum supported Gradle/AGP/KPG versions

### DIFF
--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -26,10 +26,9 @@ enum class AgpVersion(
   val minJdkVersion: JavaVersion = JavaVersion.VERSION_11,
 ) {
   // minimum supported
-  AGP_7_1(
-    value = "7.1.2",
-    minGradleVersion = GradleVersion.GRADLE_7_2,
-    firstUnsupportedGradleVersion = GradleVersion.GRADLE_8_0,
+  AGP_7_3(
+    value = "7.3.1",
+    minGradleVersion = GradleVersion.GRADLE_7_4,
   ),
 
   // stable
@@ -40,14 +39,14 @@ enum class AgpVersion(
 
   // beta channel
   AGP_8_0(
-    value = "8.0.0-beta04",
+    value = "8.0.0-beta05",
     minGradleVersion = GradleVersion.GRADLE_8_0,
     minJdkVersion = JavaVersion.VERSION_17,
   ),
 
   // canary channel
   AGP_8_1(
-    value = "8.1.0-alpha07",
+    value = "8.1.0-alpha09",
     minGradleVersion = GradleVersion.GRADLE_8_0,
     minJdkVersion = JavaVersion.VERSION_17,
   ),
@@ -55,29 +54,28 @@ enum class AgpVersion(
 
 enum class KotlinVersion(val value: String) {
   // minimum supported
-  KT_1_7("1.7.20"),
+  KT_1_7("1.7.0"),
 
   // stable
   KT_1_8("1.8.10"),
 
   // preview
-  KT_1_8_BETA("1.8.20-Beta"),
+  KT_1_8_BETA("1.8.20-RC"),
 }
 
 enum class GradleVersion(val value: String) {
   // minimum supported
-  GRADLE_7_3("7.3"),
+  GRADLE_7_4("7.4"),
 
   // stable
   GRADLE_8_0("8.0.2"),
 
   // preview
-  GRADLE_8_1("8.1-20230302232219+0000"),
+  GRADLE_8_1("8.1-rc-1"),
   ;
 
   companion object {
     // aliases for the skipped version to be able to reference the correct one in AgpVersion
-    val GRADLE_7_2 = GRADLE_7_3
     val GRADLE_7_5 = GRADLE_8_0
     val GRADLE_7_6 = GRADLE_8_0
   }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
@@ -58,21 +58,3 @@ internal fun Project.isAtLeastUsingAndroidGradleVersion(major: Int, minor: Int, 
     false
   }
 }
-
-internal fun Project.isAtLeastUsingAndroidGradleVersionBeta(major: Int, minor: Int, patch: Int, beta: Int): Boolean {
-  return try {
-    androidComponents.pluginVersion >= AndroidPluginVersion(major, minor, patch).beta(beta)
-  } catch (e: NoClassDefFoundError) {
-    // was added in 7.0
-    false
-  }
-}
-
-internal fun Project.isAtLeastUsingAndroidGradleVersionAlpha(major: Int, minor: Int, patch: Int, alpha: Int): Boolean {
-  return try {
-    androidComponents.pluginVersion >= AndroidPluginVersion(major, minor, patch).alpha(alpha)
-  } catch (e: NoClassDefFoundError) {
-    // was added in 7.0
-    false
-  }
-}


### PR DESCRIPTION
Minimum Gradle version 7.4 (we support 4 minor stable releases)
Mininum AGP version: 7.3 (we support 2 minor stable releases)
Mininum KGP version: 1.7.0 (we support 2 minor stable releases), also enforced now by a runtime check

Also updates tested pre release versions to the latest.