### PR TITLE
update gpg docs

### DIFF
--- a/docs/central.md
+++ b/docs/central.md
@@ -244,11 +244,24 @@ user home or to use environment variables for publishing from CI servers.
 
 ### In memory GPG key
 
-To obtain the in memory signing key run the following command. **Warning: this will print the private
-GPG key in plain text**
+To obtain the in memory signing key run the following command.
+
+!!! warning
+
+    This will print the private GPG key in plain text.
+
 ```sh
-gpg2 --export-secret-keys --armor <key id> <path to secring.gpg> | grep -v '\-\-' | grep -v '^=.' | tr -d '\n'
+gpg --export-secret-keys --armor <key id> | grep -v '\-\-' | grep -v '^=.' | tr -d '\n'
 ```
+
+!!! info
+
+    If you have a `secring.gpg` file that contains your key add the path to that
+    file after the `<key id>`:
+    ```sh
+    gpg --export-secret-keys --armor <key id>  <path to secring.gpg> | grep -v '\-\-' | grep -v '^=.' | tr -d '\n'
+    ```
+
 The result will be a very long single line string that looks like this
 ```
 lQdGBF4jUfwBEACblZV4uBViHcYLOb2280tEpr64iB9b6YRkWil3EODiiLd9JS3V...9pip+B1QLwEdLCEJA+3IIiw4qM5hnMw=


### PR DESCRIPTION
The docs now account for gpg2 by default not having a secring.gpg file. I've also moved the warning into a proper warning box.

<img width="956" alt="Screenshot 2024-05-01 at 10 39 10" src="https://github.com/vanniktech/gradle-maven-publish-plugin/assets/1358105/0fa7c142-d783-4489-b47b-b53c73722566">

Closes #745 