### PR TITLE
Change the Authorization header to use Bearer for Maven Central

### DIFF
--- a/central-portal/src/main/kotlin/com/vanniktech/maven/publish/portal/SonatypeCentralPortalOkHttpInterceptor.kt
+++ b/central-portal/src/main/kotlin/com/vanniktech/maven/publish/portal/SonatypeCentralPortalOkHttpInterceptor.kt
@@ -12,7 +12,7 @@ internal class SonatypeCentralPortalOkHttpInterceptor(
     val requestBuilder = chain.request().newBuilder()
 
     requestBuilder.addHeader("Accept", "application/json") // request json by default, XML is returned else
-    requestBuilder.addHeader("Authorization", "UserToken $usertoken")
+    requestBuilder.addHeader("Authorization", "Bearer $usertoken")
     requestBuilder.addHeader("User-Agent", "$userAgentName/$userAgentVersion")
 
     return chain.proceed(requestBuilder.build())


### PR DESCRIPTION
While Maven Central does support the `UserToken` header they recommend using the `Bearer` value.

From the [docs](https://central.sonatype.org/publish/publish-portal-api/#authentication-authorization)

> The API also accepts a non-standard UserToken Authorization header with the same base64 encoded value, but we recommend using the standard Bearer value and future versions of the API may drop support for UserToken.