### PR TITLE
always close, release and drop from build service

### DIFF
--- a/docs/central.md
+++ b/docs/central.md
@@ -279,16 +279,22 @@ The publishing process for Maven Central consists of several steps
 4. The staging repository is released
 5. All artifacts in the released repository will be synchronized to maven central
 
-By running the following Gradle task the plugin will take care of steps 1 to 3 automatically:
+The plugin will always do step 1 to 3 and when automatic releases are enabled also take
+care of step 4.
+
+Regardless of whether it is done automatically or manually after the staging repository is released
+the artifacts will be synced to Maven Central. This process takes 10-30 minutes and when it is completed
+the artifacts are available for download.
+
+### Automatic release
+
+Run the following to let the plugin handle all steps automatically:
 
 ```
-./gradlew publishAllPublicationsToMavenCentralRepository --no-configuration-cache
+./gradlew publishAllPublicationsToMavenCentralRepository closeAndReleaseRepository --no-configuration-cache
 ```
 
-The releasing step can be done manually by going to oss.sonatype.org (or s01.oss.sonatype.org) and
-clicking the button in the web UI or by executing `./gradlew closeAndReleaseRepository`.
-
-It is also possible to configure the plugin to perform this step automatically together with the first 3
+It is also possible to permanently enable the automatic releases without having to specify `closeAndReleaseRepository`
 by adding an extra parameter in the DSL or setting a Gradle property
 
 === "build.gradle"
@@ -309,9 +315,9 @@ by adding an extra parameter in the DSL or setting a Gradle property
     import com.vanniktech.maven.publish.SonatypeHost
 
     mavenPublishing {
-      publishToMavenCentral(SonatypeHost.DEFAULT, true)
+      publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
       // or when publishing to https://s01.oss.sonatype.org
-      publishToMavenCentral(SonatypeHost.S01, true)
+      publishToMavenCentral(SonatypeHost.S01, automaticRelease = true)
     }
     ```
 
@@ -321,11 +327,15 @@ by adding an extra parameter in the DSL or setting a Gradle property
     SONATYPE_AUTOMATIC_RELEASE=true
     ```
 
-Regardless of whether it is done automatically or manually after the staging repository is released the artifacts
-will be synced to Maven Central. This process takes 10-30 minutes and when it is completed
-the artifacts are available for download.
+### Manual release
 
-## Timeouts
+The release (step 4) can be done manually by running the following command, so that the plugin will
+only do step 1 to 3:
+```
+./gradlew publishAllPublicationsToMavenCentralRepository --no-configuration-cache
+```
+
+### Timeouts
 
 From time to time Sonatype tends to time out during staging operations. The default timeouts of the plugin
 are long already, but can be modified if needed. The timeout for HTTP requests can be modified with

--- a/docs/central.md
+++ b/docs/central.md
@@ -279,20 +279,24 @@ The publishing process for Maven Central consists of several steps
 4. The staging repository is released
 5. All artifacts in the released repository will be synchronized to maven central
 
-The plugin will always do step 1 to 3 and when automatic releases are enabled also take
-care of step 4.
+The plugin will always do steps 1 to 3. Step 4 is only taken care of if automatic releases are enabled.
 
-Regardless of whether it is done automatically or manually after the staging repository is released
-the artifacts will be synced to Maven Central. This process takes 10-30 minutes and when it is completed
+After the staging repository has been released, either manually or automatically, the artifacts will
+be synced to Maven Central. This process usually takes around 10-30 minutes and only when it completes
 the artifacts are available for download.
 
 ### Automatic release
 
-Run the following to let the plugin handle all steps automatically:
+Run the following tasks to let the plugin handle all steps automatically:
 
 ```
 ./gradlew publishAllPublicationsToMavenCentralRepository closeAndReleaseRepository --no-configuration-cache
 ```
