### PR TITLE
make it possible to use configure with the main plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ and has been enhanced to add Kotlin support and keep up with the latest changes.
 - [Publishing open source projects to Maven Central](https://vanniktech.github.io/gradle-maven-publish-plugin/central/)
 - [Publishing to other Maven repositories](https://vanniktech.github.io/gradle-maven-publish-plugin/other/)
 
+For modifying what is getting published see [configuring what to publish](https://vanniktech.github.io/gradle-maven-publish-plugin/what/).
+
+There is also a [base plugin](https://vanniktech.github.io/gradle-maven-publish-plugin/base/) that doesn't apply any
+default configuration and allows the most customization.
+
 # Supported plugins
 
 The output of the following Gradle plugins is supported to be published with this plugin:
@@ -43,9 +48,6 @@ plugin directly integrate with, so why should you use this plugin?
   no extra setup required.
 - **Gradle property based config**. Easily configure the plugin with Gradle properties that will apply to all
   subprojects
-
-There is also a [base plugin](https://vanniktech.github.io/gradle-maven-publish-plugin/base/) which removes any automatic configuration and allows for a more manual
-configuration of what should be published.
 
 # License
 

--- a/docs/base.md
+++ b/docs/base.md
@@ -1,8 +1,8 @@
 # Base plugin
 
-Starting with version 0.15.0 there is a base plugin. This new plugin has the same capabilities as the main
-plugin but does not configure anything automatically. In the current stage the APIs are still marked with `@Incubating`
-so they might change.
+The base plugin generally provides the same functionality as the main plugin,
+but it doesn't configure anything automatically and instead relies on manual
+configuration.
 
 ## Applying the plugin
 
@@ -26,10 +26,11 @@ Add the plugin to any Gradle project that should be published
 
 ## General configuration
 
+Follow the steps of the [Maven Central](central.md) or [other Maven repositories](other.md) guides.
+Note that the `SONATYPE_HOST`, `SONATYPE_AUTOMATIC_RELEASE` and `RELEASE_SIGNING_ENABLED` are not
+considered by the base plugin and the appropriate DSL methods need to be called.
 
-Follow the steps of the [Maven Central](central.md) or [other Maven repositories](other.md) guides. Note that the
-configuration of where to publish to with Gradle properties won't work in the base plugin. For the pom configuration
-via Gradle properties the following needs to be enabled in the DSL:
+For the pom configuration via Gradle properties the following needs to be enabled in the DSL:
 
 === "build.gradle"
 
@@ -49,367 +50,29 @@ via Gradle properties the following needs to be enabled in the DSL:
 
 ## Configuring what to publish
 
-The biggest difference between the regular and the base plugin is that it won't setup what to publish by default. The
-base plugin offers various APIs depending on the type of project that should be published
+To define what should be published, the `configure` method in the `mavenPublishing`
+block needs to be called. Check out the [what to publish page](what.md) which
+contains a detailed description of available options for each project type.
 
-### Android Library (multiple variants)
-
-For projects using the `com.android.library` plugin. This will publish all variants of the project (e.g. both
-`debug` and `release`) or a subset of specified variants.
+It is also possible to get the automatic behavior of the main plugin by calling
+`configureBasedOnAppliedPlugins()` instead of `configure`
 
 === "build.gradle"
 
     ```groovy
-    import com.vanniktech.maven.publish.AndroidMultiVariantLibrary
-
     mavenPublishing {
-      // the first parameter represents whether to publish a sources jar
-      // the second whether to publish a javadoc jar
-      configure(new AndroidMultiVariantLibrary(true, true))
-      // or to limit which build types to include
-      configure(new AndroidMultiVariantLibrary(true, true, ["beta", "release"]))
-      // or to limit which flavors to include, the map key is a flavor dimension, the set contains the flavors
-      configure(new AndroidMultiVariantLibrary(true, true, ["beta", "release"], ["store": ["google", "samsung"]]))
-    }
-    ```
-
-=== "build.gradle.kts"
-
-    ```kotlin
-    import com.vanniktech.maven.publish.AndroidMultiVariantLibrary
-
-    mavenPublishing {
-      configure(AndroidMultiVariantLibrary(
-        // whether to publish a sources jar
-        sourcesJar = true,
-        // whether to publish a javadoc jar
-        publishJavadocJar = true,
-      ))
+      configure(...)
       // or
-      configure(AndroidMultiVariantLibrary(
-        // whether to publish a sources jar
-        sourcesJar = true,
-        // whether to publish a javadoc jar
-        publishJavadocJar = true,
-        // limit which build types to include
-        includedBuildTypeValues = setOf("beta", "release"),
-      ))
+      configureBasedOnAppliedPlugins()
+    }
+    ```
+
+=== "build.gradle.kts"
+
+    ```kotlin
+    mavenPublishing {
+      configure(...)
       // or
-      configure(AndroidMultiVariantLibrary(
-        // whether to publish a sources jar
-        sourcesJar = true,
-        // whether to publish a javadoc jar
-        publishJavadocJar = true,
-        // limit which build types to include
-        includedBuildTypeValues = setOf("beta", "release"),
-        // limit which flavors to include, the map key is a flavor dimension, the set contains the flavors
-        includedFlavorDimensionsAndValues = mapOf("store" to setOf("google", "samsung")),
-      ))
-    }
-    ```
-
-### Android Library (single variant)
-
-For projects using the `com.android.library` plugin. Compared to the multi variant version above this will only publish
-the specified variant instead of publishing all of them.
-
-=== "build.gradle"
-
-    ```groovy
-    import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-
-    mavenPublishing {
-      // the first parameter represennts which variant is published
-      // the second whether to publish a sources jar
-      // the third whether to publish a javadoc jar
-      configure(new AndroidSingleVariantLibrary("release", true, true))
-    }
-    ```
-
-=== "build.gradle.kts"
-
-    ```kotlin
-    import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-
-    mavenPublishing {
-      configure(AndroidSingleVariantLibrary(
-        // the published variant
-        variant = "release",
-        // whether to publish a sources jar
-        sourcesJar = true,
-        // whether to publish a javadoc jar
-        publishJavadocJar = true,
-      ))
-    }
-    ```
-
-### Java Library
-
-For projects using the `java-library` plugin.
-
-=== "build.gradle"
-
-    ```groovy
-    import com.vanniktech.maven.publish.JavaLibrary
-    import com.vanniktech.maven.publish.JavadocJar
-
-    mavenPublishing {
-      // the first parameter configures the -javadoc artifact, possible values:
-      // - `JavadocJar.None()` don't publish this artifact
-      // - `JavadocJar.Empty()` publish an emprt jar
-      // - `JavadocJar.Javadoc()` to publish standard javadocs
-      // the second whether to publish a sources jar
-      configure(new JavaLibrary(new JavadocJar.Javadoc(), true))
-    }
-    ```
-
-=== "build.gradle.kts"
-
-    ```kotlin
-    import com.vanniktech.maven.publish.JavaLibrary
-    import com.vanniktech.maven.publish.JavadocJar
-
-    mavenPublishing {
-      configure(JavaLibrary(
-        // configures the -javadoc artifact, possible values:
-        // - `JavadocJar.None()` don't publish this artifact
-        // - `JavadocJar.Empty()` publish an emprt jar
-        // - `JavadocJar.Javadoc()` to publish standard javadocs
-        javadocJar = JavadocJar.Javadoc(),
-        // whether to publish a sources jar
-        sourcesJar = true,
-      ))
-    }
-    ```
-
-### Kotlin JVM Library
-
-For projects using the `org.jetbrains.kotlin.jvm` plugin.
-
-=== "build.gradle"
-
-    ```groovy
-    import com.vanniktech.maven.publish.KotlinJvm
-    import com.vanniktech.maven.publish.JavadocJar
-
-    mavenPublishing {
-      // the first parameter configures the -javadoc artifact, possible values:
-      // - `JavadocJar.None()` don't publish this artifact
-      // - `JavadocJar.Empty()` publish an emprt jar
-      // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
-      // the second whether to publish a sources jar
-      configure(new KotlinJvm(new JavadocJar.Dokka("dokkaHtml"), true))
-    }
-    ```
-
-=== "build.gradle.kts"
-
-    ```kotlin
-    import com.vanniktech.maven.publish.KotlinJvm
-    import com.vanniktech.maven.publish.JavadocJar
-
-    mavenPublishing {
-      configure(KotlinJvm(
-        // configures the -javadoc artifact, possible values:
-        // - `JavadocJar.None()` don't publish this artifact
-        // - `JavadocJar.Empty()` publish an emprt jar
-        // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
-        javadocJar = JavadocJar.Dokka("dokkaHtml"),
-        // whether to publish a sources jar
-        sourcesJar = true,
-      ))
-    }
-    ```
-
-### Kotlin JS Library
-
-For projects using the `org.jetbrains.kotlin.js` plugin.
-
-=== "build.gradle"
-
-    ```groovy
-    import com.vanniktech.maven.publish.KotlinJs
-    import com.vanniktech.maven.publish.JavadocJar
-
-    mavenPublishing {
-      // the first parameter configures the -javadoc artifact, possible values:
-      // - `JavadocJar.None()` don't publish this artifact
-      // - `JavadocJar.Empty()` publish an emprt jar
-      // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
-      // sources publishing is always enabled by the Kotlin/JS plugin
-      configure(new KotlinJs(new JavadocJar.Dokka("dokkaHtml")))
-    }
-    ```
-
-=== "build.gradle.kts"
-
-    ```kotlin
-    import com.vanniktech.maven.publish.KotlinJs
-    import com.vanniktech.maven.publish.JavadocJar
-
-    mavenPublishing {
-      // sources publishing is always enabled by the Kotlin/JS plugin
-      configure(KotlinJs(
-        // configures the -javadoc artifact, possible values:
-        // - `JavadocJar.None()` don't publish this artifact
-        // - `JavadocJar.Empty()` publish an emprt jar
-        // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
-        javadocJar = JavadocJar.Dokka("dokkaHtml"),
-      ))
-    }
-    ```
-
-### Kotlin Multiplatform Library
-
-For projects using the `org.jetbrains.kotlin.multiplatform` plugin.
-
-=== "build.gradle"
-
-    ```groovy
-    import com.vanniktech.maven.publish.KotlinMultiplatform
-    import com.vanniktech.maven.publish.JavadocJar
-
-    mavenPublishing {
-      // the parameter configures the -javadoc artifact, possible values:
-      // - `JavadocJar.None()` don't publish this artifact
-      // - `JavadocJar.Empty()` publish an emprt jar
-      // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
-      // sources publishing is always enabled by the Kotlin Multiplatform plugin
-      configure(new KotlinMultiplatform(new JavadocJar.Dokka("dokkaHtml")))
-    }
-    ```
-
-=== "build.gradle.kts"
-
-    ```kotlin
-    import com.vanniktech.maven.publish.KotlinMultiplatform
-    import com.vanniktech.maven.publish.JavadocJar
-
-    mavenPublishing {
-      // sources publishing is always enabled by the Kotlin Multiplatform plugin
-      configure(KotlinMultiplatform(
-        // configures the -javadoc artifact, possible values:
-        // - `JavadocJar.None()` don't publish this artifact
-        // - `JavadocJar.Empty()` publish an emprt jar
-        // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
-        javadocJar = JavadocJar.Dokka("dokkaHtml"),
-      ))
-    }
-    ```
-
-### Gradle Plugin
-
-For projects using the `java-gradle-plugin` plugin. When also using `com.gradle.plugin-publish` please
-use [GradlePublishPlugin](#gradle-publish-plugin)
-
-=== "build.gradle"
-
-    ```groovy
-    import com.vanniktech.maven.publish.GradlePlugin
-    import com.vanniktech.maven.publish.JavadocJar
-
-    mavenPublishing {
-      // the first parameter configures the -javadoc artifact, possible values:
-      // - `JavadocJar.None()` don't publish this artifact
-      // - `JavadocJar.Empty()` publish an emprt jar
-      // - `JavadocJar.Javadoc()` to publish standard javadocs
-      // the second whether to publish a sources jar
-      configure(new GradlePlugin(new JavadocJar.Javadoc(), true))
-    }
-    ```
-
-=== "build.gradle.kts"
-
-    ```kotlin
-    import com.vanniktech.maven.publish.GradlePlugin
-    import com.vanniktech.maven.publish.JavadocJar
-
-    mavenPublishing {
-      configure(GradlePlugin(
-        // configures the -javadoc artifact, possible values:
-        // - `JavadocJar.None()` don't publish this artifact
-        // - `JavadocJar.Empty()` publish an emprt jar
-        // - `JavadocJar.Javadoc()` to publish standard javadocs
-        // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
-        javadocJar = JavadocJar.Javadoc(),
-        // whether to publish a sources jar
-        sourcesJar = true,
-      ))
-    }
-    ```
-
-### Gradle Publish Plugin
-
-For projects using the `com.gradle.plugin-publish` plugin. This will always publish a sources jar
-and a javadoc jar.
-
-=== "build.gradle"
-
-    ```groovy
-    import com.vanniktech.maven.publish.GradlePublishPlugin
-
-    mavenPublishing {
-      configure(new GradlePublishPlugin())
-    }
-    ```
-
-=== "build.gradle.kts"
-
-    ```kotlin
-    import com.vanniktech.maven.publish.GradlePublishPlugin
-
-    mavenPublishing {
-      configure(GradlePublishPlugin())
-    }
-    ```
-
-### Java Platform
-
-
-For projects using the `java-platform` plugin.
-
-=== "build.gradle"
-
-    ```groovy
-    import com.vanniktech.maven.publish.JavaPlatform
-
-    mavenPublishing {
-      configure(new JavaPlatform())
-    }
-    ```
-
-=== "build.gradle.kts"
-
-    ```kotlin
-    import com.vanniktech.maven.publish.JavaPlatform
-
-    mavenPublishing {
-      configure(JavaPlatform())
-    }
-    ```
-
-
-### Version Catalog
-
-
-For projects using the `version-catalog` plugin.
-
-=== "build.gradle"
-
-    ```groovy
-    import com.vanniktech.maven.publish.VersionCatalog
-
-    mavenPublishing {
-      configure(new VersionCatalog())
-    }
-    ```
-
-=== "build.gradle.kts"
-
-    ```kotlin
-    import com.vanniktech.maven.publish.VersionCatalog
-
-    mavenPublishing {
-      configure(VersionCatalog())
+      configureBasedOnAppliedPlugins()
     }
     ```

--- a/docs/central.md
+++ b/docs/central.md
@@ -34,6 +34,34 @@ Add the plugin to any Gradle project that should be published
     }
     ```
 
+## Configuring what to publish
+
+By default, the plugin will automatically detect other applied plugins like the
+Android Gradle plugin or Kotlin Gradle plugin and set up what to publish automatically.
+This automatic configuration includes publishing a sources and a javadoc jar. The
+javadoc jar content is either created from the default javadoc task or from Dokka if
+applied.
+
+To modify these defaults it is possible to call `configure` in the DSL. For
+more check out the [what to publish page](what.md) which contains a detailed
+description of available options for each project type.
+
+=== "build.gradle"
+
+    ```groovy
+    mavenPublishing {
+      configure(...)
+    }
+    ```
+
+=== "build.gradle.kts"
+
+    ```kotlin
+    mavenPublishing {
+      configure(...)
+    }
+    ```
+
 ## Configuring Maven Central
 
 After applying the plugin the first step is to enable publishing to Maven Central

--- a/docs/other.md
+++ b/docs/other.md
@@ -23,6 +23,34 @@ Add the plugin to any Gradle project that should be published
     }
     ```
 
+## Configuring what to publish
+
+By default, the plugin will automatically detect other applied plugins like the
+Android Gradle plugin or Kotlin Gradle plugin and set up what to publish automatically.
+This automatic configuration includes publishing a sources and a javadoc jar. The
+javadoc jar content is either created from the default javadoc task or from Dokka if
+applied.
+
+To modify these defaults it is possible to call `configure` in the DSL. For
+more check out the [what to publish page](what.md) which contains a detailed
+description of available options for each project type.
+
+=== "build.gradle"
+
+    ```groovy
+    mavenPublishing {
+      configure(...)
+    }
+    ```
+
+=== "build.gradle.kts"
+
+    ```kotlin
+    mavenPublishing {
+      configure(...)
+    }
+    ```
+
 ## Configuring the repository
 
 A new repository to publish to can be added like this

--- a/docs/what.md
+++ b/docs/what.md
@@ -1,0 +1,376 @@
+# Configuring what to publish
+
+It is possible to configure publishing for the following Gradle plugins:
+- `com.android.library` as [single variant library](#android-library-single-variant) or
+  as [multi variant library](#android-library-multiple-variants)
+- [`org.jetbrains.kotlin.jvm`](#kotlin-jvm-library)
+- [`org.jetbrains.kotlin.js`](#kotlin-js-library)
+- [`org.jetbrains.kotlin.multiplatform`](#kotlin-multiplatform-library)
+- [`java`](#java-library)
+- [`java-library`](#java-library)
+- [`java-gradle-plugin`](#gradle-plugin)
+- [`com.gradle.plugin-publish`](#gradle-publish-plugin)
+- [`java-platform`](#java-platform)
+- [`version-catalog`](#version-catalog)
+
+## Android Library (multiple variants)
+
+For projects using the `com.android.library` plugin. This will publish all variants of the project (e.g. both
+`debug` and `release`) or a subset of specified variants.
+
+=== "build.gradle"
+
+    ```groovy
+    import com.vanniktech.maven.publish.AndroidMultiVariantLibrary
+
+    mavenPublishing {
+      // the first parameter represents whether to publish a sources jar
+      // the second whether to publish a javadoc jar
+      configure(new AndroidMultiVariantLibrary(true, true))
+      // or to limit which build types to include
+      configure(new AndroidMultiVariantLibrary(true, true, ["beta", "release"]))
+      // or to limit which flavors to include, the map key is a flavor dimension, the set contains the flavors
+      configure(new AndroidMultiVariantLibrary(true, true, ["beta", "release"], ["store": ["google", "samsung"]]))
+    }
+    ```
+
+=== "build.gradle.kts"
+
+    ```kotlin
+    import com.vanniktech.maven.publish.AndroidMultiVariantLibrary
+
+    mavenPublishing {
+      configure(AndroidMultiVariantLibrary(
+        // whether to publish a sources jar
+        sourcesJar = true,
+        // whether to publish a javadoc jar
+        publishJavadocJar = true,
+      ))
+      // or
+      configure(AndroidMultiVariantLibrary(
+        // whether to publish a sources jar
+        sourcesJar = true,
+        // whether to publish a javadoc jar
+        publishJavadocJar = true,
+        // limit which build types to include
+        includedBuildTypeValues = setOf("beta", "release"),
+      ))
+      // or
+      configure(AndroidMultiVariantLibrary(
+        // whether to publish a sources jar
+        sourcesJar = true,
+        // whether to publish a javadoc jar
+        publishJavadocJar = true,
+        // limit which build types to include
+        includedBuildTypeValues = setOf("beta", "release"),
+        // limit which flavors to include, the map key is a flavor dimension, the set contains the flavors
+        includedFlavorDimensionsAndValues = mapOf("store" to setOf("google", "samsung")),
+      ))
+    }
+    ```
+
+## Android Library (single variant)
+
+For projects using the `com.android.library` plugin. Compared to the multi variant version above this will only publish
+the specified variant instead of publishing all of them.
+
+=== "build.gradle"
+
+    ```groovy
+    import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+
+    mavenPublishing {
+      // the first parameter represennts which variant is published
+      // the second whether to publish a sources jar
+      // the third whether to publish a javadoc jar
+      configure(new AndroidSingleVariantLibrary("release", true, true))
+    }
+    ```
+
+=== "build.gradle.kts"
+
+    ```kotlin
+    import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+
+    mavenPublishing {
+      configure(AndroidSingleVariantLibrary(
+        // the published variant
+        variant = "release",
+        // whether to publish a sources jar
+        sourcesJar = true,
+        // whether to publish a javadoc jar
+        publishJavadocJar = true,
+      ))
+    }
+    ```
+
+## Java Library
+
+For projects using the `java-library` plugin.
+
+=== "build.gradle"
+
+    ```groovy
+    import com.vanniktech.maven.publish.JavaLibrary
+    import com.vanniktech.maven.publish.JavadocJar
+
+    mavenPublishing {
+      // the first parameter configures the -javadoc artifact, possible values:
+      // - `JavadocJar.None()` don't publish this artifact
+      // - `JavadocJar.Empty()` publish an emprt jar
+      // - `JavadocJar.Javadoc()` to publish standard javadocs
+      // the second whether to publish a sources jar
+      configure(new JavaLibrary(new JavadocJar.Javadoc(), true))
+    }
+    ```
+
+=== "build.gradle.kts"
+
+    ```kotlin
+    import com.vanniktech.maven.publish.JavaLibrary
+    import com.vanniktech.maven.publish.JavadocJar
+
+    mavenPublishing {
+      configure(JavaLibrary(
+        // configures the -javadoc artifact, possible values:
+        // - `JavadocJar.None()` don't publish this artifact
+        // - `JavadocJar.Empty()` publish an emprt jar
+        // - `JavadocJar.Javadoc()` to publish standard javadocs
+        javadocJar = JavadocJar.Javadoc(),
+        // whether to publish a sources jar
+        sourcesJar = true,
+      ))
+    }
+    ```
+
+## Kotlin JVM Library
+
+For projects using the `org.jetbrains.kotlin.jvm` plugin.
+
+=== "build.gradle"
+
+    ```groovy
+    import com.vanniktech.maven.publish.KotlinJvm
+    import com.vanniktech.maven.publish.JavadocJar
+
+    mavenPublishing {
+      // the first parameter configures the -javadoc artifact, possible values:
+      // - `JavadocJar.None()` don't publish this artifact
+      // - `JavadocJar.Empty()` publish an emprt jar
+      // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
+      // the second whether to publish a sources jar
+      configure(new KotlinJvm(new JavadocJar.Dokka("dokkaHtml"), true))
+    }
+    ```
+
+=== "build.gradle.kts"
+
+    ```kotlin
+    import com.vanniktech.maven.publish.KotlinJvm
+    import com.vanniktech.maven.publish.JavadocJar
+
+    mavenPublishing {
+      configure(KotlinJvm(
+        // configures the -javadoc artifact, possible values:
+        // - `JavadocJar.None()` don't publish this artifact
+        // - `JavadocJar.Empty()` publish an emprt jar
+        // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
+        javadocJar = JavadocJar.Dokka("dokkaHtml"),
+        // whether to publish a sources jar
+        sourcesJar = true,
+      ))
+    }
+    ```
+
+## Kotlin JS Library
+
+For projects using the `org.jetbrains.kotlin.js` plugin.
+
+=== "build.gradle"
+
+    ```groovy
+    import com.vanniktech.maven.publish.KotlinJs
+    import com.vanniktech.maven.publish.JavadocJar
+
+    mavenPublishing {
+      // the first parameter configures the -javadoc artifact, possible values:
+      // - `JavadocJar.None()` don't publish this artifact
+      // - `JavadocJar.Empty()` publish an emprt jar
+      // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
+      // sources publishing is always enabled by the Kotlin/JS plugin
+      configure(new KotlinJs(new JavadocJar.Dokka("dokkaHtml")))
+    }
+    ```
+
+=== "build.gradle.kts"
+
+    ```kotlin
+    import com.vanniktech.maven.publish.KotlinJs
+    import com.vanniktech.maven.publish.JavadocJar
+
+    mavenPublishing {
+      // sources publishing is always enabled by the Kotlin/JS plugin
+      configure(KotlinJs(
+        // configures the -javadoc artifact, possible values:
+        // - `JavadocJar.None()` don't publish this artifact
+        // - `JavadocJar.Empty()` publish an emprt jar
+        // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
+        javadocJar = JavadocJar.Dokka("dokkaHtml"),
+      ))
+    }
+    ```
+
+## Kotlin Multiplatform Library
+
+For projects using the `org.jetbrains.kotlin.multiplatform` plugin.
+
+=== "build.gradle"
+
+    ```groovy
+    import com.vanniktech.maven.publish.KotlinMultiplatform
+    import com.vanniktech.maven.publish.JavadocJar
+
+    mavenPublishing {
+      // the parameter configures the -javadoc artifact, possible values:
+      // - `JavadocJar.None()` don't publish this artifact
+      // - `JavadocJar.Empty()` publish an emprt jar
+      // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
+      // sources publishing is always enabled by the Kotlin Multiplatform plugin
+      configure(new KotlinMultiplatform(new JavadocJar.Dokka("dokkaHtml")))
+    }
+    ```
+
+=== "build.gradle.kts"
+
+    ```kotlin
+    import com.vanniktech.maven.publish.KotlinMultiplatform
+    import com.vanniktech.maven.publish.JavadocJar
+
+    mavenPublishing {
+      // sources publishing is always enabled by the Kotlin Multiplatform plugin
+      configure(KotlinMultiplatform(
+        // configures the -javadoc artifact, possible values:
+        // - `JavadocJar.None()` don't publish this artifact
+        // - `JavadocJar.Empty()` publish an emprt jar
+        // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
+        javadocJar = JavadocJar.Dokka("dokkaHtml"),
+      ))
+    }
+    ```
+
+## Gradle Plugin
+
+For projects using the `java-gradle-plugin` plugin. When also using `com.gradle.plugin-publish` please
+use [GradlePublishPlugin](#gradle-publish-plugin)
+
+=== "build.gradle"
+
+    ```groovy
+    import com.vanniktech.maven.publish.GradlePlugin
+    import com.vanniktech.maven.publish.JavadocJar
+
+    mavenPublishing {
+      // the first parameter configures the -javadoc artifact, possible values:
+      // - `JavadocJar.None()` don't publish this artifact
+      // - `JavadocJar.Empty()` publish an emprt jar
+      // - `JavadocJar.Javadoc()` to publish standard javadocs
+      // the second whether to publish a sources jar
+      configure(new GradlePlugin(new JavadocJar.Javadoc(), true))
+    }
+    ```
+
+=== "build.gradle.kts"
+
+    ```kotlin
+    import com.vanniktech.maven.publish.GradlePlugin
+    import com.vanniktech.maven.publish.JavadocJar
+
+    mavenPublishing {
+      configure(GradlePlugin(
+        // configures the -javadoc artifact, possible values:
+        // - `JavadocJar.None()` don't publish this artifact
+        // - `JavadocJar.Empty()` publish an emprt jar
+        // - `JavadocJar.Javadoc()` to publish standard javadocs
+        // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
+        javadocJar = JavadocJar.Javadoc(),
+        // whether to publish a sources jar
+        sourcesJar = true,
+      ))
+    }
+    ```
+
+## Gradle Publish Plugin
+
+For projects using the `com.gradle.plugin-publish` plugin. This will always publish a sources jar
+and a javadoc jar.
+
+=== "build.gradle"
+
+    ```groovy
+    import com.vanniktech.maven.publish.GradlePublishPlugin
+
+    mavenPublishing {
+      configure(new GradlePublishPlugin())
+    }
+    ```
+
+=== "build.gradle.kts"
+
+    ```kotlin
+    import com.vanniktech.maven.publish.GradlePublishPlugin
+
+    mavenPublishing {
+      configure(GradlePublishPlugin())
+    }
+    ```
+
+## Java Platform
+
+
+For projects using the `java-platform` plugin.
+
+=== "build.gradle"
+
+    ```groovy
+    import com.vanniktech.maven.publish.JavaPlatform
+
+    mavenPublishing {
+      configure(new JavaPlatform())
+    }
+    ```
+
+=== "build.gradle.kts"
+
+    ```kotlin
+    import com.vanniktech.maven.publish.JavaPlatform
+
+    mavenPublishing {
+      configure(JavaPlatform())
+    }
+    ```
+
+
+## Version Catalog
+
+
+For projects using the `version-catalog` plugin.
+
+=== "build.gradle"
+
+    ```groovy
+    import com.vanniktech.maven.publish.VersionCatalog
+
+    mavenPublishing {
+      configure(new VersionCatalog())
+    }
+    ```
+
+=== "build.gradle.kts"
+
+    ```kotlin
+    import com.vanniktech.maven.publish.VersionCatalog
+
+    mavenPublishing {
+      configure(VersionCatalog())
+    }
+    ```

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
@@ -178,7 +178,6 @@ private fun writeSettingFile(path: Path) {
 
     dependencyResolutionManagement {
         repositories {
-            mavenLocal()
             mavenCentral()
             google()
         }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
@@ -3,7 +3,9 @@ package com.vanniktech.maven.publish
 import com.android.build.api.AndroidPluginVersion
 import com.android.build.api.variant.AndroidComponentsExtension
 import org.gradle.api.Action
+import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.plugins.signing.SigningExtension
@@ -33,6 +35,20 @@ internal fun Project.mavenPublicationsWithoutPluginMarker(action: Action<MavenPu
       action.execute(it)
     }
   }
+}
+
+internal fun Project.javaVersion(): JavaVersion {
+  try {
+    val extension = extensions.findByType(JavaPluginExtension::class.java)
+    if (extension != null) {
+      val toolchain = extension.toolchain
+      val version = toolchain.languageVersion.get().asInt()
+      return JavaVersion.toVersion(version)
+    }
+  } catch (t: Throwable) {
+    // ignore failures and fallback to java version in which Gradle is running
+  }
+  return JavaVersion.current()
 }
 
 internal fun Project.isAtLeastKotlinVersion(id: String, major: Int, minor: Int, patch: Int): Boolean {


### PR DESCRIPTION
This brings 2 changes:
- It's possible to call configure from a build script in the main plugin which resolves #675, #624 and #565.
- The underlying functionality of automatic configuration is now exposed in the extension through `configureBasedOnAppliedPlugins`. This allows to get the automatic behavior for the base plugin while keeping the rest configurable manually.

The tests run through without an issue, so moving the automatic KMP configuration to `afterEvaluate` doesn't seem to have any issues. In the first place I only moved it out of `afterEvaluate` in #351 so that it runs before the Android configuration in `finalizeDsl`. That's not really needed since we can just do the KMP configuration in `finalizeDsl` as well and then no-op in `afterEvaluate` if the platform was already configured.

