### PR TITLE
fix: resolve issue with attempting to register a task by the same name more than once.

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -98,9 +98,11 @@ data class GradlePlugin @JvmOverloads constructor(
       "Calling configure(GradlePlugin(...)) requires the java-gradle-plugin to be applied"
     }
 
+    val javadocJarTask = project.javadocJarTask(javadocJar)
+
     project.mavenPublicationsWithoutPluginMarker {
       it.withJavaSourcesJar(sourcesJar, project)
-      it.withJavadocJar { project.javadocJarTask(javadocJar) }
+      it.withJavadocJar { javadocJarTask }
     }
   }
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocJar.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocJar.kt
@@ -4,7 +4,6 @@ import com.vanniktech.maven.publish.JavadocJar as JavadocJarOption
 import com.vanniktech.maven.publish.JavadocJar.Dokka.DokkaTaskName
 import com.vanniktech.maven.publish.JavadocJar.Dokka.ProviderDokkaTaskName
 import com.vanniktech.maven.publish.JavadocJar.Dokka.StringDokkaTaskName
-import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.tasks.Jar
@@ -28,39 +27,21 @@ open class JavadocJar : Jar() {
     private fun Project.emptyJavadocJar(): TaskProvider<*> = tasks.register("emptyJavadocJar", JavadocJar::class.java)
 
     private fun Project.plainJavadocJar(): TaskProvider<*> {
-      val javadoc = tasks.named("javadoc")
-
-      return try {
-        // This can throw an DuplicateTaskException (which is private, but extends InvalidUserDataException).
-        tasks.register("simpleJavadocJar", JavadocJar::class.java) { javadocJar ->
-          javadocJar.dependsOn(javadoc)
-          javadocJar.from(javadoc)
-        }
-      } catch (e: InvalidUserDataException) {
-        tasks.named("simpleJavadocJar", JavadocJar::class.java) { javadocJar ->
-          javadocJar.dependsOn(javadoc)
-          javadocJar.from(javadoc)
-        }
+      return tasks.register("simpleJavadocJar", JavadocJar::class.java) {
+        val task = tasks.named("javadoc")
+        it.dependsOn(task)
+        it.from(task)
       }
     }
 
     private fun Project.dokkaJavadocJar(taskName: DokkaTaskName): TaskProvider<*> {
-      val task = when (taskName) {
-        is ProviderDokkaTaskName -> taskName.value.flatMap { name -> tasks.named(name) }
-        is StringDokkaTaskName -> tasks.named(taskName.value)
-      }
-
-      return try {
-        // This can throw an DuplicateTaskException (which is private, but extends InvalidUserDataException).
-        tasks.register("dokkaJavadocJar", JavadocJar::class.java) { javadocJar ->
-          javadocJar.dependsOn(task)
-          javadocJar.from(task)
+      return tasks.register("dokkaJavadocJar", JavadocJar::class.java) {
+        val task = when (taskName) {
+          is ProviderDokkaTaskName -> taskName.value.flatMap { name -> tasks.named(name) }
+          is StringDokkaTaskName -> tasks.named(taskName.value)
         }
-      } catch (e: InvalidUserDataException) {
-        tasks.named("dokkaJavadocJar", JavadocJar::class.java) { javadocJar ->
-          javadocJar.dependsOn(task)
-          javadocJar.from(task)
-        }
+        it.dependsOn(task)
+        it.from(task)
       }
     }
   }


### PR DESCRIPTION
I wasn't sure what the best resolution was to the problem I faced, so I figured it would be best to just show a PR and we could discuss. This is the error I ran into in my (closed source) project:
```
Caused by: org.gradle.api.internal.tasks.DefaultTaskContainer$DuplicateTaskException: Cannot add task 'simpleJavadocJar' as a task with that name already exists.
at org.gradle.api.internal.tasks.DefaultTaskContainer.failOnDuplicateTask(DefaultTaskContainer.java:257)	
•••
at com.vanniktech.maven.publish.tasks.JavadocJar$Companion.plainJavadocJar(JavadocJar.kt:27)	
at com.vanniktech.maven.publish.tasks.JavadocJar$Companion.javadocJarTask$plugin(JavadocJar.kt:19)	
at com.vanniktech.maven.publish.GradlePlugin$configure$1$1.invoke(Platform.kt:85)	
at com.vanniktech.maven.publish.GradlePlugin$configure$1$1.invoke(Platform.kt:85)	
at com.vanniktech.maven.publish.PlatformKt.withJavadocJar(Platform.kt:444)	
at com.vanniktech.maven.publish.PlatformKt.access$withJavadocJar(Platform.kt:1)	
at com.vanniktech.maven.publish.GradlePlugin.configure$lambda$0(Platform.kt:85)	
at com.vanniktech.maven.publish.ProjectExtensionsKt.mavenPublicationsWithoutPluginMarker$lambda$0(ProjectExtensions.kt:32)
```
I did a bit of tracing and it looks like you're iterating over every publication in a project, and then adding one of the tasks for each. I have a plugin to support testing gradle plugins that also [adds a publication for test purposes](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/testkit/gradle-testkit-plugin/src/main/kotlin/com/autonomousapps/GradleTestKitSupportExtension.kt#L173-L187).