### PR TITLE
bump minimum versions and cleanup conditional code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        java_version: [11, 17, 20, 21]
+        java_version: [11, 17, 21]
         test_config_method: ["DSL", "PROPERTIES", "BASE"]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Change Log
 
+## 0.28.0 **UNRELEASED**
+
+- Removed support for the deprecated Kotlin/JS plugin.
+- Updated minimum supported Gradle, Android Gradle Plugin and Kotlin versions.
+
+#### Minimum supported versions
+- JDK 11
+- Gradle 8.1
+- Android Gradle Plugin 8.0.0
+- Kotlin Gradle Plugin 1.9.20
+
+#### Compatibility tested up to
+- JDK 21
+- Gradle 8.5
+- Gradle 8.6-rc-1
+- Android Gradle Plugin 8.2.1
+- Android Gradle Plugin 8.3.0-beta01
+- Android Gradle Plugin 8.4.0-alpha03
+- Kotlin Gradle Plugin 1.9.22
+- Kotlin Gradle Plugin 2.0.0-Beta2
+
+#### Configuration cache status
+
+Configuration cache is generally supported, except for:
+- Publishing releases to Maven Central (snapshots are fine), blocked by [Gradle issue #22779](https://github.com/gradle/gradle/issues/22779).
+- Dokka does not support configuration cache
+
+
 ## 0.27.0 *(2024-01-06)*
 
 - Added new publishing related tasks

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ The output of the following Gradle plugins is supported to be published with thi
 
 - `com.android.library`
 - `org.jetbrains.kotlin.jvm`
-- `org.jetbrains.kotlin.js`
 - `org.jetbrains.kotlin.multiplatform`
 - `java`
 - `java-library`

--- a/docs/what.md
+++ b/docs/what.md
@@ -4,7 +4,6 @@ It is possible to configure publishing for the following Gradle plugins:
 - `com.android.library` as [single variant library](#android-library-single-variant) or
   as [multi variant library](#android-library-multiple-variants)
 - [`org.jetbrains.kotlin.jvm`](#kotlin-jvm-library)
-- [`org.jetbrains.kotlin.js`](#kotlin-js-library)
 - [`org.jetbrains.kotlin.multiplatform`](#kotlin-multiplatform-library)
 - [`java`](#java-library)
 - [`java-library`](#java-library)
@@ -178,44 +177,6 @@ For projects using the `org.jetbrains.kotlin.jvm` plugin.
         javadocJar = JavadocJar.Dokka("dokkaHtml"),
         // whether to publish a sources jar
         sourcesJar = true,
-      ))
-    }
-    ```
-
-## Kotlin JS Library
-
-For projects using the `org.jetbrains.kotlin.js` plugin.
-
-=== "build.gradle"
-
-    ```groovy
-    import com.vanniktech.maven.publish.KotlinJs
-    import com.vanniktech.maven.publish.JavadocJar
-
-    mavenPublishing {
-      // the first parameter configures the -javadoc artifact, possible values:
-      // - `JavadocJar.None()` don't publish this artifact
-      // - `JavadocJar.Empty()` publish an emprt jar
-      // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
-      // sources publishing is always enabled by the Kotlin/JS plugin
-      configure(new KotlinJs(new JavadocJar.Dokka("dokkaHtml")))
-    }
-    ```
-
-=== "build.gradle.kts"
-
-    ```kotlin
-    import com.vanniktech.maven.publish.KotlinJs
-    import com.vanniktech.maven.publish.JavadocJar
-
-    mavenPublishing {
-      // sources publishing is always enabled by the Kotlin/JS plugin
-      configure(KotlinJs(
-        // configures the -javadoc artifact, possible values:
-        // - `JavadocJar.None()` don't publish this artifact
-        // - `JavadocJar.Empty()` publish an emprt jar
-        // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
-        javadocJar = JavadocJar.Dokka("dokkaHtml"),
       ))
     }
     ```

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginPlatformTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginPlatformTest.kt
@@ -289,38 +289,6 @@ class MavenPublishPluginPlatformTest {
   }
 
   @TestParameterInjectorTest
-  fun kotlinJsProject(
-    @TestParameter(valuesProvider = KotlinVersionProvider::class) kotlinVersion: KotlinVersion,
-  ) {
-    kotlinVersion.assumeSupportedJdkAndGradleVersion(gradleVersion)
-
-    val project = kotlinJsProjectSpec(kotlinVersion)
-    val result = project.run(fixtures, testProjectDir, testOptions)
-
-    assertThat(result).outcome().succeeded()
-    assertThat(result).artifact("klib").exists()
-    assertThat(result).artifact("klib").isSigned()
-    assertThat(result).pom().exists()
-    assertThat(result).pom().isSigned()
-    if (kotlinVersion >= KotlinVersion.KT_1_9_0) {
-      assertThat(result).pom().matchesExpectedPom(
-        "klib",
-        kotlinStdlibJs(kotlinVersion),
-        kotlinDomApi(kotlinVersion),
-      )
-    } else {
-      assertThat(result).pom().matchesExpectedPom("klib", kotlinStdlibJs(kotlinVersion))
-    }
-    assertThat(result).module().exists()
-    assertThat(result).module().isSigned()
-    assertThat(result).sourcesJar().exists()
-    assertThat(result).sourcesJar().isSigned()
-    assertThat(result).sourcesJar().containsAllSourceFiles()
-    assertThat(result).javadocJar().exists()
-    assertThat(result).javadocJar().isSigned()
-  }
-
-  @TestParameterInjectorTest
   fun kotlinMultiplatformProject(
     @TestParameter(valuesProvider = KotlinVersionProvider::class) kotlinVersion: KotlinVersion,
   ) {
@@ -387,26 +355,7 @@ class MavenPublishPluginPlatformTest {
     assertThat(nodejsResult).artifact("klib").isSigned()
     assertThat(nodejsResult).pom().exists()
     assertThat(nodejsResult).pom().isSigned()
-    if (kotlinVersion >= KotlinVersion.KT_1_9_20) {
-      assertThat(nodejsResult).pom().matchesExpectedPom(
-        "klib",
-        kotlinStdlibMppJs(kotlinVersion),
-        kotlinDomApi(kotlinVersion),
-      )
-    } else if (kotlinVersion >= KotlinVersion.KT_1_9_0) {
-      assertThat(nodejsResult).pom().matchesExpectedPom(
-        "klib",
-        kotlinStdlibMppJs(kotlinVersion),
-        kotlinDomApi(kotlinVersion),
-        kotlinStdlibCommon(kotlinVersion),
-      )
-    } else {
-      assertThat(nodejsResult).pom().matchesExpectedPom(
-        "klib",
-        kotlinStdlibMppJs(kotlinVersion),
-        kotlinStdlibCommon(kotlinVersion),
-      )
-    }
+    assertThat(nodejsResult).pom().matchesExpectedPom("klib", kotlinStdlibJs(kotlinVersion), kotlinDomApi(kotlinVersion))
     assertThat(nodejsResult).module().exists()
     assertThat(nodejsResult).module().isSigned()
     assertThat(nodejsResult).sourcesJar().exists()
@@ -485,26 +434,7 @@ class MavenPublishPluginPlatformTest {
     assertThat(nodejsResult).artifact("klib").isSigned()
     assertThat(nodejsResult).pom().exists()
     assertThat(nodejsResult).pom().isSigned()
-    if (kotlinVersion >= KotlinVersion.KT_1_9_20) {
-      assertThat(nodejsResult).pom().matchesExpectedPom(
-        "klib",
-        kotlinStdlibMppJs(kotlinVersion),
-        kotlinDomApi(kotlinVersion),
-      )
-    } else if (kotlinVersion >= KotlinVersion.KT_1_9_0) {
-      assertThat(nodejsResult).pom().matchesExpectedPom(
-        "klib",
-        kotlinStdlibMppJs(kotlinVersion),
-        kotlinDomApi(kotlinVersion),
-        kotlinStdlibCommon(kotlinVersion),
-      )
-    } else {
-      assertThat(nodejsResult).pom().matchesExpectedPom(
-        "klib",
-        kotlinStdlibMppJs(kotlinVersion),
-        kotlinStdlibCommon(kotlinVersion),
-      )
-    }
+    assertThat(nodejsResult).pom().matchesExpectedPom("klib", kotlinStdlibJs(kotlinVersion), kotlinDomApi(kotlinVersion))
     assertThat(nodejsResult).module().exists()
     assertThat(nodejsResult).module().isSigned()
     assertThat(nodejsResult).sourcesJar().exists()
@@ -660,8 +590,6 @@ class MavenPublishPluginPlatformTest {
 
   @TestParameterInjectorTest
   fun versionCatalogProject() {
-    assume().that(gradleVersion).isAtLeast(GradleVersion.GRADLE_7_6)
-
     val project = versionCatalogProjectSpec()
     val result = project.run(fixtures, testProjectDir, testOptions)
 

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginSpecialCaseTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginSpecialCaseTest.kt
@@ -80,26 +80,7 @@ class MavenPublishPluginSpecialCaseTest {
     assertThat(nodejsResult).outcome().succeeded()
     assertThat(nodejsResult).artifact("klib").exists()
     assertThat(nodejsResult).pom().exists()
-    if (kotlinVersion >= KotlinVersion.KT_1_9_20) {
-      assertThat(nodejsResult).pom().matchesExpectedPom(
-        "klib",
-        kotlinStdlibMppJs(kotlinVersion),
-        kotlinDomApi(kotlinVersion),
-      )
-    } else if (kotlinVersion >= KotlinVersion.KT_1_9_0) {
-      assertThat(nodejsResult).pom().matchesExpectedPom(
-        "klib",
-        kotlinStdlibMppJs(kotlinVersion),
-        kotlinDomApi(kotlinVersion),
-        kotlinStdlibCommon(kotlinVersion),
-      )
-    } else {
-      assertThat(nodejsResult).pom().matchesExpectedPom(
-        "klib",
-        kotlinStdlibMppJs(kotlinVersion),
-        kotlinStdlibCommon(kotlinVersion),
-      )
-    }
+    assertThat(nodejsResult).pom().matchesExpectedPom("klib", kotlinStdlibJs(kotlinVersion), kotlinDomApi(kotlinVersion))
     assertThat(nodejsResult).module().exists()
     assertThat(nodejsResult).sourcesJar().exists()
     assertThat(nodejsResult).sourcesJar().containsSourceSetFiles("commonMain", "nodeJsMain")
@@ -159,26 +140,7 @@ class MavenPublishPluginSpecialCaseTest {
     assertThat(nodejsResult).outcome().succeeded()
     assertThat(nodejsResult).artifact("klib").exists()
     assertThat(nodejsResult).pom().exists()
-    if (kotlinVersion >= KotlinVersion.KT_1_9_20) {
-      assertThat(nodejsResult).pom().matchesExpectedPom(
-        "klib",
-        kotlinStdlibMppJs(kotlinVersion),
-        kotlinDomApi(kotlinVersion),
-      )
-    } else if (kotlinVersion >= KotlinVersion.KT_1_9_0) {
-      assertThat(nodejsResult).pom().matchesExpectedPom(
-        "klib",
-        kotlinStdlibMppJs(kotlinVersion),
-        kotlinDomApi(kotlinVersion),
-        kotlinStdlibCommon(kotlinVersion),
-      )
-    } else {
-      assertThat(nodejsResult).pom().matchesExpectedPom(
-        "klib",
-        kotlinStdlibMppJs(kotlinVersion),
-        kotlinStdlibCommon(kotlinVersion),
-      )
-    }
+    assertThat(nodejsResult).pom().matchesExpectedPom("klib", kotlinStdlibJs(kotlinVersion), kotlinDomApi(kotlinVersion))
     assertThat(nodejsResult).module().exists()
     assertThat(nodejsResult).sourcesJar().exists()
     assertThat(nodejsResult).sourcesJar().containsSourceSetFiles("commonMain", "nodeJsMain")

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/Pom.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/Pom.kt
@@ -15,27 +15,11 @@ data class PomDependency(
   val optional: Boolean? = null,
 )
 
-fun kotlinStdlibCommon(version: KotlinVersion) = PomDependency(
-  "org.jetbrains.kotlin",
-  version.commonStdlibArtifactId,
-  version.value,
-  "compile",
-)
+fun kotlinStdlibCommon(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", "kotlin-stdlib", version.value, "compile")
 
-private val KotlinVersion.commonStdlibArtifactId
-  get() = if (this < KotlinVersion.KT_1_9_20) "kotlin-stdlib-common" else "kotlin-stdlib"
+fun kotlinStdlibJdk(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", "kotlin-stdlib", version.value, "compile")
 
-fun kotlinStdlibJdk(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", version.jdkStdlibArtifactId, version.value, "compile")
-
-private val KotlinVersion.jdkStdlibArtifactId
-  get() = if (this < KotlinVersion.KT_1_9_20) "kotlin-stdlib-jdk8" else "kotlin-stdlib"
-
-fun kotlinStdlibJs(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", version.jsStdlibArtifactId, version.value, "compile")
-
-private val KotlinVersion.jsStdlibArtifactId
-  get() = if (this < KotlinVersion.KT_1_9_20) "kotlin-stdlib-js" else "kotlin-stdlib"
-
-fun kotlinStdlibMppJs(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", "kotlin-stdlib-js", version.value, "compile")
+fun kotlinStdlibJs(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", "kotlin-stdlib-js", version.value, "compile")
 
 fun kotlinDomApi(version: KotlinVersion) = PomDependency("org.jetbrains.kotlin", "kotlin-dom-api-compat", version.value, "compile")
 

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
@@ -19,7 +19,7 @@ fun ProjectSpec.run(fixtures: Path, temp: Path, options: TestOptions): ProjectRe
 
   val task = ":publishAllPublicationsToTestFolderRepository"
   val arguments = mutableListOf(task, "--stacktrace")
-  if (options.supportsConfigCaching(plugins)) {
+  if (supportsConfigCaching(plugins)) {
     arguments.add("--configuration-cache")
   }
 
@@ -39,24 +39,9 @@ fun ProjectSpec.run(fixtures: Path, temp: Path, options: TestOptions): ProjectRe
   )
 }
 
-private fun TestOptions.supportsConfigCaching(plugins: List<PluginSpec>): Boolean {
+private fun supportsConfigCaching(plugins: List<PluginSpec>): Boolean {
   // TODO https://github.com/Kotlin/dokka/issues/2231
-  if (plugins.any { it.id == dokkaPlugin.id }) {
-    return false
-  }
-
-  // publishing supports configuration cache starting with 7.6
-  // signing only supports configuration cache starting with 8.1
-  val configCachingSupported = gradleVersion >= GradleVersion.GRADLE_8_1 || signing == TestOptions.Signing.NO_SIGNING
-
-  // Kotlin MPP supports config cache since 1.9.0
-  val multiplatformPlugin = plugins.find { it.id == kotlinMultiplatformPlugin.id }
-  if (multiplatformPlugin != null) {
-    val version = KotlinVersion.entries.find { it.value == multiplatformPlugin.version }!!
-    return version >= KotlinVersion.KT_1_9_0 && configCachingSupported
-  }
-
-  return configCachingSupported
+  return !plugins.any { it.id == dokkaPlugin.id }
 }
 
 private fun ProjectSpec.writeBuildFile(path: Path, repo: Path, options: TestOptions) {

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecs.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecs.kt
@@ -11,7 +11,6 @@ val javaPlatformPlugin = PluginSpec("java-platform")
 val versionCatalogPlugin = PluginSpec("version-catalog")
 val kotlinJvmPlugin = PluginSpec("org.jetbrains.kotlin.jvm")
 val kotlinMultiplatformPlugin = PluginSpec("org.jetbrains.kotlin.multiplatform")
-val kotlinJsPlugin = PluginSpec("org.jetbrains.kotlin.js")
 val kotlinAndroidPlugin = PluginSpec("org.jetbrains.kotlin.android")
 val androidLibraryPlugin = PluginSpec("com.android.library")
 val gradlePluginPublishPlugin = PluginSpec("com.gradle.plugin-publish")
@@ -119,27 +118,6 @@ fun kotlinJvmProjectSpec(version: KotlinVersion) = ProjectSpec(
     SourceFile("main", "kotlin", "com/vanniktech/maven/publish/test/KotlinTestClass.kt"),
   ),
   basePluginConfig = "configure(new KotlinJvm(new JavadocJar.Empty(), true))",
-)
-
-fun kotlinJsProjectSpec(version: KotlinVersion) = ProjectSpec(
-  plugins = listOf(
-    kotlinJsPlugin.copy(version = version.value),
-  ),
-  group = "com.example",
-  artifactId = "test-artifact",
-  version = "1.0.0",
-  properties = defaultProperties,
-  sourceFiles = listOf(
-    SourceFile("main", "kotlin", "com/vanniktech/maven/publish/test/KotlinTestClass.kt"),
-  ),
-  basePluginConfig = "configure(new KotlinJs(new JavadocJar.Empty(), true))",
-  buildFileExtra = """
-    kotlin {
-        js("IR") {
-            nodejs()
-        }
-    }
-  """.trimIndent(),
 )
 
 fun kotlinMultiplatformProjectSpec(version: KotlinVersion) = ProjectSpec(

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/Subjects.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/Subjects.kt
@@ -158,7 +158,7 @@ open class ArtifactSubject internal constructor(
     val notMatchingFiles = mutableListOf<Fact>()
 
     filesToFind.forEach { sourceFile ->
-      // fallback is a workaround for KotlinJs creating a main folder inside the jar
+      // fallback is a workaround for Kotlin creating a main folder inside the jar
       val entry = zipFiles.find { fileMatcher(sourceFile, it) }
       if (entry == null) {
         missingFiles.add(fileDescriptor(sourceFile))

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -42,7 +42,7 @@ enum class AgpVersion(
   // beta channel
   AGP_8_3(
     value = "8.3.0-beta01",
-    minGradleVersion = GradleVersion.GRADLE_8_2,
+    minGradleVersion = GradleVersion.GRADLE_8_4,
     minJdkVersion = JavaVersion.VERSION_17,
   ),
 

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -105,7 +105,7 @@ fun KotlinVersion.assumeSupportedJdkAndGradleVersion(gradleVersion: GradleVersio
 }
 
 fun AgpVersion.assumeSupportedJdkAndGradleVersion(gradleVersion: GradleVersion) {
-  assume().that(JavaVersion.current()).isLessThan(minJdkVersion)
+  assume().that(JavaVersion.current()).isAtLeast(minJdkVersion)
   assume().that(gradleVersion).isAtLeast(minGradleVersion)
   if (firstUnsupportedGradleVersion != null) {
     assume().that(gradleVersion).isLessThan(firstUnsupportedGradleVersion)

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -36,13 +36,13 @@ enum class AgpVersion(
   // stable
   AGP_8_2(
     value = "8.2.0",
-    minGradleVersion = GradleVersion.GRADLE_8_1,
+    minGradleVersion = GradleVersion.GRADLE_8_2,
   ),
 
   // canary channel
   AGP_8_3(
     value = "8.3.0-alpha18",
-    minGradleVersion = GradleVersion.GRADLE_8_1,
+    minGradleVersion = GradleVersion.GRADLE_8_2,
   ),
 }
 
@@ -73,6 +73,12 @@ enum class GradleVersion(
   GRADLE_8_5(
     value = "8.5",
   ),
+  ;
+
+  companion object {
+    // aliases for the skipped version to be able to reference the correct one in AgpVersion
+    val GRADLE_8_2 = GRADLE_8_5
+  }
 }
 
 enum class GradlePluginPublish(val version: String) {
@@ -99,7 +105,7 @@ fun KotlinVersion.assumeSupportedJdkAndGradleVersion(gradleVersion: GradleVersio
 }
 
 fun AgpVersion.assumeSupportedJdkAndGradleVersion(gradleVersion: GradleVersion) {
-  assume().that(JavaVersion.current()).isAtLeast(minJdkVersion)
+  assume().that(JavaVersion.current()).isLessThan(minJdkVersion)
   assume().that(gradleVersion).isAtLeast(minGradleVersion)
   if (firstUnsupportedGradleVersion != null) {
     assume().that(gradleVersion).isLessThan(firstUnsupportedGradleVersion)

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -25,26 +25,24 @@ enum class AgpVersion(
   val value: String,
   val minGradleVersion: GradleVersion,
   val firstUnsupportedGradleVersion: GradleVersion? = null,
-  val minJdkVersion: JavaVersion = JavaVersion.VERSION_11,
+  val minJdkVersion: JavaVersion = JavaVersion.VERSION_17,
 ) {
   // minimum supported
-  AGP_7_4(
-    value = "7.4.0",
-    minGradleVersion = GradleVersion.GRADLE_7_6,
+  AGP_8_0(
+    value = "8.0.0",
+    minGradleVersion = GradleVersion.GRADLE_8_1,
   ),
 
   // stable
   AGP_8_2(
     value = "8.2.0",
     minGradleVersion = GradleVersion.GRADLE_8_1,
-    minJdkVersion = JavaVersion.VERSION_17,
   ),
 
   // canary channel
   AGP_8_3(
-    value = "8.3.0-alpha17",
+    value = "8.3.0-alpha18",
     minGradleVersion = GradleVersion.GRADLE_8_1,
-    minJdkVersion = JavaVersion.VERSION_17,
   ),
 }
 
@@ -54,23 +52,11 @@ enum class KotlinVersion(
   val firstUnsupportedGradleVersion: GradleVersion? = null,
 ) {
   // minimum supported
-  KT_1_8_20(
-    "1.8.20",
-    firstUnsupportedJdkVersion = JavaVersion.VERSION_20,
-  ),
-
   // stable
   KT_1_9_21("1.9.21"),
 
   // beta
-  KT_2_0_0("2.0.0-Beta1"),
-  ;
-
-  companion object {
-    // aliases for skipped versions
-    val KT_1_9_0 = KT_1_9_21
-    val KT_1_9_20 = KT_1_9_21
-  }
+  KT_2_0_0("2.0.0-Beta2"),
 }
 
 enum class GradleVersion(
@@ -78,25 +64,15 @@ enum class GradleVersion(
   val firstUnsupportedJdkVersion: JavaVersion? = null,
 ) {
   // minimum supported
-  GRADLE_7_6(
-    value = "7.6",
-    firstUnsupportedJdkVersion = JavaVersion.VERSION_18,
+  GRADLE_8_1(
+    value = "8.1",
+    firstUnsupportedJdkVersion = JavaVersion.VERSION_20,
   ),
 
   // stable
   GRADLE_8_5(
     value = "8.5",
   ),
-  ;
-
-  companion object {
-    // aliases for the skipped version to be able to reference the correct one in AgpVersion
-    val GRADLE_8_0 = GRADLE_8_5
-    val GRADLE_8_1 = GRADLE_8_5
-    val GRADLE_8_2 = GRADLE_8_5
-    val GRADLE_8_3 = GRADLE_8_5
-    val GRADLE_8_4 = GRADLE_8_5
-  }
 }
 
 enum class GradlePluginPublish(val version: String) {

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -19,7 +19,6 @@ import org.gradle.external.javadoc.StandardJavadocDocletOptions
 import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningPlugin
 import org.gradle.plugins.signing.type.pgp.ArmoredSignatureType
-import org.gradle.util.GradleVersion
 import org.jetbrains.dokka.gradle.DokkaTask
 
 abstract class MavenPublishBaseExtension(
@@ -134,15 +133,7 @@ abstract class MavenPublishBaseExtension(
     }
 
     project.mavenPublications { publication ->
-      if (GradleVersion.current() < GradleVersion.version("8.0-rc-1")) {
-        // workaround incompatibility with other plugins because sign(publication) was not idempotent
-        val task = project.tasks.findByName("sign${publication.name.capitalize()}Publication")
-        if (task == null) {
-          project.gradleSigning.sign(publication)
-        }
-      } else {
-        project.gradleSigning.sign(publication)
-      }
+      project.gradleSigning.sign(publication)
     }
 
     // TODO: remove after https://youtrack.jetbrains.com/issue/KT-46466 is fixed
@@ -376,9 +367,6 @@ abstract class MavenPublishBaseExtension(
         configure(GradlePlugin(defaultJavaDocOption(plainJavadocSupported = true)))
       project.plugins.hasPlugin("org.jetbrains.kotlin.jvm") ->
         configure(KotlinJvm(defaultJavaDocOption(plainJavadocSupported = true)))
-      project.plugins.hasPlugin("org.jetbrains.kotlin.js") ->
-        @Suppress("DEPRECATION")
-        configure(KotlinJs(defaultJavaDocOption(plainJavadocSupported = false)))
       project.plugins.hasPlugin("java-library") ->
         configure(JavaLibrary(defaultJavaDocOption(plainJavadocSupported = true)))
       project.plugins.hasPlugin("java") ->

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBasePlugin.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBasePlugin.kt
@@ -19,24 +19,23 @@ open class MavenPublishBasePlugin : Plugin<Project> {
       error("You need Gradle version $MIN_GRADLE_VERSION or higher, was ${GradleVersion.current()}")
     }
     plugins.withId("com.android.library") {
-      if (!isAtLeastUsingAndroidGradleVersion(7, 4, 0)) {
-        error("You need AGP version 7.4.0 or newer")
+      if (!isAtLeastUsingAndroidGradleVersion(8, 0, 0)) {
+        error("You need AGP version 8.0.0 or newer")
       }
     }
     KOTLIN_PLUGIN_IDS.forEach { pluginId ->
       plugins.withId(pluginId) {
-        if (!isAtLeastKotlinVersion(pluginId, 1, 8, 20)) {
-          error("You need Kotlin version 1.8.20 or newer")
+        if (!isAtLeastKotlinVersion(pluginId, 1, 9, 20)) {
+          error("You need Kotlin version 1.9.20 or newer")
         }
       }
     }
   }
 
   private companion object {
-    val MIN_GRADLE_VERSION: GradleVersion = GradleVersion.version("7.6")
+    val MIN_GRADLE_VERSION: GradleVersion = GradleVersion.version("8.1")
     val KOTLIN_PLUGIN_IDS = listOf(
       "org.jetbrains.kotlin.jvm",
-      "org.jetbrains.kotlin.js",
       "org.jetbrains.kotlin.multiplatform",
     )
   }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -2,7 +2,6 @@ package com.vanniktech.maven.publish
 
 import com.android.build.api.dsl.LibraryExtension
 import com.vanniktech.maven.publish.tasks.JavadocJar.Companion.javadocJarTask
-import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.attributes.DocsType
 import org.gradle.api.internal.project.ProjectInternal
@@ -10,15 +9,12 @@ import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.plugins.internal.JavaConfigurationVariantMapping
 import org.gradle.api.plugins.internal.JavaPluginHelper
 import org.gradle.api.plugins.internal.JvmPluginsHelper
-import org.gradle.api.plugins.jvm.internal.JvmPluginServices
 import org.gradle.api.provider.Provider
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.configurationcache.extensions.serviceOf
 import org.gradle.internal.component.external.model.ProjectDerivedCapability
 import org.gradle.jvm.component.internal.DefaultJvmSoftwareComponent
 import org.gradle.jvm.tasks.Jar
-import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 /**
@@ -286,14 +282,8 @@ data class KotlinMultiplatform @JvmOverloads constructor(
       it.withJavadocJar { javadocJarTask }
     }
 
-    if (project.isAtLeastKotlinVersion("org.jetbrains.kotlin.multiplatform", 1, 9, 0)) {
-      project.extensions.configure(KotlinMultiplatformExtension::class.java) {
-        it.withSourcesJar(sourcesJar)
-      }
-    } else {
-      check(sourcesJar) {
-        "Disabling sources publishing for Kotlin/Multiplatform is not supported until Kotlin 1.9.0"
-      }
+    project.extensions.configure(KotlinMultiplatformExtension::class.java) {
+      it.withSourcesJar(sourcesJar)
     }
   }
 }
@@ -334,61 +324,6 @@ data class KotlinJvm @JvmOverloads constructor(
     setupTestFixtures(project, sourcesJar)
   }
 }
-
-/**
- * To be used for `org.jetbrains.kotlin.js` projects. Applying this creates a publication for the component called
- * `kotlin`. Depending on the passed parameters for [javadocJar] and [sourcesJar], `-javadoc` and `-sources` jars will be
- * added to the publication.
- *
- * Equivalent Gradle set up:
- * ```
- * publications {
- *   create<MavenPublication>("maven") {
- *     from(components["kotlin"])
- *     artifact(project.tasks.named("kotlinSourcesJar"))
- *   }
- * }
- * ```
- * This does not include javadoc jars because there are no APIs for that available.
- */
-@Deprecated("The Kotlin/JS plugin has been deprecated in Kotlin 1.9.0")
-data class KotlinJs
-  @Deprecated(
-    "Disabling sources publishing for Kotlin/JS is not supported since Kotlin 1.8.20. " +
-      "Use the single or no-arg constructors instead.",
-  )
-  constructor(
-    override val javadocJar: JavadocJar,
-    override val sourcesJar: Boolean,
-  ) : Platform() {
-    @Suppress("DEPRECATION")
-    @JvmOverloads
-    constructor(
-      javadocJar: JavadocJar = JavadocJar.Empty(),
-    ) : this(javadocJar, true)
-
-    override fun configure(project: Project) {
-      check(project.plugins.hasPlugin("org.jetbrains.kotlin.js")) {
-        "Calling configure(KotlinJs(...)) requires the org.jetbrains.kotlin.js plugin to be applied"
-      }
-
-      // Create publication, since Kotlin/JS doesn't provide one by default.
-      // https://youtrack.jetbrains.com/issue/KT-41582
-      project.afterEvaluate {
-        project.gradlePublishing.publications.create(PUBLICATION_NAME, MavenPublication::class.java) {
-          it.from(project.components.getByName("kotlin"))
-          if (project.isAtLeastKotlinVersion("org.jetbrains.kotlin.js", 1, 8, 20)) {
-            check(sourcesJar) {
-              "Disabling sources publishing for Kotlin/JS is not supported since Kotlin 1.8.20"
-            }
-          } else {
-            it.withKotlinSourcesJar(sourcesJar, project)
-          }
-          it.withJavadocJar { project.javadocJarTask(javadocJar) }
-        }
-      }
-    }
-  }
 
 /**
  * To be used for `java-platforms` projects. Applying this creates a publication for the component called
@@ -547,31 +482,21 @@ private fun setupTestFixtures(project: Project, sourcesJar: Boolean) {
     if (sourcesJar) {
       // TODO: remove after https://github.com/gradle/gradle/issues/20539 is resolved
       val testFixtureSourceSetName = "testFixtures"
-      if (GradleVersion.current() >= GradleVersion.version("8.1")) {
-        val extension = project.extensions.getByType(JavaPluginExtension::class.java)
-        val testFixturesSourceSet = extension.sourceSets.maybeCreate(testFixtureSourceSetName)
+      val extension = project.extensions.getByType(JavaPluginExtension::class.java)
+      val testFixturesSourceSet = extension.sourceSets.maybeCreate(testFixtureSourceSetName)
 
-        val sourceElements = JvmPluginsHelper.createDocumentationVariantWithArtifact(
-          testFixturesSourceSet.sourcesElementsConfigurationName,
-          testFixtureSourceSetName,
-          DocsType.SOURCES,
-          listOf(ProjectDerivedCapability(project, "testFixtures")),
-          testFixturesSourceSet.sourcesJarTaskName,
-          testFixturesSourceSet.allSource,
-          project as ProjectInternal,
-        )
+      val sourceElements = JvmPluginsHelper.createDocumentationVariantWithArtifact(
+        testFixturesSourceSet.sourcesElementsConfigurationName,
+        testFixtureSourceSetName,
+        DocsType.SOURCES,
+        listOf(ProjectDerivedCapability(project, "testFixtures")),
+        testFixturesSourceSet.sourcesJarTaskName,
+        testFixturesSourceSet.allSource,
+        project as ProjectInternal,
+      )
 
-        val component = JavaPluginHelper.getJavaComponent(project) as DefaultJvmSoftwareComponent
-        component.addVariantsFromConfiguration(sourceElements, JavaConfigurationVariantMapping("compile", true))
-      } else {
-        val services = project.serviceOf<JvmPluginServices>()
-        val action = Action<Any> {
-          it.javaClass.getMethod("withSourcesJar").invoke(it)
-          it.javaClass.getMethod("published").invoke(it)
-        }
-        val method = services.javaClass.getMethod("createJvmVariant", String::class.java, Action::class.java)
-        method.invoke(services, testFixtureSourceSetName, action)
-      }
+      val component = JavaPluginHelper.getJavaComponent(project) as DefaultJvmSoftwareComponent
+      component.addVariantsFromConfiguration(sourceElements, JavaConfigurationVariantMapping("compile", true))
     }
 
     // test fixtures can't be mapped to the POM because there is no equivalent concept in Maven


### PR DESCRIPTION
I'll not merge this immediately, probably only after the next release.

- minimum Gradle version is now 8.1
- minimum AGP version is now 8.0
- minimum Kotlin version is now 1.9.20
- removed support for deprecated `org.jetbrains.kotlin.js` plugin
- removed obsolete workarounds