### PR TITLE
refactor: Make the `coordinates()` parameters nullable

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -166,10 +166,10 @@ abstract class MavenPublishBaseExtension(
    * artifactIds like `[artifactId]-jvm`.
    */
   @Incubating
-  fun coordinates(groupId: String, artifactId: String, version: String) {
-    groupId(groupId)
-    artifactId(artifactId)
-    version(version)
+  fun coordinates(groupId: String? = null, artifactId: String? = null, version: String? = null) {
+    groupId?.also { groupId(it) }
+    artifactId?.also { artifactId(it) }
+    version?.also { version(it) }
   }
 
   private fun groupId(groupId: String) {


### PR DESCRIPTION
Allow to set only specific (non-null) arguments.