### PR TITLE
support publishing through central portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.28.0 **UNRELEASED**
 
+- Added support for publishing through the new [Central Portal](https://central.sonatype.com). To use
+  this use the `CENTRAL_PORTAL` option when specifying the Sonatype host.
 - Removed support for the deprecated Kotlin/JS plugin.
 - Updated minimum supported Gradle, Android Gradle Plugin and Kotlin versions.
 

--- a/central-portal/build.gradle.kts
+++ b/central-portal/build.gradle.kts
@@ -9,4 +9,5 @@ dependencies {
   implementation(libs.moshi)
   implementation(libs.retrofit)
   implementation(libs.retrofit.converter.moshi)
+  implementation(libs.retrofit.converter.scalars)
 }

--- a/central-portal/src/main/kotlin/com/vanniktech/maven/publish/portal/SonatypeCentralPortal.kt
+++ b/central-portal/src/main/kotlin/com/vanniktech/maven/publish/portal/SonatypeCentralPortal.kt
@@ -6,10 +6,10 @@ import java.util.concurrent.TimeUnit
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
-import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.converter.scalars.ScalarsConverterFactory
 
 class SonatypeCentralPortal(
   private val baseUrl: String,
@@ -27,6 +27,7 @@ class SonatypeCentralPortal(
       .writeTimeout(okhttpTimeoutSeconds, TimeUnit.SECONDS)
       .build()
     val retrofit = Retrofit.Builder()
+      .addConverterFactory(ScalarsConverterFactory.create())
       .addConverterFactory(MoshiConverterFactory.create())
       .client(okHttpClient)
       .baseUrl(baseUrl)
@@ -35,7 +36,7 @@ class SonatypeCentralPortal(
     retrofit.create(SonatypeCentralPortalService::class.java)
   }
 
-  private fun deleteDeployment(deploymentId: String) {
+  fun deleteDeployment(deploymentId: String) {
     val deleteDeploymentResponse = service.deleteDeployment(deploymentId).execute()
     if (!deleteDeploymentResponse.isSuccessful) {
       throw IOException(
@@ -46,7 +47,7 @@ class SonatypeCentralPortal(
     }
   }
 
-  private fun publishDeployment(deploymentId: String) {
+  fun publishDeployment(deploymentId: String) {
     val publishDeploymentResponse = service.publishDeployment(deploymentId).execute()
     if (!publishDeploymentResponse.isSuccessful) {
       throw IOException(
@@ -118,10 +119,9 @@ class SonatypeCentralPortal(
     }
   }
 
-  private fun upload(name: String?, publishingType: String?, file: File): String {
-    val uploadFile: RequestBody = file.asRequestBody("application/octet-stream".toMediaType())
-    val multipart =
-      MultipartBody.Part.createFormData("bundle", file.getName(), uploadFile)
+  fun upload(name: String?, publishingType: String?, file: File): String {
+    val uploadFile = file.asRequestBody("application/octet-stream".toMediaType())
+    val multipart = MultipartBody.Part.createFormData("bundle", file.name, uploadFile)
     val uploadResponse = service.uploadBundle(name, publishingType, multipart).execute()
     if (uploadResponse.isSuccessful) {
       return uploadResponse.body()!!

--- a/central-portal/src/main/kotlin/com/vanniktech/maven/publish/portal/SonatypeCentralPortalService.kt
+++ b/central-portal/src/main/kotlin/com/vanniktech/maven/publish/portal/SonatypeCentralPortalService.kt
@@ -3,11 +3,11 @@ package com.vanniktech.maven.publish.portal
 import okhttp3.MultipartBody
 import okhttp3.ResponseBody
 import retrofit2.Call
-import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.POST
+import retrofit2.http.Part
 import retrofit2.http.Path
 import retrofit2.http.Query
 import retrofit2.http.Streaming
@@ -50,7 +50,7 @@ internal interface SonatypeCentralPortalService {
   fun uploadBundle(
     @Query("name") name: String?,
     @Query("publishingType") publishingType: String?,
-    @Body input: MultipartBody.Part,
+    @Part input: MultipartBody.Part,
   ): Call<String>
 
   @Streaming

--- a/docs/central.md
+++ b/docs/central.md
@@ -77,6 +77,8 @@ This can be done through either the DSL or by setting Gradle properties.
       publishToMavenCentral(SonatypeHost.DEFAULT)
       // or when publishing to https://s01.oss.sonatype.org
       publishToMavenCentral(SonatypeHost.S01)
+      // or when publishing to https://central.sonatype.com/
+      publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
 
       signAllPublications()
     }
@@ -91,6 +93,8 @@ This can be done through either the DSL or by setting Gradle properties.
       publishToMavenCentral(SonatypeHost.DEFAULT)
       // or when publishing to https://s01.oss.sonatype.org
       publishToMavenCentral(SonatypeHost.S01)
+      // or when publishing to https://central.sonatype.com/
+      publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
 
       signAllPublications()
     }
@@ -102,6 +106,8 @@ This can be done through either the DSL or by setting Gradle properties.
     SONATYPE_HOST=DEFAULT
     # or when publishing to https://s01.oss.sonatype.org
     SONATYPE_HOST=S01
+    // or when publishing to https://central.sonatype.com/
+    SONATYPE_HOST=CENTRAL_PORTAL
 
     RELEASE_SIGNING_ENABLED=true
     ```
@@ -252,6 +258,11 @@ lQdGBF4jUfwBEACblZV4uBViHcYLOb2280tEpr64iB9b6YRkWil3EODiiLd9JS3V...9pip+B1QLwEdL
 ```
 
 ## Publishing snapshots
+
+!!! warning "Central Portal"
+
+    Publishing snapshots is not supported when using the Central Portal (central.sonatype.com).
+
 
 Snapshots can be published by setting the version to something ending with `-SNAPSHOT`
 and then running the following Gradle task:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ moshi-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.re
 
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit-converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit" }
+retrofit-converter-scalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit" }
 
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 testParameterInjector = "com.google.testparameterinjector:test-parameter-injector-junit5:1.15"

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -61,6 +61,7 @@ val integrationTest by tasks.registering(Test::class) {
   dependsOn(
     tasks.publishToMavenLocal,
     projects.nexus.dependencyProject.tasks.publishToMavenLocal,
+    projects.centralPortal.dependencyProject.tasks.publishToMavenLocal,
   )
   mustRunAfter(tasks.test)
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
   compileOnly(libs.kotlin.plugin)
   compileOnly(libs.android.plugin)
 
+  implementation(projects.centralPortal)
   implementation(projects.nexus)
 
   testImplementation(gradleTestKit())

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -71,7 +71,7 @@ abstract class MavenPublishBaseExtension(
     project.gradlePublishing.repositories.maven { repo ->
       repo.name = "mavenCentral"
       repo.setUrl(buildService.map { it.publishingUrl(configCacheEnabled) })
-      if (!host.centralPortal) {
+      if (!host.isCentralPortal) {
         repo.credentials(PasswordCredentials::class.java)
       }
     }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -64,13 +64,17 @@ abstract class MavenPublishBaseExtension(
       repositoryUsername = project.providers.gradleProperty("mavenCentralUsername"),
       repositoryPassword = project.providers.gradleProperty("mavenCentralPassword"),
       automaticRelease = automaticRelease,
+      // TODO: stop accessing rootProject https://github.com/gradle/gradle/pull/26635
+      rootBuildDirectory = project.rootProject.layout.buildDirectory,
     )
 
     val configCacheEnabled = project.configurationCache()
     project.gradlePublishing.repositories.maven { repo ->
       repo.name = "mavenCentral"
       repo.setUrl(buildService.map { it.publishingUrl(configCacheEnabled) })
-      repo.credentials(PasswordCredentials::class.java)
+      if (!host.centralPortal) {
+        repo.credentials(PasswordCredentials::class.java)
+      }
     }
 
     val createRepository = project.tasks.registerCreateRepository(buildService)

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
@@ -8,11 +8,18 @@ import java.io.Serializable
  *
  * https://central.sonatype.org/articles/2021/Feb/23/new-users-on-s01osssonatypeorg/
  */
-data class SonatypeHost(
+data class SonatypeHost internal constructor(
   internal val rootUrl: String,
+  internal val centralPortal: Boolean,
 ) : Serializable {
+  constructor(rootUrl: String) : this(rootUrl, centralPortal = false)
+
   internal fun apiBaseUrl(): String {
-    return "$rootUrl/service/local/"
+    return if (centralPortal) {
+      "$rootUrl/api/v1/"
+    } else {
+      "$rootUrl/service/local/"
+    }
   }
 
   companion object {
@@ -20,13 +27,17 @@ data class SonatypeHost(
     fun valueOf(sonatypeHost: String): SonatypeHost = when (sonatypeHost) {
       "DEFAULT" -> DEFAULT
       "S01" -> S01
+      "CENTRAL_PORTAL" -> CENTRAL_PORTAL
       else -> throw IllegalArgumentException("No SonatypeHost constant $sonatypeHost")
     }
 
     @JvmField
-    val DEFAULT = SonatypeHost("https://oss.sonatype.org")
+    val DEFAULT = SonatypeHost("https://oss.sonatype.org", centralPortal = false)
 
     @JvmField
-    val S01 = SonatypeHost("https://s01.oss.sonatype.org")
+    val S01 = SonatypeHost("https://s01.oss.sonatype.org", centralPortal = false)
+
+    @JvmField
+    val CENTRAL_PORTAL = SonatypeHost("https://central.sonatype.com", centralPortal = true)
   }
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
@@ -10,12 +10,12 @@ import java.io.Serializable
  */
 data class SonatypeHost internal constructor(
   internal val rootUrl: String,
-  internal val centralPortal: Boolean,
+  internal val isCentralPortal: Boolean,
 ) : Serializable {
-  constructor(rootUrl: String) : this(rootUrl, centralPortal = false)
+  constructor(rootUrl: String) : this(rootUrl, isCentralPortal = false)
 
   internal fun apiBaseUrl(): String {
-    return if (centralPortal) {
+    return if (isCentralPortal) {
       "$rootUrl/api/v1/"
     } else {
       "$rootUrl/service/local/"
@@ -32,12 +32,12 @@ data class SonatypeHost internal constructor(
     }
 
     @JvmField
-    val DEFAULT = SonatypeHost("https://oss.sonatype.org", centralPortal = false)
+    val DEFAULT = SonatypeHost("https://oss.sonatype.org", isCentralPortal = false)
 
     @JvmField
-    val S01 = SonatypeHost("https://s01.oss.sonatype.org", centralPortal = false)
+    val S01 = SonatypeHost("https://s01.oss.sonatype.org", isCentralPortal = false)
 
     @JvmField
-    val CENTRAL_PORTAL = SonatypeHost("https://central.sonatype.com", centralPortal = true)
+    val CENTRAL_PORTAL = SonatypeHost("https://central.sonatype.com", isCentralPortal = true)
   }
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
@@ -119,7 +119,7 @@ internal abstract class SonatypeRepositoryBuildService :
       return
     }
 
-    uploadId = if (parameters.sonatypeHost.get().centralPortal) {
+    uploadId = if (parameters.sonatypeHost.get().isCentralPortal) {
       UUID.randomUUID().toString()
     } else {
       nexus.createRepositoryForGroup(parameters.groupId.get())
@@ -143,7 +143,7 @@ internal abstract class SonatypeRepositoryBuildService :
     if (manualStagingRepositoryId != null) {
       publishId = manualStagingRepositoryId
     } else {
-      if (uploadId == null && parameters.sonatypeHost.get().centralPortal) {
+      if (uploadId == null && parameters.sonatypeHost.get().isCentralPortal) {
         error("A deployment id needs to be provided with `--repository` when publishing through Central Portal")
       }
     }
@@ -160,7 +160,7 @@ internal abstract class SonatypeRepositoryBuildService :
     if (manualStagingRepositoryId != null) {
       publishId = manualStagingRepositoryId
     } else {
-      if (parameters.sonatypeHost.get().centralPortal) {
+      if (parameters.sonatypeHost.get().isCentralPortal) {
         error("A deployment id needs to be provided with `--repository` when publishing through Central Portal")
       }
     }
@@ -178,7 +178,7 @@ internal abstract class SonatypeRepositoryBuildService :
       }
 
       val host = parameters.sonatypeHost.get()
-      require(!host.centralPortal) {
+      require(!host.isCentralPortal) {
         "Snapshots are not supported when publishing through the central portal."
       }
 
@@ -194,7 +194,7 @@ internal abstract class SonatypeRepositoryBuildService :
       }
 
       val host = parameters.sonatypeHost.get()
-      if (host.centralPortal) {
+      if (host.isCentralPortal) {
         "file://${parameters.rootBuildDirectory.get()}/publish/staging/$stagingRepositoryId"
       } else {
         "${host.rootUrl}/service/local/staging/deployByRepositoryId/$stagingRepositoryId/"
@@ -226,7 +226,7 @@ internal abstract class SonatypeRepositoryBuildService :
   }
 
   private fun runEndOfBuildActions(actions: List<EndOfBuildAction>) {
-    if (parameters.sonatypeHost.get().centralPortal) {
+    if (parameters.sonatypeHost.get().isCentralPortal) {
       runCentralPortalEndOfBuildActions(actions)
     } else {
       runNexusEndOfBuildActions(actions)


### PR DESCRIPTION
This is a first working implementation. There are some parts that can be improved in the future but for now I wanted to keep the code shared as much as possible. 

General process:
1) `createStagingRepsitory` creates a uuid inside the build service
2) All modules publish to `<root>/build/publish/staging>/<uuid>`
3) The build service will create a zip out of that at the end of the build
4) The build service makes the upload API call (this is now just one call in which we directly say whether we want to automatically release or not)

Also supported
- using `releaseRepository` and `dropRepository` when specifying a depoyment id through `--repository`

Not supported:
- snapshots (generally not supported by central portal)
- using `releaseRepository` and `dropRepository` without specifying a depoyment id through `--repository`

Future improvements:
- Wait for validations to finish before stopping the build (maybe also wait for publishing, but it seems slow from my test)
- Use Gradle mechanisms to publish each module into it's own build folder and make the output consumable. Then have a propert zip and upload task in the root project that consumes these.
- Add versions of `releaseRepository` and `dropRepository` that use `deployment` in their name and `deployment-id` for the parameter? Would be more aligned with the new naming.

Closes #720, closes #722