### PR TITLE
move repository creation to build service

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
@@ -1,8 +1,6 @@
 package com.vanniktech.maven.publish
 
-import com.vanniktech.maven.publish.sonatype.SonatypeRepositoryBuildService
 import java.io.Serializable
-import org.gradle.api.provider.Provider
 
 /**
  * Describes the various hosts for Sonatype OSSRH. Depending on when a user signed up with Sonatype
@@ -15,31 +13,6 @@ data class SonatypeHost(
 ) : Serializable {
   internal fun apiBaseUrl(): String {
     return "$rootUrl/service/local/"
-  }
-
-  internal fun publishingUrl(
-    snapshot: Provider<Boolean>,
-    buildService: Provider<SonatypeRepositoryBuildService>,
-    configCache: Boolean,
-  ): String {
-    return if (snapshot.get()) {
-      require(buildService.get().stagingRepositoryId == null) {
-        "Staging repositories are not supported for SNAPSHOT versions."
-      }
-      "$rootUrl/content/repositories/snapshots/"
-    } else {
-      val stagingRepositoryId = buildService.get().stagingRepositoryId
-      requireNotNull(stagingRepositoryId) {
-        if (configCache) {
-          "Publishing releases to Maven Central is not supported yet with configuration caching enabled, because of " +
-            "this missing Gradle feature: https://github.com/gradle/gradle/issues/22779"
-        } else {
-          "The staging repository was not created yet. Please open a bug with a build scan or build logs and stacktrace"
-        }
-      }
-
-      "$rootUrl/service/local/staging/deployByRepositoryId/$stagingRepositoryId/"
-    }
   }
 
   companion object {

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
@@ -31,35 +31,19 @@ internal abstract class CreateSonatypeRepositoryTask : DefaultTask() {
     val workQueue: WorkQueue = getWorkerExecutor().noIsolation()
     workQueue.submit(CreateStagingRepository::class.java) {
       requireNotNull(it)
-      it.projectGroup.set(projectGroup)
-      it.versionIsSnapshot.set(versionIsSnapshot)
       it.buildService.set(buildService)
     }
   }
 
   internal interface CreateStagingRepositoryParameters : WorkParameters {
-    val projectGroup: Property<String>
-    val versionIsSnapshot: Property<Boolean>
     val buildService: Property<SonatypeRepositoryBuildService>
   }
 
   abstract class CreateStagingRepository : WorkAction<CreateStagingRepositoryParameters?> {
     override fun execute() {
       val parameters = requireNotNull(parameters)
-      if (parameters.versionIsSnapshot.get()) {
-        return
-      }
-
       val service = parameters.buildService.get()
-
-      // if repository was already created in this build this is a no-op
-      val currentStagingRepositoryId = service.stagingRepositoryId
-      if (currentStagingRepositoryId != null) {
-        return
-      }
-
-      val id = service.nexus.createRepositoryForGroup(parameters.projectGroup.get())
-      service.stagingRepositoryId = id
+      service.createStagingRepository()
     }
   }
 
@@ -67,15 +51,11 @@ internal abstract class CreateSonatypeRepositoryTask : DefaultTask() {
     private const val NAME = "createStagingRepository"
 
     fun TaskContainer.registerCreateRepository(
-      projectGroup: Provider<String>,
-      versionIsSnapshot: Provider<Boolean>,
       buildService: Provider<SonatypeRepositoryBuildService>,
     ): TaskProvider<CreateSonatypeRepositoryTask> {
       return register(NAME, CreateSonatypeRepositoryTask::class.java) {
         it.description = "Create a staging repository on Sonatype OSS"
         it.group = "release"
-        it.projectGroup.set(projectGroup)
-        it.versionIsSnapshot.set(versionIsSnapshot)
         it.buildService.set(buildService)
         it.usesService(buildService)
       }


### PR DESCRIPTION
Moves the logic from the `CreateSonatypeRepositoryTask` and `SonatypeHost.publishingUrl(...)` to the build service so that `stagingRepositoryId` can be private. This avoids wrong usages of that variable and also will allow some improvements for the closeAndRelease and drop repository tasks.