### PR TITLE
Gradle 8.8 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        java_version: [11, 17, 21]
+        java_version: [11, 17, 22]
         test_config_method: ["DSL", "PROPERTIES", "BASE"]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        java_version: [11, 17, 22]
+        java_version: [11, 17, 21]
         test_config_method: ["DSL", "PROPERTIES", "BASE"]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
 - Kotlin Gradle Plugin 1.9.20
 
 #### Compatibility tested up to
-- JDK 22
+- JDK 21
 - Gradle 8.7
-- Gradle 8.8-rc-1
+- Gradle 8.8-rc-1g
 - Android Gradle Plugin 8.3.2
 - Android Gradle Plugin 8.4.0-rc02
 - Android Gradle Plugin 8.5.0-alpha05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 #### Compatibility tested up to
 - JDK 21
 - Gradle 8.7
+- Gradle 8.8-rc-1g
 - Android Gradle Plugin 8.3.2
 - Android Gradle Plugin 8.4.0-rc02
 - Android Gradle Plugin 8.5.0-alpha05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 #### Compatibility tested up to
 - JDK 21
 - Gradle 8.7
-- Gradle 8.8-rc-1g
+- Gradle 8.8-rc-1
 - Android Gradle Plugin 8.3.2
 - Android Gradle Plugin 8.4.0-rc02
 - Android Gradle Plugin 8.5.0-alpha05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
 - Kotlin Gradle Plugin 1.9.20
 
 #### Compatibility tested up to
-- JDK 21
+- JDK 22
 - Gradle 8.7
-- Gradle 8.8-rc-1g
+- Gradle 8.8-rc-1
 - Android Gradle Plugin 8.3.2
 - Android Gradle Plugin 8.4.0-rc02
 - Android Gradle Plugin 8.5.0-alpha05

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -78,7 +78,6 @@ enum class GradleVersion(
   // stable
   GRADLE_8_7(
     value = "8.7",
-    firstUnsupportedJdkVersion = JavaVersion.VERSION_22,
   ),
 
   // rc

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -47,7 +47,7 @@ enum class AgpVersion(
 
   // canary channel
   AGP_8_5(
-    value = "8.5.0-alpha05",
+    value = "8.5.0-alpha06",
     minGradleVersion = GradleVersion.GRADLE_8_6,
   ),
 }
@@ -82,7 +82,7 @@ enum class GradleVersion(
 
   // rc
   GRADLE_8_8(
-    value = "8.8-20240328002759+0000",
+    value = "8.8-rc-1",
   ),
   ;
 

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -78,6 +78,7 @@ enum class GradleVersion(
   // stable
   GRADLE_8_7(
     value = "8.7",
+    firstUnsupportedJdkVersion = JavaVersion.VERSION_22,
   ),
 
   // rc

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -79,6 +79,11 @@ enum class GradleVersion(
   GRADLE_8_7(
     value = "8.7",
   ),
+
+  // rc
+  GRADLE_8_8(
+    value = "8.8-20240328002759+0000",
+  ),
   ;
 
   companion object {

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptionsProvider.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptionsProvider.kt
@@ -1,12 +1,12 @@
 package com.vanniktech.maven.publish
 
 import com.google.common.collect.ImmutableList
-import com.google.testing.junit.testparameterinjector.junit5.TestParameter.TestParameterValuesProvider
+import com.google.testing.junit.testparameterinjector.junit5.TestParameterValuesProvider
 
 private val quickTestProperty get() = System.getProperty("quickTest")
 
-internal class TestOptionsConfigProvider : TestParameterValuesProvider {
-  override fun provideValues(): ImmutableList<TestOptions.Config?> {
+internal class TestOptionsConfigProvider : TestParameterValuesProvider() {
+  override fun provideValues(context: Context?): List<*> {
     val property = System.getProperty("testConfigMethod")
     if (property.isNotBlank()) {
       return ImmutableList.of(TestOptions.Config.valueOf(property))
@@ -18,8 +18,8 @@ internal class TestOptionsConfigProvider : TestParameterValuesProvider {
   }
 }
 
-internal class GradleVersionProvider : TestParameterValuesProvider {
-  override fun provideValues(): ImmutableList<GradleVersion> {
+internal class GradleVersionProvider : TestParameterValuesProvider() {
+  override fun provideValues(context: Context?): List<*> {
     if (quickTestProperty.isNotBlank()) {
       return ImmutableList.of(GradleVersion.entries.last())
     }
@@ -27,8 +27,8 @@ internal class GradleVersionProvider : TestParameterValuesProvider {
   }
 }
 
-internal class AgpVersionProvider : TestParameterValuesProvider {
-  override fun provideValues(): ImmutableList<AgpVersion> {
+internal class AgpVersionProvider : TestParameterValuesProvider() {
+  override fun provideValues(context: Context?): List<*> {
     if (quickTestProperty.isNotBlank()) {
       return ImmutableList.of(AgpVersion.entries.last())
     }
@@ -36,8 +36,8 @@ internal class AgpVersionProvider : TestParameterValuesProvider {
   }
 }
 
-internal class KotlinVersionProvider : TestParameterValuesProvider {
-  override fun provideValues(): ImmutableList<KotlinVersion> {
+internal class KotlinVersionProvider : TestParameterValuesProvider() {
+  override fun provideValues(context: Context?): List<*> {
     if (quickTestProperty.isNotBlank()) {
       return ImmutableList.of(KotlinVersion.entries.last())
     }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -238,7 +238,7 @@ abstract class MavenPublishBaseExtension(
    */
   fun pom(configure: Action<in MavenPom>) {
     project.mavenPublications { publication ->
-      if (GradleVersion.current() >= GradleVersion.version("8.8-20240328002759+0000")) {
+      if (GradleVersion.current() >= GradleVersion.version("8.8-rc-1")) {
         publication.pom(configure)
       } else {
         project.afterEvaluate {

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -19,6 +19,7 @@ import org.gradle.external.javadoc.StandardJavadocDocletOptions
 import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningPlugin
 import org.gradle.plugins.signing.type.pgp.ArmoredSignatureType
+import org.gradle.util.GradleVersion
 import org.jetbrains.dokka.gradle.DokkaTask
 
 abstract class MavenPublishBaseExtension(
@@ -152,7 +153,7 @@ abstract class MavenPublishBaseExtension(
       project.gradleSigning.sign(publication)
     }
 
-    // TODO: remove after https://youtrack.jetbrains.com/issue/KT-46466 is fixed
+    // TODO: https://youtrack.jetbrains.com/issue/KT-46466 https://github.com/gradle/gradle/issues/26091
     project.tasks.withType(AbstractPublishToMaven::class.java).configureEach { publishTask ->
       publishTask.dependsOn(project.tasks.withType(Sign::class.java))
     }
@@ -237,9 +238,12 @@ abstract class MavenPublishBaseExtension(
    */
   fun pom(configure: Action<in MavenPom>) {
     project.mavenPublications { publication ->
-      // TODO without afterEvaluate https://github.com/gradle/gradle/issues/12259 will happen
-      project.afterEvaluate {
+      if (GradleVersion.current() >= GradleVersion.version("8.8-20240328002759+0000")) {
         publication.pom(configure)
+      } else {
+        project.afterEvaluate {
+          publication.pom(configure)
+        }
       }
     }
   }


### PR DESCRIPTION
Just opening this already so that I don't forget about it. Needs to wait for rc1 to be available before getting merged because the nightly version is not considered smaller than a rc version so the check wouldn't actually work.