### PR TITLE
Update tested versions

### DIFF
--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginPlatformTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginPlatformTest.kt
@@ -287,7 +287,15 @@ class MavenPublishPluginPlatformTest {
     assertThat(result).artifact("klib").isSigned()
     assertThat(result).pom().exists()
     assertThat(result).pom().isSigned()
-    assertThat(result).pom().matchesExpectedPom("klib", kotlinStdlibJs(kotlinVersion))
+    if (kotlinVersion >= KotlinVersion.KT_1_9_0) {
+      assertThat(result).pom().matchesExpectedPom(
+        "klib",
+        kotlinStdlibJs(kotlinVersion),
+        kotlinDomApi(kotlinVersion),
+      )
+    } else {
+      assertThat(result).pom().matchesExpectedPom("klib", kotlinStdlibJs(kotlinVersion))
+    }
     assertThat(result).module().exists()
     assertThat(result).module().isSigned()
     assertThat(result).sourcesJar().exists()
@@ -366,11 +374,20 @@ class MavenPublishPluginPlatformTest {
     assertThat(nodejsResult).artifact("klib").isSigned()
     assertThat(nodejsResult).pom().exists()
     assertThat(nodejsResult).pom().isSigned()
-    assertThat(nodejsResult).pom().matchesExpectedPom(
-      "klib",
-      kotlinStdlibJs(kotlinVersion),
-      kotlinStdlibCommon(kotlinVersion),
-    )
+    if (kotlinVersion >= KotlinVersion.KT_1_9_0) {
+      assertThat(nodejsResult).pom().matchesExpectedPom(
+        "klib",
+        kotlinStdlibJs(kotlinVersion),
+        kotlinDomApi(kotlinVersion),
+        kotlinStdlibCommon(kotlinVersion),
+      )
+    } else {
+      assertThat(nodejsResult).pom().matchesExpectedPom(
+        "klib",
+        kotlinStdlibJs(kotlinVersion),
+        kotlinStdlibCommon(kotlinVersion),
+      )
+    }
     assertThat(nodejsResult).module().exists()
     assertThat(nodejsResult).module().isSigned()
     assertThat(nodejsResult).sourcesJar().exists()
@@ -452,11 +469,20 @@ class MavenPublishPluginPlatformTest {
     assertThat(nodejsResult).artifact("klib").isSigned()
     assertThat(nodejsResult).pom().exists()
     assertThat(nodejsResult).pom().isSigned()
-    assertThat(nodejsResult).pom().matchesExpectedPom(
-      "klib",
-      kotlinStdlibJs(kotlinVersion),
-      kotlinStdlibCommon(kotlinVersion),
-    )
+    if (kotlinVersion >= KotlinVersion.KT_1_9_0) {
+      assertThat(nodejsResult).pom().matchesExpectedPom(
+        "klib",
+        kotlinStdlibJs(kotlinVersion),
+        kotlinDomApi(kotlinVersion),
+        kotlinStdlibCommon(kotlinVersion),
+      )
+    } else {
+      assertThat(nodejsResult).pom().matchesExpectedPom(
+        "klib",
+        kotlinStdlibJs(kotlinVersion),
+        kotlinStdlibCommon(kotlinVersion),
+      )
+    }
     assertThat(nodejsResult).module().exists()
     assertThat(nodejsResult).module().isSigned()
     assertThat(nodejsResult).sourcesJar().exists()

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginPlatformTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginPlatformTest.kt
@@ -90,9 +90,12 @@ class MavenPublishPluginPlatformTest {
     assertThat(result).javadocJar().isSigned()
     assertThat(result).artifact("test-fixtures", "jar").exists()
     assertThat(result).artifact("test-fixtures", "jar").isSigned()
-    assertThat(result).sourcesJar("test-fixtures").exists()
-    assertThat(result).sourcesJar("test-fixtures").isSigned()
-    assertThat(result).sourcesJar("test-fixtures").containsSourceSetFiles("testFixtures")
+    // TODO test fixtures source publishing is broken in 8.2
+    if (testOptions.gradleVersion < GradleVersion.GRADLE_8_2) {
+      assertThat(result).sourcesJar("test-fixtures").exists()
+      assertThat(result).sourcesJar("test-fixtures").isSigned()
+      assertThat(result).sourcesJar("test-fixtures").containsSourceSetFiles("testFixtures")
+    }
   }
 
   @TestParameterInjectorTest
@@ -270,9 +273,12 @@ class MavenPublishPluginPlatformTest {
     assertThat(result).javadocJar().isSigned()
     assertThat(result).artifact("test-fixtures", "jar").exists()
     assertThat(result).artifact("test-fixtures", "jar").isSigned()
-    assertThat(result).sourcesJar("test-fixtures").exists()
-    assertThat(result).sourcesJar("test-fixtures").isSigned()
-    assertThat(result).sourcesJar("test-fixtures").containsSourceSetFiles("testFixtures")
+    // TODO test fixtures source publishing is broken in 8.2
+    if (testOptions.gradleVersion < GradleVersion.GRADLE_8_2) {
+      assertThat(result).sourcesJar("test-fixtures").exists()
+      assertThat(result).sourcesJar("test-fixtures").isSigned()
+      assertThat(result).sourcesJar("test-fixtures").containsSourceSetFiles("testFixtures")
+    }
   }
 
   @TestParameterInjectorTest

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginPlatformTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginPlatformTest.kt
@@ -90,12 +90,9 @@ class MavenPublishPluginPlatformTest {
     assertThat(result).javadocJar().isSigned()
     assertThat(result).artifact("test-fixtures", "jar").exists()
     assertThat(result).artifact("test-fixtures", "jar").isSigned()
-    // TODO test fixtures source publishing is broken in 8.2
-    if (testOptions.gradleVersion < GradleVersion.GRADLE_8_2) {
-      assertThat(result).sourcesJar("test-fixtures").exists()
-      assertThat(result).sourcesJar("test-fixtures").isSigned()
-      assertThat(result).sourcesJar("test-fixtures").containsSourceSetFiles("testFixtures")
-    }
+    assertThat(result).sourcesJar("test-fixtures").exists()
+    assertThat(result).sourcesJar("test-fixtures").isSigned()
+    assertThat(result).sourcesJar("test-fixtures").containsSourceSetFiles("testFixtures")
   }
 
   @TestParameterInjectorTest
@@ -273,12 +270,9 @@ class MavenPublishPluginPlatformTest {
     assertThat(result).javadocJar().isSigned()
     assertThat(result).artifact("test-fixtures", "jar").exists()
     assertThat(result).artifact("test-fixtures", "jar").isSigned()
-    // TODO test fixtures source publishing is broken in 8.2
-    if (testOptions.gradleVersion < GradleVersion.GRADLE_8_2) {
-      assertThat(result).sourcesJar("test-fixtures").exists()
-      assertThat(result).sourcesJar("test-fixtures").isSigned()
-      assertThat(result).sourcesJar("test-fixtures").containsSourceSetFiles("testFixtures")
-    }
+    assertThat(result).sourcesJar("test-fixtures").exists()
+    assertThat(result).sourcesJar("test-fixtures").isSigned()
+    assertThat(result).sourcesJar("test-fixtures").containsSourceSetFiles("testFixtures")
   }
 
   @TestParameterInjectorTest

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginSpecialCaseTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginSpecialCaseTest.kt
@@ -76,11 +76,20 @@ class MavenPublishPluginSpecialCaseTest {
     assertThat(nodejsResult).outcome().succeeded()
     assertThat(nodejsResult).artifact("klib").exists()
     assertThat(nodejsResult).pom().exists()
-    assertThat(nodejsResult).pom().matchesExpectedPom(
-      "klib",
-      kotlinStdlibJs(kotlinVersion),
-      kotlinStdlibCommon(kotlinVersion),
-    )
+    if (kotlinVersion >= KotlinVersion.KT_1_9_0) {
+      assertThat(nodejsResult).pom().matchesExpectedPom(
+        "klib",
+        kotlinStdlibJs(kotlinVersion),
+        kotlinDomApi(kotlinVersion),
+        kotlinStdlibCommon(kotlinVersion),
+      )
+    } else {
+      assertThat(nodejsResult).pom().matchesExpectedPom(
+        "klib",
+        kotlinStdlibJs(kotlinVersion),
+        kotlinStdlibCommon(kotlinVersion),
+      )
+    }
     assertThat(nodejsResult).module().exists()
     assertThat(nodejsResult).sourcesJar().exists()
     assertThat(nodejsResult).sourcesJar().containsSourceSetFiles("commonMain", "nodeJsMain")
@@ -142,11 +151,20 @@ class MavenPublishPluginSpecialCaseTest {
     assertThat(nodejsResult).outcome().succeeded()
     assertThat(nodejsResult).artifact("klib").exists()
     assertThat(nodejsResult).pom().exists()
-    assertThat(nodejsResult).pom().matchesExpectedPom(
-      "klib",
-      kotlinStdlibJs(kotlinVersion),
-      kotlinStdlibCommon(kotlinVersion),
-    )
+    if (kotlinVersion >= KotlinVersion.KT_1_9_0) {
+      assertThat(nodejsResult).pom().matchesExpectedPom(
+        "klib",
+        kotlinStdlibJs(kotlinVersion),
+        kotlinDomApi(kotlinVersion),
+        kotlinStdlibCommon(kotlinVersion),
+      )
+    } else {
+      assertThat(nodejsResult).pom().matchesExpectedPom(
+        "klib",
+        kotlinStdlibJs(kotlinVersion),
+        kotlinStdlibCommon(kotlinVersion),
+      )
+    }
     assertThat(nodejsResult).module().exists()
     assertThat(nodejsResult).sourcesJar().exists()
     assertThat(nodejsResult).sourcesJar().containsSourceSetFiles("commonMain", "nodeJsMain")

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/Pom.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/Pom.kt
@@ -18,6 +18,7 @@ data class PomDependency(
 fun kotlinStdlibCommon(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", "kotlin-stdlib-common", version.value, "compile")
 fun kotlinStdlibJdk(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", "kotlin-stdlib-jdk8", version.value, "compile")
 fun kotlinStdlibJs(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", "kotlin-stdlib-js", version.value, "compile")
+fun kotlinDomApi(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", "kotlin-dom-api-compat", version.value, "compile")
 
 fun createPom(
   groupId: String,

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
@@ -40,12 +40,13 @@ fun ProjectSpec.run(fixtures: Path, temp: Path, options: TestOptions): ProjectRe
 }
 
 private fun TestOptions.supportsConfigCaching(plugins: List<PluginSpec>): Boolean {
-  // TODO: Kotlin Multiplatform plugin has configuration cache issues
-  //  - https://youtrack.jetbrains.com/issue/KT-49933 (meta ticket)
-  //  - https://youtrack.jetbrains.com/issue/KT-43293 (closed but still has issues)
-  //  - https://youtrack.jetbrains.com/issue/KT-55051
-  if (plugins.any { it.id == kotlinMultiplatformPlugin.id }) {
-    return false
+  // Kotlin MPP support s config cache since 1.9.0
+  val multiplatform = plugins.find { it.id == kotlinMultiplatformPlugin.id }
+  if (multiplatform != null) {
+    val parts = multiplatform.version!!.split(".")
+    if (parts[0].toInt() == 1 && parts[1].toInt() < 9) {
+      return false
+    }
   }
   // TODO https://github.com/Kotlin/dokka/issues/2231
   if (plugins.any { it.id == dokkaPlugin.id }) {

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
@@ -40,7 +40,7 @@ fun ProjectSpec.run(fixtures: Path, temp: Path, options: TestOptions): ProjectRe
 }
 
 private fun TestOptions.supportsConfigCaching(plugins: List<PluginSpec>): Boolean {
-  // Kotlin MPP support s config cache since 1.9.0
+  // Kotlin MPP supports config cache since 1.9.0
   val multiplatform = plugins.find { it.id == kotlinMultiplatformPlugin.id }
   if (multiplatform != null) {
     val parts = multiplatform.version!!.split(".")

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -33,21 +33,21 @@ enum class AgpVersion(
 
   // stable
   AGP_8_0(
-    value = "8.0.1",
+    value = "8.0.2",
     minGradleVersion = GradleVersion.GRADLE_8_0,
     minJdkVersion = JavaVersion.VERSION_17,
   ),
 
   // beta channel
   AGP_8_1(
-    value = "8.1.0-beta03",
-    minGradleVersion = GradleVersion.GRADLE_8_0,
+    value = "8.1.0-beta05",
+    minGradleVersion = GradleVersion.GRADLE_8_1,
     minJdkVersion = JavaVersion.VERSION_17,
   ),
 
   // canary channel
   AGP_8_2(
-    value = "8.2.0-alpha04",
+    value = "8.2.0-alpha09",
     minGradleVersion = GradleVersion.GRADLE_8_1,
     minJdkVersion = JavaVersion.VERSION_17,
   ),
@@ -58,7 +58,10 @@ enum class KotlinVersion(val value: String) {
   KT_1_7_0("1.7.0"),
 
   // stable
-  KT_1_8_20("1.8.21"),
+  KT_1_8_20("1.8.22"),
+
+  // eap
+  KT_1_9_0("1.9.0-RC"),
 }
 
 enum class GradleVersion(val value: String) {
@@ -67,6 +70,9 @@ enum class GradleVersion(val value: String) {
 
   // stable
   GRADLE_8_1("8.1.1"),
+
+  // preview
+  GRADLE_8_2("8.2-rc-2"),
   ;
 
   companion object {

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -13,7 +13,6 @@ import org.gradle.api.plugins.internal.JvmPluginsHelper
 import org.gradle.api.plugins.jvm.internal.JvmPluginServices
 import org.gradle.api.provider.Provider
 import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.configurationcache.extensions.serviceOf
 import org.gradle.internal.component.external.model.ProjectDerivedCapability

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -5,10 +5,10 @@ import com.vanniktech.maven.publish.tasks.JavadocJar.Companion.javadocJarTask
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
-import org.gradle.api.plugins.jvm.internal.JvmModelingServices
-import org.gradle.api.plugins.jvm.internal.JvmVariantBuilder
+import org.gradle.api.plugins.jvm.internal.JvmPluginServices
 import org.gradle.api.provider.Provider
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.configurationcache.extensions.serviceOf
 import org.gradle.jvm.tasks.Jar
@@ -492,18 +492,28 @@ private fun setupTestFixtures(project: Project, sourcesJar: Boolean) {
   project.plugins.withId("java-test-fixtures") {
     if (sourcesJar) {
       // TODO: remove after https://github.com/gradle/gradle/issues/20539 is resolved
-      val services = project.serviceOf<JvmModelingServices>()
-      val variant = "testFixtures"
-      val action = Action<JvmVariantBuilder> {
-        it.withSourcesJar().published()
-      }
-      if (GradleVersion.current() >= GradleVersion.version("8.1")) {
-        val extension = project.extensions.getByType(JavaPluginExtension::class.java)
-        val testFixturesSourceSet = extension.sourceSets.maybeCreate(variant)
-        services.createJvmVariant(variant, testFixturesSourceSet, action)
-      } else {
-        val method = services.javaClass.getMethod("createJvmVariant", String::class.java, Action::class.java)
-        method.invoke(services, variant, action)
+      // TODO: make test fixture source publishing work in 8.2+
+      if (GradleVersion.current() < GradleVersion.version("8.2-rc-1")) {
+        val services = project.serviceOf<JvmPluginServices>()
+        val variant = "testFixtures"
+        val action = Action<Any> {
+          it.javaClass.getMethod("withSourcesJar").invoke(it)
+          it.javaClass.getMethod("published").invoke(it)
+        }
+        if (GradleVersion.current() >= GradleVersion.version("8.1")) {
+          val extension = project.extensions.getByType(JavaPluginExtension::class.java)
+          val testFixturesSourceSet = extension.sourceSets.maybeCreate(variant)
+          val method = services.javaClass.getMethod(
+            "createJvmVariant",
+            String::class.java,
+            SourceSet::class.java,
+            Action::class.java,
+          )
+          method.invoke(services, variant, testFixturesSourceSet, action)
+        } else {
+          val method = services.javaClass.getMethod("createJvmVariant", String::class.java, Action::class.java)
+          method.invoke(services, variant, action)
+        }
       }
     }
 


### PR DESCRIPTION
Changes based on the new versions:
- Gradle completely changed the API used to model test fixtures (`JvmModelingServices` and `JvmVariantBuilder` don't exist at all anymore)
    - ~I haven't found a new workaround yet since the replacement is just an [instantiated class](https://github.com/gradle/gradle/blob/master/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaTestFixturesPlugin.java#L67-L74) and I didn't find a way to obtain it. So for now we don't apply a workaround to enable test fixture source publishing on 8.2+.~
    - Added a new workaround that works from 8.1 on, so the workaround only has 2 variants and not 3
    - Adjusted the existing workaround to not directly reference any of the removed types which will make it possible to compile against 8.2 when it is out
- Kotlin/JS adds an additional dependency by default which our tests need to account for
- Kotlin MPP now supports config caching so it's now enabled in multiplatform tests
