### PR TITLE
Add status code to error message

### DIFF
--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
@@ -37,7 +37,7 @@ class Nexus(
     val stagingProfilesResponse = service.getStagingProfiles().execute()
 
     if (!stagingProfilesResponse.isSuccessful) {
-      throw IOException("Cannot get stagingProfiles for account $username: ${stagingProfilesResponse.errorBody()?.string()}")
+      throw IOException("Cannot get stagingProfiles for account $username: (${stagingProfilesResponse.code}) ${stagingProfilesResponse.errorBody()?.string()}")
     }
 
     return stagingProfilesResponse.body()?.data

--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
@@ -37,7 +37,11 @@ class Nexus(
     val stagingProfilesResponse = service.getStagingProfiles().execute()
 
     if (!stagingProfilesResponse.isSuccessful) {
-      throw IOException("Cannot get stagingProfiles for account $username: (${stagingProfilesResponse.code}) ${stagingProfilesResponse.errorBody()?.string()}")
+      throw IOException(
+        "Cannot get stagingProfiles for account $username: " +
+          "(${stagingProfilesResponse.code()}) " +
+          "${stagingProfilesResponse.errorBody()?.string()}",
+      )
     }
 
     return stagingProfilesResponse.body()?.data


### PR DESCRIPTION
Not all error responses have error bodies, so currently this error is opaque if there isn't one. For example - if it's a 500 error, then the user would know there's nothing they've done wrong and it's just an issue on sonatype