### PR TITLE
add specific support to Gradle plugin publish plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@
   sources jar creation for Kotlin/JS projects anymore starting with 1.8.20. The `KotlinJs` constructor
   with a `sourcesJar` parameter has been deprecated.
 - Fix incompatibility with Gradle 8.1 for `java-test-fixtures` projects
+- Fix incompatibility with `com.gradle.plugin-publish` 1.0.0 and 1.1.0
 - New minimum supported versions:
   - Gradle 7.4
   - Android Gradle Plugin 7.3.0
   - Kotlin Gradle Plugin 1.7.0
+  - `com.gradle.plugin-publish` 1.0.0
 - Note: Starting with Kotlin 1.8.20-Beta the `common` sources jar for multiplatform projects will only contain
   the sources of the common source set instead of containing the sources from all source sets.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The output of the following Gradle plugins is supported to be published with thi
 - `java`
 - `java-library`
 - `java-gradle-plugin`
+- `com.gradle.plugin-publish`
 - `java-platform`
 - `version-catalog`
 

--- a/docs/base.md
+++ b/docs/base.md
@@ -299,8 +299,8 @@ For projects using the `org.jetbrains.kotlin.multiplatform` plugin.
 
 ### Gradle Plugin
 
-
-For projects using the `java-gradle-plugin` plugin.
+For projects using the `java-gradle-plugin` plugin. When also using `com.gradle.plugin-publish` please
+use [GradlePublishPlugin](#gradle-publish-plugin)
 
 === "build.gradle"
 
@@ -335,6 +335,31 @@ For projects using the `java-gradle-plugin` plugin.
         // whether to publish a sources jar
         sourcesJar = true,
       ))
