### PR TITLE
update tested versions and compatibility with Gradle 8.6

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-rc-1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -43,11 +43,11 @@ set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
 if %ERRORLEVEL% equ 0 goto execute
 
-echo.
-echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 
@@ -57,11 +57,11 @@ set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
 if exist "%JAVA_EXE%" goto execute
 
-echo.
-echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -40,9 +40,16 @@ enum class AgpVersion(
     minJdkVersion = JavaVersion.VERSION_17,
   ),
 
-  // canary channel
+  // beta channel
   AGP_8_3(
-    value = "8.3.0-alpha17",
+    value = "8.3.0-beta01",
+    minGradleVersion = GradleVersion.GRADLE_8_1,
+    minJdkVersion = JavaVersion.VERSION_17,
+  ),
+
+  // canary channel
+  AGP_8_4(
+    value = "8.4.0-alpha01",
     minGradleVersion = GradleVersion.GRADLE_8_1,
     minJdkVersion = JavaVersion.VERSION_17,
   ),
@@ -63,7 +70,7 @@ enum class KotlinVersion(
   KT_1_9_21("1.9.21"),
 
   // beta
-  KT_2_0_0("2.0.0-Beta1"),
+  KT_2_0_0("2.0.0-Beta2"),
   ;
 
   companion object {
@@ -86,6 +93,11 @@ enum class GradleVersion(
   // stable
   GRADLE_8_5(
     value = "8.5",
+  ),
+
+  // rc
+  GRADLE_8_6(
+    value = "8.6-rc-1",
   ),
   ;
 


### PR DESCRIPTION
One parameter of the internal `createDocumentationVariantWithArtifact` method that we use for the test fixture workaround changed. The workaround was updated and the project itself is now already using Gradle 8.6.

