### PR TITLE
raise minimum versions

### DIFF
--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginPlatformTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginPlatformTest.kt
@@ -339,11 +339,7 @@ class MavenPublishPluginPlatformTest {
     assertThat(result).module().isSigned()
     assertThat(result).sourcesJar().exists()
     assertThat(result).sourcesJar().isSigned()
-    if (kotlinVersion < KotlinVersion.KT_1_8_20) {
-      assertThat(result).sourcesJar().containsAllSourceFiles()
-    } else {
-      assertThat(result).sourcesJar().containsSourceSetFiles("commonMain")
-    }
+    assertThat(result).sourcesJar().containsSourceSetFiles("commonMain")
     assertThat(result).javadocJar().exists()
     assertThat(result).javadocJar().isSigned()
 
@@ -435,11 +431,7 @@ class MavenPublishPluginPlatformTest {
     assertThat(result).module().isSigned()
     assertThat(result).sourcesJar().exists()
     assertThat(result).sourcesJar().isSigned()
-    if (kotlinVersion < KotlinVersion.KT_1_8_20) {
-      assertThat(result).sourcesJar().containsAllSourceFiles()
-    } else {
-      assertThat(result).sourcesJar().containsSourceSetFiles("commonMain")
-    }
+    assertThat(result).sourcesJar().containsSourceSetFiles("commonMain")
     assertThat(result).javadocJar().exists()
     assertThat(result).javadocJar().isSigned()
 

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginSpecialCaseTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginSpecialCaseTest.kt
@@ -104,6 +104,8 @@ class MavenPublishPluginSpecialCaseTest {
   fun artifactIdThatContainsProjectNameProducesCorrectArtifactId2(
     @TestParameter(valuesProvider = KotlinVersionProvider::class) kotlinVersion: KotlinVersion,
   ) {
+    kotlinVersion.assumeSupportedJdkAndGradleVersion(gradleVersion)
+
     val project = kotlinMultiplatformProjectSpec(kotlinVersion).copy(
       defaultProjectName = "foo",
       artifactId = "bar-foo",

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginSpecialCaseTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginSpecialCaseTest.kt
@@ -47,11 +47,7 @@ class MavenPublishPluginSpecialCaseTest {
     )
     assertThat(result).module().exists()
     assertThat(result).sourcesJar().exists()
-    if (kotlinVersion < KotlinVersion.KT_1_8_20) {
-      assertThat(result).sourcesJar().containsAllSourceFiles()
-    } else {
-      assertThat(result).sourcesJar().containsSourceSetFiles("commonMain")
-    }
+    assertThat(result).sourcesJar().containsSourceSetFiles("commonMain")
     assertThat(result).javadocJar().exists()
 
     val jvmResult = result.withArtifactIdSuffix("jvm")
@@ -122,11 +118,7 @@ class MavenPublishPluginSpecialCaseTest {
     )
     assertThat(result).module().exists()
     assertThat(result).sourcesJar().exists()
-    if (kotlinVersion < KotlinVersion.KT_1_8_20) {
-      assertThat(result).sourcesJar().containsAllSourceFiles()
-    } else {
-      assertThat(result).sourcesJar().containsSourceSetFiles("commonMain")
-    }
+    assertThat(result).sourcesJar().containsSourceSetFiles("commonMain")
     assertThat(result).javadocJar().exists()
 
     val jvmResult = result.withArtifactIdSuffix("jvm")
@@ -266,7 +258,7 @@ class MavenPublishPluginSpecialCaseTest {
 
   @TestParameterInjectorTest
   fun dokka() {
-    val kotlinVersion = KotlinVersion.values().last()
+    val kotlinVersion = KotlinVersion.entries.last()
     val original = kotlinJvmProjectSpec(kotlinVersion)
     val project = original.copy(
       plugins = original.plugins + dokkaPlugin,

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
@@ -52,6 +52,8 @@ private fun TestOptions.supportsConfigCaching(plugins: List<PluginSpec>): Boolea
     return false
   }
 
+  // publishing supports configuration cache starting with 7.6
+  // signing only supports configuration cache starting with 8.1
   return gradleVersion >= GradleVersion.GRADLE_8_1 || signing == TestOptions.Signing.NO_SIGNING
 }
 

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
@@ -41,26 +41,18 @@ fun ProjectSpec.run(fixtures: Path, temp: Path, options: TestOptions): ProjectRe
 
 private fun TestOptions.supportsConfigCaching(plugins: List<PluginSpec>): Boolean {
   // Kotlin MPP supports config cache since 1.9.0
-  val multiplatform = plugins.find { it.id == kotlinMultiplatformPlugin.id }
-  if (multiplatform != null) {
-    val parts = multiplatform.version!!.split(".")
-    if (parts[0].toInt() == 1 && parts[1].toInt() < 9) {
-      return false
-    }
+  val multiplatformPlugin = plugins.find { it.id == kotlinMultiplatformPlugin.id }
+  if (multiplatformPlugin != null) {
+    val version = KotlinVersion.entries.find { it.value == multiplatformPlugin.version }!!
+    return version >= KotlinVersion.KT_1_9_0
   }
+
   // TODO https://github.com/Kotlin/dokka/issues/2231
   if (plugins.any { it.id == dokkaPlugin.id }) {
     return false
   }
-  // publishing supports configuration cache starting with 7.6
-  // signing only supports configuration cache starting with 8.1
-  if (gradleVersion >= GradleVersion.GRADLE_8_1) {
-    return true
-  }
-  if (gradleVersion >= GradleVersion.GRADLE_7_6) {
-    return signing == TestOptions.Signing.NO_SIGNING
-  }
-  return false
+
+  return gradleVersion >= GradleVersion.GRADLE_8_1 || signing == TestOptions.Signing.NO_SIGNING
 }
 
 private fun ProjectSpec.writeBuildFile(path: Path, repo: Path, options: TestOptions) {

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
@@ -40,13 +40,6 @@ fun ProjectSpec.run(fixtures: Path, temp: Path, options: TestOptions): ProjectRe
 }
 
 private fun TestOptions.supportsConfigCaching(plugins: List<PluginSpec>): Boolean {
-  // Kotlin MPP supports config cache since 1.9.0
-  val multiplatformPlugin = plugins.find { it.id == kotlinMultiplatformPlugin.id }
-  if (multiplatformPlugin != null) {
-    val version = KotlinVersion.entries.find { it.value == multiplatformPlugin.version }!!
-    return version >= KotlinVersion.KT_1_9_0
-  }
-
   // TODO https://github.com/Kotlin/dokka/issues/2231
   if (plugins.any { it.id == dokkaPlugin.id }) {
     return false
@@ -54,7 +47,16 @@ private fun TestOptions.supportsConfigCaching(plugins: List<PluginSpec>): Boolea
 
   // publishing supports configuration cache starting with 7.6
   // signing only supports configuration cache starting with 8.1
-  return gradleVersion >= GradleVersion.GRADLE_8_1 || signing == TestOptions.Signing.NO_SIGNING
+  val configCachingSupported = gradleVersion >= GradleVersion.GRADLE_8_1 || signing == TestOptions.Signing.NO_SIGNING
+
+  // Kotlin MPP supports config cache since 1.9.0
+  val multiplatformPlugin = plugins.find { it.id == kotlinMultiplatformPlugin.id }
+  if (multiplatformPlugin != null) {
+    val version = KotlinVersion.entries.find { it.value == multiplatformPlugin.version }!!
+    return version >= KotlinVersion.KT_1_9_0 && configCachingSupported
+  }
+
+  return configCachingSupported
 }
 
 private fun ProjectSpec.writeBuildFile(path: Path, repo: Path, options: TestOptions) {

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecs.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecs.kt
@@ -1,6 +1,7 @@
 package com.vanniktech.maven.publish
 
 import java.nio.file.Paths
+import kotlin.io.path.absolute
 
 val javaPlugin = PluginSpec("java")
 val javaLibraryPlugin = PluginSpec("java-library")
@@ -16,7 +17,7 @@ val androidLibraryPlugin = PluginSpec("com.android.library")
 val gradlePluginPublishPlugin = PluginSpec("com.gradle.plugin-publish")
 val dokkaPlugin = PluginSpec("org.jetbrains.dokka", "1.8.10")
 
-val fixtures = Paths.get("src/integrationTest/fixtures2").toAbsolutePath()
+val fixtures = Paths.get("src/integrationTest/fixtures2").absolute()
 
 val defaultProperties = mapOf(
   "POM_NAME" to "Gradle Maven Publish Plugin Test Artifact",

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/Subjects.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/Subjects.kt
@@ -202,7 +202,7 @@ open class ArtifactSubject internal constructor(
 
 class SourcesJarSubject private constructor(
   failureMetadata: FailureMetadata,
-  private val artifact: Path,
+  artifact: Path,
   private val result: ProjectResult,
 ) : ArtifactSubject(failureMetadata, artifact, result) {
 

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -53,7 +53,10 @@ enum class KotlinVersion(
   val firstUnsupportedGradleVersion: GradleVersion? = null,
 ) {
   // minimum supported
-  KT_1_8_20("1.8.20"),
+  KT_1_8_20(
+    "1.8.20",
+    firstUnsupportedJdkVersion = JavaVersion.VERSION_20,
+  ),
 
   // stable
   KT_1_9_0("1.9.0"),

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -58,10 +58,6 @@ enum class KotlinVersion(
   // stable
   KT_1_9_0("1.9.0"),
   ;
-
-  companion object {
-    val KT_1_8_20 = KT_1_9_0
-  }
 }
 
 enum class GradleVersion(

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -27,9 +27,9 @@ enum class AgpVersion(
   val minJdkVersion: JavaVersion = JavaVersion.VERSION_11,
 ) {
   // minimum supported
-  AGP_7_3(
-    value = "7.3.1",
-    minGradleVersion = GradleVersion.GRADLE_7_4,
+  AGP_7_4(
+    value = "7.4.0",
+    minGradleVersion = GradleVersion.GRADLE_7_6,
   ),
 
   // stable
@@ -53,11 +53,7 @@ enum class KotlinVersion(
   val firstUnsupportedGradleVersion: GradleVersion? = null,
 ) {
   // minimum supported
-  KT_1_7_0(
-    value = "1.7.0",
-    firstUnsupportedJdkVersion = JavaVersion.VERSION_18,
-    firstUnsupportedGradleVersion = GradleVersion.GRADLE_8_3,
-  ),
+  KT_1_8_20("1.8.20"),
 
   // stable
   KT_1_9_0("1.9.0"),
@@ -73,8 +69,8 @@ enum class GradleVersion(
   val firstUnsupportedJdkVersion: JavaVersion? = null,
 ) {
   // minimum supported
-  GRADLE_7_4(
-    value = "7.4",
+  GRADLE_7_6(
+    value = "7.6",
     firstUnsupportedJdkVersion = JavaVersion.VERSION_18,
   ),
 
@@ -90,8 +86,6 @@ enum class GradleVersion(
 
   companion object {
     // aliases for the skipped version to be able to reference the correct one in AgpVersion
-    val GRADLE_7_5 = GRADLE_8_2
-    val GRADLE_7_6 = GRADLE_8_2
     val GRADLE_8_0 = GRADLE_8_2
     val GRADLE_8_1 = GRADLE_8_2
   }

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptionsProvider.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptionsProvider.kt
@@ -14,33 +14,33 @@ internal class TestOptionsConfigProvider : TestParameterValuesProvider {
     if (quickTestProperty.isNotBlank()) {
       return ImmutableList.of(TestOptions.Config.BASE)
     }
-    return ImmutableList.copyOf(TestOptions.Config.values())
+    return ImmutableList.copyOf(TestOptions.Config.entries)
   }
 }
 
 internal class GradleVersionProvider : TestParameterValuesProvider {
   override fun provideValues(): ImmutableList<GradleVersion> {
     if (quickTestProperty.isNotBlank()) {
-      return ImmutableList.of(GradleVersion.values().last())
+      return ImmutableList.of(GradleVersion.entries.last())
     }
-    return ImmutableList.copyOf(GradleVersion.values())
+    return ImmutableList.copyOf(GradleVersion.entries)
   }
 }
 
 internal class AgpVersionProvider : TestParameterValuesProvider {
   override fun provideValues(): ImmutableList<AgpVersion> {
     if (quickTestProperty.isNotBlank()) {
-      return ImmutableList.of(AgpVersion.values().last())
+      return ImmutableList.of(AgpVersion.entries.last())
     }
-    return ImmutableList.copyOf(AgpVersion.values())
+    return ImmutableList.copyOf(AgpVersion.entries)
   }
 }
 
 internal class KotlinVersionProvider : TestParameterValuesProvider {
   override fun provideValues(): ImmutableList<KotlinVersion> {
     if (quickTestProperty.isNotBlank()) {
-      return ImmutableList.of(KotlinVersion.values().last())
+      return ImmutableList.of(KotlinVersion.entries.last())
     }
-    return ImmutableList.copyOf(KotlinVersion.values())
+    return ImmutableList.copyOf(KotlinVersion.entries)
   }
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -35,7 +35,7 @@ abstract class MavenPublishBaseExtension(
   /**
    * Sets up Maven Central publishing through Sonatype OSSRH by configuring the target repository. Gradle will then
    * automatically create a `publishAllPublicationsToMavenCentralRepository` task as well as include it in the general
-   * `publish` task. As part of running publish the plugin will automatically create a staging repostory on Sonatype
+   * `publish` task. As part of running publish the plugin will automatically create a staging repository on Sonatype
    * to which all artifacts will be published. At the end of the build this staging repository will be automatically
    * closed. When the [automaticRelease] parameter is `true` the staging repository will also be released
    * automatically afterwards.
@@ -99,7 +99,7 @@ abstract class MavenPublishBaseExtension(
    * signing.secretKeyRingFile=/Users/me/.gnupg/secring.gpg
    * ```
    *
-   * Alternatively an in memory key can be used by exporting an ascii-armored GPG key and setting these Gradle properties"
+   * Alternatively an in memory key can be used by exporting an ascii-armored GPG key and setting these Gradle properties:
    * ```
    * signingInMemoryKey=exported_ascii_armored_key
    * # optional
@@ -147,6 +147,7 @@ abstract class MavenPublishBaseExtension(
       publishTask.dependsOn(project.tasks.withType(Sign::class.java))
     }
 
+    // TODO: https://youtrack.jetbrains.com/issue/KT-61313/ https://github.com/gradle/gradle/issues/26132
     project.plugins.withId("org.jetbrains.kotlin.multiplatform") {
       project.tasks.withType(Sign::class.java).configureEach {
         it.signatureType = WorkaroundSignatureType(
@@ -199,7 +200,7 @@ abstract class MavenPublishBaseExtension(
     return if (publication.artifactId == projectName) {
       this
     } else if (publication.artifactId.startsWith("$projectName-")) {
-      // Publications for specific platform targes use derived artifact ids (e.g. library, library-jvm,
+      // Publications for specific platform targets use derived artifact ids (e.g. library, library-jvm,
       // library-js) and the suffix needs to be preserved
       publication.artifactId.replace("$projectName-", "$this-")
     } else {

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBasePlugin.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBasePlugin.kt
@@ -20,21 +20,21 @@ open class MavenPublishBasePlugin : Plugin<Project> {
       error("You need Gradle version $MIN_GRADLE_VERSION or higher, was ${GradleVersion.current()}")
     }
     plugins.withId("com.android.library") {
-      if (!isAtLeastUsingAndroidGradleVersion(7, 3, 0)) {
-        error("You need AGP version 7.3.0 or newer")
+      if (!isAtLeastUsingAndroidGradleVersion(7, 4, 0)) {
+        error("You need AGP version 7.4.0 or newer")
       }
     }
     KOTLIN_PLUGIN_IDS.forEach { pluginId ->
       plugins.withId(pluginId) {
-        if (!isAtLeastKotlinVersion(pluginId, 1, 7, 0)) {
-          error("You need Kotlin version 1.7.0 or newer")
+        if (!isAtLeastKotlinVersion(pluginId, 1, 8, 20)) {
+          error("You need Kotlin version 1.8.20 or newer")
         }
       }
     }
   }
 
   private companion object {
-    val MIN_GRADLE_VERSION: GradleVersion = GradleVersion.version("7.4")
+    val MIN_GRADLE_VERSION: GradleVersion = GradleVersion.version("7.6")
     val KOTLIN_PLUGIN_IDS = listOf(
       "org.jetbrains.kotlin.jvm",
       "org.jetbrains.kotlin.js",

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
@@ -7,7 +7,6 @@ import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.plugins.signing.SigningExtension
-import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
 
 internal fun Project.findOptionalProperty(propertyName: String) = findProperty(propertyName)?.toString()
@@ -62,8 +61,5 @@ internal fun Project.isAtLeastUsingAndroidGradleVersion(major: Int, minor: Int, 
 
 @Suppress("UnstableApiUsage")
 internal fun Project.configurationCache(): Boolean {
-  if (GradleVersion.current() >= GradleVersion.version("7.6")) {
-    return gradle.startParameter.isConfigurationCacheRequested
-  }
-  return false
+  return gradle.startParameter.isConfigurationCacheRequested
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
@@ -90,7 +90,6 @@ internal abstract class SonatypeRepositoryBuildService : BuildService<SonatypeRe
   companion object {
     private const val NAME = "sonatype-repository-build-service"
 
-    @Suppress("UnstableApiUsage")
     fun Project.registerSonatypeRepositoryBuildService(
       sonatypeHost: Provider<SonatypeHost>,
       repositoryUsername: Provider<String>,

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocJar.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocJar.kt
@@ -37,7 +37,7 @@ open class JavadocJar : Jar() {
     private fun Project.dokkaJavadocJar(taskName: DokkaTaskName): TaskProvider<*> {
       return tasks.register("dokkaJavadocJar", JavadocJar::class.java) {
         val task = when (taskName) {
-          is ProviderDokkaTaskName -> taskName.value.flatMap { tasks.named(it) }
+          is ProviderDokkaTaskName -> taskName.value.flatMap { name -> tasks.named(name) }
           is StringDokkaTaskName -> tasks.named(taskName.value)
         }
         it.dependsOn(task)


### PR DESCRIPTION
Before adding newer versions to the tests this increases the minimum supported version of Gradle, Kotlin and AGP and does some clean up based on that.

Gradle: 7.4 -> 7.6
Kotlin: 1.8.20 -> 1.9.0
AGP: 7.3.0 -> 7.4.0