+
+!!! note "Configuration cache"
+
+    Configuration caching when uploading releases is currently not possible. Supporting it is
+    blocked by [Gradle issue #22779](https://github.com/gradle/gradle/issues/22779).
 
 It is also possible to permanently enable the automatic releases without having to specify `closeAndReleaseRepository`
 by adding an extra parameter in the DSL or setting a Gradle property
@@ -334,6 +338,11 @@ only do step 1 to 3:
 ```
 ./gradlew publishAllPublicationsToMavenCentralRepository --no-configuration-cache
 ```
+
+!!! note "Configuration cache"
+
+    Configuration caching when uploading releases is currently not possible. Supporting it is
+    blocked by [Gradle issue #22779](https://github.com/gradle/gradle/issues/22779).
 
 ### Timeouts
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,4 +44,6 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
+  - admonition
+  - pymdownx.details
   - tables

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -81,8 +81,8 @@ abstract class MavenPublishBaseExtension(
       }
     }
 
-    project.tasks.registerCloseAndReleaseRepository(buildService)
-    project.tasks.registerDropRepository(buildService)
+    project.tasks.registerCloseAndReleaseRepository(buildService, createRepository)
+    project.tasks.registerDropRepository(buildService, createRepository)
   }
 
   @JvmOverloads

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
@@ -36,7 +36,7 @@ internal abstract class SonatypeRepositoryBuildService :
     val runAfterFailure: Boolean
 
     data class Close(
-      val searchForRepositoryIfNoIdPresent: Boolean
+      val searchForRepositoryIfNoIdPresent: Boolean,
     ) : EndOfBuildAction {
       override val runAfterFailure: Boolean = false
     }
