### PR TITLE
fix snapshot publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.25.1 *(2023-03-23)*
+
+- Fix snapshot publishing being broken.
+
+
 ## 0.25.0 *(2023-03-23)*
 
 - The `createStagingRepository` task now uses the worker API which allows the project to built

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ okhttp = "com.squareup.okhttp3:okhttp:4.10.0"
 dokka = "org.jetbrains.dokka:dokka-gradle-plugin:1.8.10"
 android-plugin = "com.android.tools.build:gradle:7.4.2"
 ktlint-plugin = "org.jlleitschuh.gradle:ktlint-gradle:11.3.1"
-maven-publish-plugin = "com.vanniktech:gradle-maven-publish-plugin:0.25.0"
+maven-publish-plugin = "com.vanniktech:gradle-maven-publish-plugin:0.24.0"
 buildconfig-plugin = "com.github.gmazzo:gradle-buildconfig-plugin:3.1.0"
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ okhttp = "com.squareup.okhttp3:okhttp:4.10.0"
 dokka = "org.jetbrains.dokka:dokka-gradle-plugin:1.8.10"
 android-plugin = "com.android.tools.build:gradle:7.4.2"
 ktlint-plugin = "org.jlleitschuh.gradle:ktlint-gradle:11.3.1"
-maven-publish-plugin = "com.vanniktech:gradle-maven-publish-plugin:0.24.0"
+maven-publish-plugin = "com.vanniktech:gradle-maven-publish-plugin:0.25.0"
 buildconfig-plugin = "com.github.gmazzo:gradle-buildconfig-plugin:3.1.0"
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -9,7 +9,6 @@ import org.gradle.api.Incubating
 import org.gradle.api.Project
 import org.gradle.api.credentials.PasswordCredentials
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
 import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Incubating
 import org.gradle.api.Project
 import org.gradle.api.credentials.PasswordCredentials
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
@@ -62,21 +63,11 @@ abstract class MavenPublishBaseExtension(
 
     val versionIsSnapshot = version.map { it.endsWith("-SNAPSHOT") }
     val createRepository = project.tasks.registerCreateRepository(groupId, versionIsSnapshot, buildService)
-    val stagingRepositoryId = buildService.map {
-      requireNotNull(it.stagingRepositoryId) {
-        @Suppress("UnstableApiUsage")
-        if (project.gradle.startParameter.isConfigurationCacheRequested) {
-          "Publishing releases to Maven Central is not supported yet with configuration caching enabled, because of " +
-            "this missing Gradle feature: https://github.com/gradle/gradle/issues/22779"
-        } else {
-          "The staging repository was not created yet. Please open a bug with a build scan or build logs and stacktrace"
-        }
-      }
-    }
+    val url = sonatypeHost.map { it.publishingUrl(versionIsSnapshot, buildService, project.configurationCache()) }
 
     project.gradlePublishing.repositories.maven { repo ->
       repo.name = "mavenCentral"
-      repo.setUrl(sonatypeHost.map { it.publishingUrl(versionIsSnapshot.get(), stagingRepositoryId) })
+      repo.setUrl(url)
       repo.credentials(PasswordCredentials::class.java)
     }
 

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
@@ -7,6 +7,7 @@ import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.plugins.signing.SigningExtension
+import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
 
 internal fun Project.findOptionalProperty(propertyName: String) = findProperty(propertyName)?.toString()
@@ -57,4 +58,12 @@ internal fun Project.isAtLeastUsingAndroidGradleVersion(major: Int, minor: Int, 
     // was added in 7.0
     false
   }
+}
+
+@Suppress("UnstableApiUsage")
+internal fun Project.configurationCache(): Boolean {
+  if (GradleVersion.current() > GradleVersion.version("7.6")) {
+    return gradle.startParameter.isConfigurationCacheRequested
+  }
+  return false
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
@@ -62,7 +62,7 @@ internal fun Project.isAtLeastUsingAndroidGradleVersion(major: Int, minor: Int, 
 
 @Suppress("UnstableApiUsage")
 internal fun Project.configurationCache(): Boolean {
-  if (GradleVersion.current() > GradleVersion.version("7.6")) {
+  if (GradleVersion.current() >= GradleVersion.version("7.6")) {
     return gradle.startParameter.isConfigurationCacheRequested
   }
   return false

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
@@ -1,5 +1,6 @@
 package com.vanniktech.maven.publish
 
+import com.vanniktech.maven.publish.sonatype.SonatypeRepositoryBuildService
 import java.io.Serializable
 import org.gradle.api.provider.Provider
 
@@ -16,14 +17,28 @@ data class SonatypeHost(
     return "$rootUrl/service/local/"
   }
 
-  internal fun publishingUrl(snapshot: Boolean, stagingRepositoryId: Provider<String>): String {
-    return if (snapshot) {
-      if (stagingRepositoryId.isPresent) {
-        throw IllegalArgumentException("Staging repositories are not supported for SNAPSHOT versions.")
+  internal fun publishingUrl(
+    snapshot: Provider<Boolean>,
+    buildService: Provider<SonatypeRepositoryBuildService>,
+    configCache: Boolean,
+  ): String {
+    return if (snapshot.get()) {
+      require(buildService.get().stagingRepositoryId == null) {
+        "Staging repositories are not supported for SNAPSHOT versions."
       }
       "$rootUrl/content/repositories/snapshots/"
     } else {
-      "$rootUrl/service/local/staging/deployByRepositoryId/${stagingRepositoryId.get()}/"
+      val stagingRepositoryId = buildService.get().stagingRepositoryId
+      requireNotNull(stagingRepositoryId) {
+        if (configCache) {
+          "Publishing releases to Maven Central is not supported yet with configuration caching enabled, because of " +
+            "this missing Gradle feature: https://github.com/gradle/gradle/issues/22779"
+        } else {
+          "The staging repository was not created yet. Please open a bug with a build scan or build logs and stacktrace"
+        }
+      }
+
+      "$rootUrl/service/local/staging/deployByRepositoryId/${stagingRepositoryId}/"
     }
   }
 

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
@@ -38,7 +38,7 @@ data class SonatypeHost(
         }
       }
 
-      "$rootUrl/service/local/staging/deployByRepositoryId/${stagingRepositoryId}/"
+      "$rootUrl/service/local/staging/deployByRepositoryId/$stagingRepositoryId/"
     }
   }
 


### PR DESCRIPTION
The `stagingRepositoryId.isPresent` check in `publishingUrl` will cause the `Provider` to be evaluated which then will make `requireNotNull` throw because `stagingRepositoryId` is expected to be `null` in this case. I moved the check into `publishingUrl` to resolve this. 

Tested the solution manually by publishing to maven local and trying out both snapshot and release publishing in another project using that version. I need to find a way to have this as an automated test somehow.

Closes #544 