+    }
+    ```
+
+### Gradle Publish Plugin
+
+For projects using the `com.gradle.plugin-publish` plugin. This will always publish a sources jar
+and a javadoc jar.
+
+=== "build.gradle"
+
+    ```groovy
+    import com.vanniktech.maven.publish.GradlePublishPlugin
+
+    mavenPublishing {
+      configure(new GradlePublishPlugin())
+    }
+    ```
+
+=== "build.gradle.kts"
+
+    ```kotlin
+    import com.vanniktech.maven.publish.GradlePublishPlugin
+
+    mavenPublishing {
+      configure(GradlePublishPlugin())
     }
     ```
 

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginPlatformTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginPlatformTest.kt
@@ -126,6 +126,36 @@ class MavenPublishPluginPlatformTest {
   }
 
   @TestParameterInjectorTest
+  fun javaGradlePluginWithPluginPublishProject(@TestParameter gradlePluginPublish: GradlePluginPublish) {
+    val project = javaGradlePluginWithGradlePluginPublish(gradlePluginPublish)
+    val result = project.run(fixtures, testProjectDir, testOptions)
+
+    assertThat(result).outcome().succeeded()
+    assertThat(result).artifact("jar").exists()
+    assertThat(result).artifact("jar").isSigned()
+    assertThat(result).pom().exists()
+    assertThat(result).pom().isSigned()
+    assertThat(result).pom().matchesExpectedPom()
+    assertThat(result).module().exists()
+    assertThat(result).module().isSigned()
+    assertThat(result).sourcesJar().exists()
+    assertThat(result).sourcesJar().isSigned()
+    assertThat(result).sourcesJar().containsAllSourceFiles()
+    assertThat(result).javadocJar().exists()
+    assertThat(result).javadocJar().isSigned()
+
+    val pluginId = "com.example.test-plugin"
+    val pluginMarkerSpec = project.copy(group = pluginId, artifactId = "$pluginId.gradle.plugin")
+    val pluginMarkerResult = result.copy(projectSpec = pluginMarkerSpec)
+    assertThat(pluginMarkerResult).pom().exists()
+    assertThat(pluginMarkerResult).pom().isSigned()
+    assertThat(pluginMarkerResult).pom().matchesExpectedPom(
+      "pom",
+      PomDependency("com.example", "test-artifact", "1.0.0", null),
+    )
+  }
+
+  @TestParameterInjectorTest
   fun javaGradlePluginKotlinProject(
     @TestParameter(valuesProvider = KotlinVersionProvider::class) kotlinVersion: KotlinVersion,
   ) {

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
@@ -171,6 +171,7 @@ private fun writeSettingFile(path: Path) {
             mavenLocal()
             mavenCentral()
             google()
+            gradlePluginPortal()
         }
     }
 

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecs.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecs.kt
@@ -13,6 +13,7 @@ val kotlinMultiplatformPlugin = PluginSpec("org.jetbrains.kotlin.multiplatform")
 val kotlinJsPlugin = PluginSpec("org.jetbrains.kotlin.js")
 val kotlinAndroidPlugin = PluginSpec("org.jetbrains.kotlin.android")
 val androidLibraryPlugin = PluginSpec("com.android.library")
+val gradlePluginPublishPlugin = PluginSpec("com.gradle.plugin-publish")
 
 val fixtures = Paths.get("src/integrationTest/fixtures2").toAbsolutePath()
 
@@ -87,6 +88,14 @@ fun javaGradlePluginProjectSpec() = ProjectSpec(
   """.trimIndent(),
   basePluginConfig = "configure(new GradlePlugin(new JavadocJar.Empty(), true))",
 )
+
+fun javaGradlePluginWithGradlePluginPublish(gradlePluginPublish: GradlePluginPublish): ProjectSpec {
+  val base = javaGradlePluginProjectSpec()
+  return base.copy(
+    plugins = base.plugins + gradlePluginPublishPlugin.copy(version = gradlePluginPublish.version),
+    basePluginConfig = "configure(new GradlePublishPlugin())",
+  )
+}
 
 fun javaGradlePluginKotlinProjectSpec(version: KotlinVersion): ProjectSpec {
   val plainJavaGradlePluginProject = javaGradlePluginProjectSpec()

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -80,3 +80,12 @@ enum class GradleVersion(val value: String) {
     val GRADLE_7_6 = GRADLE_8_0
   }
 }
+
+enum class GradlePluginPublish(val version: String) {
+  // minimum supported
+  GRADLE_PLUGIN_PUBLISH_1_0("1.0.0"),
+
+  // stable
+  GRADLE_PLUGIN_PUBLISH_1_1("1.1.0"),
+}
+

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -88,4 +88,3 @@ enum class GradlePluginPublish(val version: String) {
   // stable
   GRADLE_PLUGIN_PUBLISH_1_1("1.1.0"),
 }
-

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -50,6 +50,8 @@ private fun Project.configurePlatform() {
     when {
       plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") -> {} // Handled above.
       plugins.hasPlugin("com.android.library") -> {} // Handled above.
+      plugins.hasPlugin("com.gradle.plugin-publish") ->
+        baseExtension.configure(GradlePublishPlugin())
       plugins.hasPlugin("java-gradle-plugin") ->
         baseExtension.configure(GradlePlugin(defaultJavaDocOption() ?: javadoc()))
       plugins.hasPlugin("org.jetbrains.kotlin.jvm") ->

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -92,6 +92,22 @@ data class GradlePlugin @JvmOverloads constructor(
 }
 
 /**
+ * To be used for `com.gradle.plugin-publish` projects. Uses the default publication that gets created by that plugin.
+ */
+class GradlePublishPlugin : Platform() {
+
+  override val javadocJar: JavadocJar = JavadocJar.Javadoc()
+  override val sourcesJar: Boolean = true
+
+  override fun configure(project: Project) {
+    // setup is fully handled by com.gradle.plugin-publish already
+  }
+
+  override fun equals(other: Any?): Boolean = other is GradlePublishPlugin
+  override fun hashCode(): Int = this::class.hashCode()
+}
+
+/**
  * To be used for `com.android.library` projects. Applying this creates a publication for the component of the given
  * `variant`. Depending on the passed parameters for [javadocJar] and [sourcesJar], `-javadoc` and `-sources` jars will
  * be added to the publication.


### PR DESCRIPTION
`com.gradle.plugin-publish` will already create a sources jar and javadoc jar automatically and attach it to the publication which then conflicts with the ones added by us. To resolve this I'm adding an extra `Platform` for that plugin which which will not add anything. In the main plugin `com.gradle.plugin-publish` is ranked higher than `java-gradle-plugin` so that it will be prioritized and avoid this issue. 

With this we'll be incompatible with 0.21.0 of `com.gradle.plugin-publish` because that didn't create sources and javadoc jars.

Closes #542 
Closes #536 