### PR TITLE
fix stagingRepositoryId check

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: gradle/gradle-build-action@v2
 
       - name: Publish
-        run: ./gradlew publishAndReleaseToMavenCentral
+        run: ./gradlew publish
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: gradle/gradle-build-action@v2
 
       - name: Publish
-        run: ./gradlew publishToMavenCentral
+        run: ./gradlew publish
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx2g
 org.gradle.parallel=true
 
 SONATYPE_HOST=DEFAULT
+SONATYPE_AUTOMATIC_RELEASE=true
 RELEASE_SIGNING_ENABLED=true
 
 GROUP=com.vanniktech

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ moshi = "1.15.0"
 retrofit = "2.9.0"
 junit = "5.10.1"
 truth = "1.2.0"
-maven-publish = "0.27.0-rc1"
+maven-publish = "0.26.0"
 ktlint = "12.0.3"
 
 [libraries]

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
@@ -65,7 +65,7 @@ internal abstract class SonatypeRepositoryBuildService :
 
   private var stagingRepositoryId: String? = null
     set(value) {
-      check(field != null && field != value) {
+      check(field == null || field == value) {
         "stagingRepositoryId was already set to '$field', new value '$value'"
       }
       field = value


### PR DESCRIPTION
The condition for the check was inverted which caused the release to fail:

```
* What went wrong:
Execution failed for task ':nexus:createStagingRepository'.
> A failure occurred while executing com.***.maven.publish.sonatype.CreateSonatypeRepositoryTask$CreateStagingRepository
   > stagingRepositoryId was already set to 'null', new value 'com***-1331'
```

https://github.com/vanniktech/gradle-maven-publish-plugin/actions/runs/7432566718/job/20224519444