### PR TITLE
test against new versions

### DIFF
--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginPlatformTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginPlatformTest.kt
@@ -385,17 +385,23 @@ class MavenPublishPluginPlatformTest {
     assertThat(nodejsResult).artifact("klib").isSigned()
     assertThat(nodejsResult).pom().exists()
     assertThat(nodejsResult).pom().isSigned()
-    if (kotlinVersion >= KotlinVersion.KT_1_9_0) {
+    if (kotlinVersion >= KotlinVersion.KT_1_9_20) {
       assertThat(nodejsResult).pom().matchesExpectedPom(
         "klib",
-        kotlinStdlibJs(kotlinVersion),
+        kotlinStdlibMppJs(kotlinVersion),
+        kotlinDomApi(kotlinVersion),
+      )
+    } else if (kotlinVersion >= KotlinVersion.KT_1_9_0) {
+      assertThat(nodejsResult).pom().matchesExpectedPom(
+        "klib",
+        kotlinStdlibMppJs(kotlinVersion),
         kotlinDomApi(kotlinVersion),
         kotlinStdlibCommon(kotlinVersion),
       )
     } else {
       assertThat(nodejsResult).pom().matchesExpectedPom(
         "klib",
-        kotlinStdlibJs(kotlinVersion),
+        kotlinStdlibMppJs(kotlinVersion),
         kotlinStdlibCommon(kotlinVersion),
       )
     }
@@ -477,17 +483,23 @@ class MavenPublishPluginPlatformTest {
     assertThat(nodejsResult).artifact("klib").isSigned()
     assertThat(nodejsResult).pom().exists()
     assertThat(nodejsResult).pom().isSigned()
-    if (kotlinVersion >= KotlinVersion.KT_1_9_0) {
+    if (kotlinVersion >= KotlinVersion.KT_1_9_20) {
       assertThat(nodejsResult).pom().matchesExpectedPom(
         "klib",
-        kotlinStdlibJs(kotlinVersion),
+        kotlinStdlibMppJs(kotlinVersion),
+        kotlinDomApi(kotlinVersion),
+      )
+    } else if (kotlinVersion >= KotlinVersion.KT_1_9_0) {
+      assertThat(nodejsResult).pom().matchesExpectedPom(
+        "klib",
+        kotlinStdlibMppJs(kotlinVersion),
         kotlinDomApi(kotlinVersion),
         kotlinStdlibCommon(kotlinVersion),
       )
     } else {
       assertThat(nodejsResult).pom().matchesExpectedPom(
         "klib",
-        kotlinStdlibJs(kotlinVersion),
+        kotlinStdlibMppJs(kotlinVersion),
         kotlinStdlibCommon(kotlinVersion),
       )
     }

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginSpecialCaseTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginSpecialCaseTest.kt
@@ -80,17 +80,23 @@ class MavenPublishPluginSpecialCaseTest {
     assertThat(nodejsResult).outcome().succeeded()
     assertThat(nodejsResult).artifact("klib").exists()
     assertThat(nodejsResult).pom().exists()
-    if (kotlinVersion >= KotlinVersion.KT_1_9_0) {
+    if (kotlinVersion >= KotlinVersion.KT_1_9_20) {
       assertThat(nodejsResult).pom().matchesExpectedPom(
         "klib",
-        kotlinStdlibJs(kotlinVersion),
+        kotlinStdlibMppJs(kotlinVersion),
+        kotlinDomApi(kotlinVersion),
+      )
+    } else if (kotlinVersion >= KotlinVersion.KT_1_9_0) {
+      assertThat(nodejsResult).pom().matchesExpectedPom(
+        "klib",
+        kotlinStdlibMppJs(kotlinVersion),
         kotlinDomApi(kotlinVersion),
         kotlinStdlibCommon(kotlinVersion),
       )
     } else {
       assertThat(nodejsResult).pom().matchesExpectedPom(
         "klib",
-        kotlinStdlibJs(kotlinVersion),
+        kotlinStdlibMppJs(kotlinVersion),
         kotlinStdlibCommon(kotlinVersion),
       )
     }
@@ -153,17 +159,23 @@ class MavenPublishPluginSpecialCaseTest {
     assertThat(nodejsResult).outcome().succeeded()
     assertThat(nodejsResult).artifact("klib").exists()
     assertThat(nodejsResult).pom().exists()
-    if (kotlinVersion >= KotlinVersion.KT_1_9_0) {
+    if (kotlinVersion >= KotlinVersion.KT_1_9_20) {
       assertThat(nodejsResult).pom().matchesExpectedPom(
         "klib",
-        kotlinStdlibJs(kotlinVersion),
+        kotlinStdlibMppJs(kotlinVersion),
+        kotlinDomApi(kotlinVersion),
+      )
+    } else if (kotlinVersion >= KotlinVersion.KT_1_9_0) {
+      assertThat(nodejsResult).pom().matchesExpectedPom(
+        "klib",
+        kotlinStdlibMppJs(kotlinVersion),
         kotlinDomApi(kotlinVersion),
         kotlinStdlibCommon(kotlinVersion),
       )
     } else {
       assertThat(nodejsResult).pom().matchesExpectedPom(
         "klib",
-        kotlinStdlibJs(kotlinVersion),
+        kotlinStdlibMppJs(kotlinVersion),
         kotlinStdlibCommon(kotlinVersion),
       )
     }

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/Pom.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/Pom.kt
@@ -15,9 +15,20 @@ data class PomDependency(
   val optional: Boolean? = null,
 )
 
-fun kotlinStdlibCommon(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", "kotlin-stdlib-common", version.value, "compile")
-fun kotlinStdlibJdk(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", "kotlin-stdlib-jdk8", version.value, "compile")
-fun kotlinStdlibJs(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", "kotlin-stdlib-js", version.value, "compile")
+fun kotlinStdlibCommon(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", version.commonStdlibArtifactId, version.value, "compile")
+private val KotlinVersion.commonStdlibArtifactId
+  get() = if (this < KotlinVersion.KT_1_9_20) "kotlin-stdlib-common" else "kotlin-stdlib"
+
+fun kotlinStdlibJdk(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", version.jdkStdlibArtifactId, version.value, "compile")
+private val KotlinVersion.jdkStdlibArtifactId
+  get() = if (this < KotlinVersion.KT_1_9_20) "kotlin-stdlib-jdk8" else "kotlin-stdlib"
+
+fun kotlinStdlibJs(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", version.jsStdlibArtifactId, version.value, "compile")
+private val KotlinVersion.jsStdlibArtifactId
+  get() = if (this < KotlinVersion.KT_1_9_20) "kotlin-stdlib-js" else "kotlin-stdlib"
+
+fun kotlinStdlibMppJs(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", "kotlin-stdlib-js", version.value, "compile")
+
 fun kotlinDomApi(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", "kotlin-dom-api-compat", version.value, "compile")
 
 fun createPom(
@@ -74,7 +85,7 @@ fun createMinimalPom(
   if (packaging != null) {
     model.packaging = packaging
   }
-  dependencies.forEach {
+  dependencies.distinct().forEach {
     model.addDependency(
       Dependency().apply {
         this.groupId = it.groupId
@@ -90,7 +101,7 @@ fun createMinimalPom(
 
   if (dependencyManagementDependencies.isNotEmpty()) {
     model.dependencyManagement = DependencyManagement().apply {
-      dependencyManagementDependencies.forEach {
+      dependencyManagementDependencies.distinct().forEach {
         addDependency(
           Dependency().apply {
             this.groupId = it.groupId

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -34,14 +34,21 @@ enum class AgpVersion(
 
   // stable
   AGP_8_1(
-    value = "8.1.0",
+    value = "8.1.1",
+    minGradleVersion = GradleVersion.GRADLE_8_1,
+    minJdkVersion = JavaVersion.VERSION_17,
+  ),
+
+  // beta channel
+  AGP_8_2(
+    value = "8.2.0-beta05",
     minGradleVersion = GradleVersion.GRADLE_8_1,
     minJdkVersion = JavaVersion.VERSION_17,
   ),
 
   // canary channel
-  AGP_8_2(
-    value = "8.2.0-alpha15",
+  AGP_8_3(
+    value = "8.3.0-alpha04",
     minGradleVersion = GradleVersion.GRADLE_8_1,
     minJdkVersion = JavaVersion.VERSION_17,
   ),
@@ -60,6 +67,9 @@ enum class KotlinVersion(
 
   // stable
   KT_1_9_0("1.9.0"),
+
+  // preview
+  KT_1_9_20("1.9.20-Beta2"),
   ;
 }
 
@@ -74,19 +84,20 @@ enum class GradleVersion(
   ),
 
   // stable
-  GRADLE_8_2(
-    value = "8.2.1",
+  GRADLE_8_3(
+    value = "8.3",
     firstUnsupportedJdkVersion = JavaVersion.VERSION_20,
   ),
 
   // preview
-  GRADLE_8_3("8.3-rc-3"),
+  GRADLE_8_4("8.4-rc-1"),
   ;
 
   companion object {
     // aliases for the skipped version to be able to reference the correct one in AgpVersion
-    val GRADLE_8_0 = GRADLE_8_2
-    val GRADLE_8_1 = GRADLE_8_2
+    val GRADLE_8_0 = GRADLE_8_3
+    val GRADLE_8_1 = GRADLE_8_3
+    val GRADLE_8_2 = GRADLE_8_3
   }
 }
 


### PR DESCRIPTION
KGP 1.9.20 seems to always add the `kotlin-stdlib` artifact instead of the target specific ones. The only weird exception to this is the js target for mpp.