### PR TITLE
workaround for Kotlin MPP signing issue

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/WorkaroundSignatureType.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/WorkaroundSignatureType.kt
@@ -1,0 +1,38 @@
+package com.vanniktech.maven.publish.tasks
+
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
+import org.gradle.plugins.signing.signatory.Signatory
+import org.gradle.plugins.signing.type.AbstractSignatureType
+import org.gradle.plugins.signing.type.SignatureType
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+
+class WorkaroundSignatureType(
+  @Nested
+  val actual: SignatureType,
+  @Internal
+  val directory: Provider<Directory>,
+) : AbstractSignatureType() {
+
+  override fun fileFor(toSign: File): File {
+    val original = super.fileFor(toSign)
+    return directory.get().file(original.name).asFile
+  }
+
+  override fun sign(signatory: Signatory?, toSign: File?): File {
+    // needs to call super and not actual because this is what will call fileFor
+    return super.sign(signatory, toSign)
+  }
+
+  override fun getExtension(): String {
+    return actual.extension
+  }
+
+  override fun sign(signatory: Signatory?, toSign: InputStream?, destination: OutputStream?) {
+    actual.sign(signatory, toSign, destination)
+  }
+}

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/WorkaroundSignatureType.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/WorkaroundSignatureType.kt
@@ -1,5 +1,8 @@
 package com.vanniktech.maven.publish.tasks
 
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
@@ -7,9 +10,6 @@ import org.gradle.api.tasks.Nested
 import org.gradle.plugins.signing.signatory.Signatory
 import org.gradle.plugins.signing.type.AbstractSignatureType
 import org.gradle.plugins.signing.type.SignatureType
-import java.io.File
-import java.io.InputStream
-import java.io.OutputStream
 
 class WorkaroundSignatureType(
   @Nested


### PR DESCRIPTION
closes #561 

Solves the issue that the mpp test task uses the directory of the klib as input where the sign task will also put the signature file. We add a custom `SignatureType` that provides a different task specific location for the signature files. In addition to our tests that verify that these files still get published I also used a snapshot in Molecule to both test that the issue is gone and that publishing still works.