### PR TITLE
add new release tasks

### DIFF
--- a/docs/central.md
+++ b/docs/central.md
@@ -274,7 +274,7 @@ will still be signed.
 The publishing process for Maven Central consists of several steps
 
 1. A staging repository is created on Sonatype OSS
-2. The artifacts are uploaded to this staging repository
+2. The artifacts are uploaded/published to this staging repository
 3. The staging repository is closed
 4. The staging repository is released
 5. All artifacts in the released repository will be synchronized to maven central
@@ -287,10 +287,10 @@ the artifacts are available for download.
 
 ### Automatic release
 
-Run the following tasks to let the plugin handle all steps automatically:
+Run the following task to let the plugin handle all steps automatically:
 
 ```
-./gradlew publishAllPublicationsToMavenCentralRepository closeAndReleaseRepository --no-configuration-cache
+./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
 ```
 
 !!! note "Configuration cache"
@@ -298,8 +298,8 @@ Run the following tasks to let the plugin handle all steps automatically:
     Configuration caching when uploading releases is currently not possible. Supporting it is
     blocked by [Gradle issue #22779](https://github.com/gradle/gradle/issues/22779).
 
-It is also possible to permanently enable the automatic releases without having to specify `closeAndReleaseRepository`
-by adding an extra parameter in the DSL or setting a Gradle property
+It is possible to permanently enable the automatic releases so that regular publishing tasks
+like `publish` and `publishToMavenCentral` will also always do the release step:
 
 === "build.gradle"
 
@@ -336,7 +336,7 @@ by adding an extra parameter in the DSL or setting a Gradle property
 The release (step 4) can be done manually by running the following command, so that the plugin will
 only do step 1 to 3:
 ```
-./gradlew publishAllPublicationsToMavenCentralRepository --no-configuration-cache
+./gradlew publishToMavenCentral --no-configuration-cache
 ```
 
 !!! note "Configuration cache"

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -1,6 +1,7 @@
 package com.vanniktech.maven.publish
 
 import com.vanniktech.maven.publish.sonatype.CloseAndReleaseSonatypeRepositoryTask.Companion.registerCloseAndReleaseRepository
+import com.vanniktech.maven.publish.sonatype.CloseAndReleaseSonatypeRepositoryTask.Companion.registerReleaseRepository
 import com.vanniktech.maven.publish.sonatype.CreateSonatypeRepositoryTask.Companion.registerCreateRepository
 import com.vanniktech.maven.publish.sonatype.DropSonatypeRepositoryTask.Companion.registerDropRepository
 import com.vanniktech.maven.publish.sonatype.SonatypeRepositoryBuildService.Companion.registerSonatypeRepositoryBuildService
@@ -81,8 +82,21 @@ abstract class MavenPublishBaseExtension(
       }
     }
 
+    val releaseRepository = project.tasks.registerReleaseRepository(buildService, createRepository)
     project.tasks.registerCloseAndReleaseRepository(buildService, createRepository)
     project.tasks.registerDropRepository(buildService, createRepository)
+
+    project.tasks.register("publishToMavenCentral") {
+      it.description = "Publishes to a staging repository on Sonatype OSS"
+      it.group = "release"
+      it.dependsOn(project.tasks.named("publishAllPublicationsToMavenCentralRepository"))
+    }
+    project.tasks.register("publishAndReleaseToMavenCentral") {
+      it.description = "Publishes to a staging repository on Sonatype OSS and releases it to MavenCentral"
+      it.group = "release"
+      it.dependsOn(project.tasks.named("publishAllPublicationsToMavenCentralRepository"))
+      it.dependsOn(releaseRepository)
+    }
   }
 
   @JvmOverloads

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CloseAndReleaseSonatypeRepositoryTask.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CloseAndReleaseSonatypeRepositoryTask.kt
@@ -27,18 +27,35 @@ internal abstract class CloseAndReleaseSonatypeRepositoryTask : DefaultTask() {
   }
 
   companion object {
-    private const val NAME = "closeAndReleaseRepository"
+    private const val NAME = "releaseRepository"
+    private const val LEGACY_NAME = "closeAndReleaseRepository"
+
+    fun TaskContainer.registerReleaseRepository(
+      buildService: Provider<SonatypeRepositoryBuildService>,
+      createRepository: TaskProvider<CreateSonatypeRepositoryTask>,
+    ): TaskProvider<CloseAndReleaseSonatypeRepositoryTask> {
+      return register(NAME, CloseAndReleaseSonatypeRepositoryTask::class.java) {
+        it.description = "Releases a staging repository on Sonatype OSS"
+        it.group = "release"
+        it.buildService.set(buildService)
+        it.usesService(buildService)
+        it.mustRunAfter(createRepository)
+      }
+    }
 
     fun TaskContainer.registerCloseAndReleaseRepository(
       buildService: Provider<SonatypeRepositoryBuildService>,
       createRepository: TaskProvider<CreateSonatypeRepositoryTask>,
     ): TaskProvider<CloseAndReleaseSonatypeRepositoryTask> {
-      return register(NAME, CloseAndReleaseSonatypeRepositoryTask::class.java) {
+      return register(LEGACY_NAME, CloseAndReleaseSonatypeRepositoryTask::class.java) {
         it.description = "Closes and releases a staging repository on Sonatype OSS"
         it.group = "release"
         it.buildService.set(buildService)
         it.usesService(buildService)
         it.mustRunAfter(createRepository)
+        it.doLast { task ->
+          task.logger.warn("$LEGACY_NAME is deprecated and will be removed in a future release, use $NAME instead.")
+        }
       }
     }
   }


### PR DESCRIPTION
Builds on top of #698 to further address #692.

New tasks:
- `releaseRepository` as replacement for `closeAndReleaseRepository`, I'm not 100% sure about the name yet but it makes more sense than the old one since closing happens automatically.
- `publishToMavenCentral` as alias for `publishAllPublicationToMavenCentralRepository`. This just makes it a bit nicer to read since I don't want to use `publish` in the docs and it matches the default `publishToMavenLocal` task.
- `publishAndReleaseToMavenCentral` runs both of the above so that there is a single task Gradle command to publish and release. 