### PR TITLE
deprecate Kotlin/JS platform

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -317,6 +317,7 @@ data class KotlinJvm @JvmOverloads constructor(
  * ```
  * This does not include javadoc jars because there are no APIs for that available.
  */
+@Deprecated("The Kotlin/JS plugin has been deprecated in Kotlin 1.9.0")
 data class KotlinJs
 @Deprecated(
   "Disabling sources publishing for Kotlin/JS is not supported since Kotlin 1.8.20. " +


### PR DESCRIPTION
The plugin was deprecated in Kotlin 1.9.0 so we can also deprecate this on our side.