### PR TITLE
changelog for 0.25.0

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Copy docs
         run: |
           cp README.md docs/index.md
+          cp CHANGELOG.md docs/changelog.md
           # Update page title
           sed -i 's/# gradle-maven-publish-plugin/# Overview/' docs/index.md
           # Update plugin version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Change Log
 
+## 0.25.0 **UNRELEASED**
+
+- The `createStagingRepository` task now uses the worker API which allows the project to built
+  in parallel to the creation of the staging repository.
+- Fix incompatibility with Kotlin 1.8.20-Beta for Kotlin/JS projects. The Kotlin/JS plugin is now taking
+  care of creating the sources jar on its own. Because of this the base plugin won't allow disabling
+  sources jar creation for Kotlin/JS projects anymore starting with 1.8.20. The `KotlinJs` constructor
+  with a `sourcesJar` parameter has been deprecated.
+- Fix incompatibility with Gradle 8.1 for `java-test-fixtures` projects
+- New minimum supported versions:
+  - Gradle 7.4
+  - Android Gradle Plugin 7.3.0
+  - Kotlin Gradle Plugin 1.7.0
+- Note: Starting with Kotlin 1.8.20-Beta the `common` sources jar for multiplatform projects will only contain
+  the sources of the common source set instead of containing the sources from all source sets.
+
+#### Configuration cache status
+
+Configuration cache is supported starting with **Gradle 7.6+** except for:
+- Builds with enabled signing, will be resolved in Gradle 8.1.
+- Publishing releases to Maven Central (snapshots are fine), blocked by [Gradle issue #22779](https://github.com/gradle/gradle/issues/22779).
+- Kotlin Multiplatform projects, blocked by [KT-49933](https://youtrack.jetbrains.com/issue/KT-49933).
+
+
 ## 0.24.0 *(2023-01-29)*
 
 - Support arbitrary Sonatype hosts instead of just oss.sonatype.org and s01.oss.sonatype.org.

--- a/docs/central.md
+++ b/docs/central.md
@@ -223,7 +223,25 @@ The result will be a very long single line string that looks like this
 lQdGBF4jUfwBEACblZV4uBViHcYLOb2280tEpr64iB9b6YRkWil3EODiiLd9JS3V...9pip+B1QLwEdLCEJA+3IIiw4qM5hnMw=
 ```
 
-## Publishing
+## Publishing snapshots
+
+Snapshots can be published by setting the version to something ending with `-SNAPSHOT`
+and then running the following Gradle task:
+
+```
+./gradlew publishAllPublicationsToMavenCentral
+```
+
+The snapshot will be automatically available in Sonatype's
+[snapshot repository](https://oss.sonatype.org/content/repositories/snapshots/) (or the
+[S01 snapshot repository](https://s01.oss.sonatype.org/content/repositories/snapshots/)) directly after the
+task finished.
+
+Signing is not required for snapshot builds, but if the configuration is present the build
+will still be signed.
+
+
+## Publishing releases
 
 The publishing process for Maven Central consists of several steps
 
@@ -236,7 +254,7 @@ The publishing process for Maven Central consists of several steps
 By running the following Gradle task the plugin will take care of steps 1 to 3 automatically:
 
 ```
-./gradlew publishAllPublicationsToMavenCentral
+./gradlew publishAllPublicationsToMavenCentral --no-configuration-cache
 ```
 
 The releasing step can be done manually by going to oss.sonatype.org (or s01.oss.sonatype.org) and

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
   - 'central.md'
   - 'other.md'
   - 'base.md'
+  - 'changelog.md'
 
 markdown_extensions:
   - smarty

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,11 @@ theme:
     primary: 'cyan'
     accent: 'purple'
   features:
+    - navigation.sections
+    - navigation.tracking
+    - navigation.tabs
     - content.tabs.link
+    - toc.integrate
 
 nav:
   - 'index.md'


### PR DESCRIPTION
Also
- adds section for publishing snapshots and explicitly adds `--no-configuration-cache` to the docs for releases to central
- adds changelog to website
- some tweaks to the mkdocs config 