@@ -65,7 +65,7 @@ internal abstract class SonatypeRepositoryBuildService :
 
   private var stagingRepositoryId: String? = null
     set(value) {
-      check (field != null && field != value) {
+      check(field != null && field != value) {
         "stagingRepositoryId was already set to '$field', new value '$value'"
       }
       field = value

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
@@ -32,7 +32,26 @@ internal abstract class SonatypeRepositoryBuildService :
     val closeTimeoutSeconds: Property<Long>
   }
 
-  val nexus by lazy {
+  private sealed interface EndOfBuildAction {
+    val runAfterFailure: Boolean
+
+    data class Close(
+      val searchForRepositoryIfNoIdPresent: Boolean
+    ) : EndOfBuildAction {
+      override val runAfterFailure: Boolean = false
+    }
+
+    data object ReleaseAfterClose : EndOfBuildAction {
+      override val runAfterFailure: Boolean = false
+    }
+
+    data class Drop(
+      override val runAfterFailure: Boolean,
+      val searchForRepositoryIfNoIdPresent: Boolean,
+    ) : EndOfBuildAction
+  }
+
+  private val nexus by lazy {
     Nexus(
       baseUrl = parameters.sonatypeHost.get().apiBaseUrl(),
       username = parameters.repositoryUsername.get(),
@@ -46,19 +65,13 @@ internal abstract class SonatypeRepositoryBuildService :
 
   private var stagingRepositoryId: String? = null
     set(value) {
-      if (field != null) {
-        throw IllegalStateException("stagingRepositoryId was already set")
+      check (field != null && field != value) {
+        "stagingRepositoryId was already set to '$field', new value '$value'"
       }
       field = value
     }
 
-  // should only be accessed from CloseAndReleaseSonatypeRepositoryTask
-  // indicates whether we already closed a staging repository to avoid doing it more than once in a build
-  var repositoryClosed: Boolean = false
-
-  // should only be accessed from DropSonatypeRepositoryTask
-  // indicates whether we already closed a staging repository to avoid doing it more than once in a build
-  var repositoryDropped: Boolean = false
+  private val endOfBuildActions = mutableSetOf<EndOfBuildAction>()
 
   private var buildIsSuccess: Boolean = true
 
@@ -74,7 +87,43 @@ internal abstract class SonatypeRepositoryBuildService :
       return
     }
 
-    this.stagingRepositoryId = nexus.createRepositoryForGroup(parameters.groupId.get())
+    stagingRepositoryId = nexus.createRepositoryForGroup(parameters.groupId.get())
+    endOfBuildActions += EndOfBuildAction.Close(searchForRepositoryIfNoIdPresent = false)
+    if (parameters.automaticRelease.get()) {
+      endOfBuildActions += EndOfBuildAction.ReleaseAfterClose
+    }
+    endOfBuildActions += EndOfBuildAction.Drop(
+      runAfterFailure = true,
+      searchForRepositoryIfNoIdPresent = false,
+    )
+  }
+
+  /**
+   * Is only be allowed to be called from task actions. Tasks calling this must run after tasks
+   * that call [createStagingRepository].
+   */
+  fun shouldCloseAndReleaseRepository(manualStagingRepositoryId: String?) {
+    if (manualStagingRepositoryId != null) {
+      stagingRepositoryId = manualStagingRepositoryId
+    }
+
+    endOfBuildActions += EndOfBuildAction.Close(searchForRepositoryIfNoIdPresent = true)
+    endOfBuildActions += EndOfBuildAction.ReleaseAfterClose
+  }
+
+  /**
+   * Is only be allowed to be called from task actions. Tasks calling this must run after tasks
+   * that call [createStagingRepository].
+   */
+  fun shouldDropRepository(manualStagingRepositoryId: String?) {
+    if (manualStagingRepositoryId != null) {
+      stagingRepositoryId = manualStagingRepositoryId
+    }
+
+    endOfBuildActions += EndOfBuildAction.Drop(
+      runAfterFailure = false,
+      searchForRepositoryIfNoIdPresent = true,
+    )
   }
 
   internal fun publishingUrl(configCacheEnabled: Boolean): String {
@@ -104,19 +153,45 @@ internal abstract class SonatypeRepositoryBuildService :
   }
 
   override fun close() {
-    val stagingRepositoryId = this.stagingRepositoryId
-    if (stagingRepositoryId != null) {
-      if (buildIsSuccess) {
+    if (buildIsSuccess) {
+      runEndOfBuildActions(endOfBuildActions.filter { !it.runAfterFailure })
+    } else {
+      // surround with try catch since failing again on clean up actions causes confusion
+      try {
+        runEndOfBuildActions(endOfBuildActions.filter { it.runAfterFailure })
+      } catch (e: IOException) {
+        if (buildIsSuccess) {
+          throw e
+        } else {
+          logger.info("Failed processing $stagingRepositoryId staging repository after previous build failure", e)
+        }
+      }
+    }
+  }
+
+  private fun runEndOfBuildActions(actions: List<EndOfBuildAction>) {
+    var stagingRepositoryId = stagingRepositoryId
+
+    val closeActions = actions.filterIsInstance<EndOfBuildAction.Close>()
+    if (closeActions.isNotEmpty()) {
+      if (stagingRepositoryId != null) {
         nexus.closeStagingRepository(stagingRepositoryId)
-        if (parameters.automaticRelease.get()) {
-          nexus.releaseStagingRepository(stagingRepositoryId)
-        }
-      } else {
-        try {
-          nexus.dropStagingRepository(stagingRepositoryId)
-        } catch (e: IOException) {
-          logger.info("Failed to drop staging repository $stagingRepositoryId", e)
-        }
+      } else if (closeActions.all { it.searchForRepositoryIfNoIdPresent }) {
+        stagingRepositoryId = nexus.closeCurrentStagingRepository()
+      }
+
+      if (stagingRepositoryId != null && actions.contains(EndOfBuildAction.ReleaseAfterClose)) {
+        nexus.releaseStagingRepository(stagingRepositoryId)
+      }
+    }
+
+    // there might be 2 drop actions but one of the runs on success, the other on failure
+    val dropAction = actions.filterIsInstance<EndOfBuildAction.Drop>().singleOrNull()
+    if (dropAction != null) {
+      if (stagingRepositoryId != null) {
+        nexus.dropStagingRepository(stagingRepositoryId)
+      } else if (dropAction.searchForRepositoryIfNoIdPresent) {
+        nexus.dropCurrentStagingRepository()
       }
     }
   }


### PR DESCRIPTION
Partially addresses #692.

Building on top of #695 this also runs the close, release and drop task actions always from the build service. Unlike the create actions these will not be run from the task. Instead the task only tells the build service to run the action and the service will run it at the end of the build. This allows doing something like `./gradlew publish closeAndReleaseRepository` (for when you don't want to permantently enable automatic releases) instead of having it as 2 separate Gradle invocations where the second needs to search for the repository again.