### PR TITLE
add source/javadoc options to configureBasedOnAppliedPlugins

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -359,9 +359,6 @@ abstract class MavenPublishBaseExtension(
 
   /**
    * Calls [configure] with a [Platform] chosen based on other applied Gradle plugins.
-   *
-   * Note: Passing `null` for [javadocJar] will result in the default behavior of determining
-   * the best option based on project type. For Android libraries
    */
   @Incubating
   @JvmOverloads


### PR DESCRIPTION
Partially addresses #754. While this doesn't provide a way to configure whether sources and javadocs are published based on the target repository, this at least provides and easy way to disable publishing them globally. Before this you'd need to start calling `configure` in each project which you can't easily do globally in builds with mixed project types. `configureBasedOnAppliedPlugins` could be called from a `plugins.withId` block. It's then possible to use gradle properties or env vars for the boolean values. A follow up might be to have such Gradle properties already for the call from the main plugin.