### PR TITLE
fix issue with javadocJar tasks

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -153,11 +153,6 @@ abstract class MavenPublishBaseExtension(
       project.gradleSigning.sign(publication)
     }
 
-    // TODO: https://youtrack.jetbrains.com/issue/KT-46466 https://github.com/gradle/gradle/issues/26091
-    project.tasks.withType(AbstractPublishToMaven::class.java).configureEach { publishTask ->
-      publishTask.dependsOn(project.tasks.withType(Sign::class.java))
-    }
-
     // TODO: https://youtrack.jetbrains.com/issue/KT-61313/ https://github.com/gradle/gradle/issues/26132
     project.plugins.withId("org.jetbrains.kotlin.multiplatform") {
       project.tasks.withType(Sign::class.java).configureEach {

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -12,7 +12,6 @@ import org.gradle.api.credentials.PasswordCredentials
 import org.gradle.api.provider.Property
 import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.external.javadoc.StandardJavadocDocletOptions

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -12,7 +12,6 @@ import org.gradle.api.plugins.internal.JavaPluginHelper
 import org.gradle.api.plugins.internal.JvmPluginsHelper
 import org.gradle.api.provider.Provider
 import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.tasks.TaskProvider
 import org.gradle.internal.component.external.model.ProjectDerivedCapability
 import org.gradle.jvm.component.internal.DefaultJvmSoftwareComponent
 import org.gradle.jvm.tasks.Jar

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -66,7 +66,7 @@ data class JavaLibrary @JvmOverloads constructor(
     project.gradlePublishing.publications.create(PUBLICATION_NAME, MavenPublication::class.java) {
       it.from(project.components.getByName("java"))
       it.withJavaSourcesJar(sourcesJar, project)
-      it.withJavadocJar { project.javadocJarTask(javadocJar) }
+      it.withJavadocJar(javadocJar, project)
     }
 
     setupTestFixtures(project, sourcesJar)
@@ -95,11 +95,9 @@ data class GradlePlugin @JvmOverloads constructor(
       "Calling configure(GradlePlugin(...)) requires the java-gradle-plugin to be applied"
     }
 
-    val javadocJarTask = project.javadocJarTask(javadocJar)
-
     project.mavenPublicationsWithoutPluginMarker {
       it.withJavaSourcesJar(sourcesJar, project)
-      it.withJavadocJar { javadocJarTask }
+      it.withJavadocJar(javadocJar, project)
     }
   }
 }
@@ -287,10 +285,8 @@ data class KotlinMultiplatform internal constructor(
       "Calling configure(KotlinMultiplatform(...)) requires the org.jetbrains.kotlin.multiplatform plugin to be applied"
     }
 
-    val javadocJarTask = project.javadocJarTask(javadocJar)
-
     project.mavenPublications {
-      it.withJavadocJar { javadocJarTask }
+      it.withJavadocJar(javadocJar, project)
     }
 
     project.extensions.configure(KotlinMultiplatformExtension::class.java) {
@@ -339,7 +335,7 @@ data class KotlinJvm @JvmOverloads constructor(
     project.gradlePublishing.publications.create(PUBLICATION_NAME, MavenPublication::class.java) {
       it.from(project.components.getByName("java"))
       it.withJavaSourcesJar(sourcesJar, project)
-      it.withJavadocJar { project.javadocJarTask(javadocJar) }
+      it.withJavadocJar(javadocJar, project)
     }
 
     setupTestFixtures(project, sourcesJar)
@@ -480,8 +476,8 @@ private fun MavenPublication.withJavaSourcesJar(enabled: Boolean, project: Proje
   }
 }
 
-private fun MavenPublication.withJavadocJar(factory: () -> TaskProvider<*>?) {
-  val task = factory()
+private fun MavenPublication.withJavadocJar(javadocJar: JavadocJar, project: Project) {
+  val task = project.javadocJarTask(name, javadocJar)
   if (task != null) {
     artifact(task)
   }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocJar.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocJar.kt
@@ -23,8 +23,11 @@ open class JavadocJar : Jar() {
       }
     }
 
-    private fun Project.emptyJavadocJar(prefix: String): TaskProvider<*> = tasks.register("${prefix}EmptyJavadocJar", JavadocJar::class.java) {
-      it.archiveBaseName.set("${prefix}-javadoc")
+    private fun Project.emptyJavadocJar(prefix: String): TaskProvider<*> = tasks.register(
+      "${prefix}EmptyJavadocJar",
+      JavadocJar::class.java,
+    ) {
+      it.archiveBaseName.set("$prefix-javadoc")
     }
 
     private fun Project.plainJavadocJar(prefix: String): TaskProvider<*> {
@@ -32,7 +35,7 @@ open class JavadocJar : Jar() {
         val task = tasks.named("javadoc")
         it.dependsOn(task)
         it.from(task)
-        it.archiveBaseName.set("${prefix}-javadoc")
+        it.archiveBaseName.set("$prefix-javadoc")
       }
     }
 
@@ -44,7 +47,7 @@ open class JavadocJar : Jar() {
         }
         it.dependsOn(task)
         it.from(task)
-        it.archiveBaseName.set("${prefix}-javadoc")
+        it.archiveBaseName.set("$prefix-javadoc")
       }
     }
   }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocJar.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocJar.kt
@@ -14,33 +14,37 @@ open class JavadocJar : Jar() {
   }
 
   internal companion object {
-    internal fun Project.javadocJarTask(javadocJar: JavadocJarOption): TaskProvider<*>? {
+    internal fun Project.javadocJarTask(prefix: String, javadocJar: JavadocJarOption): TaskProvider<*>? {
       return when (javadocJar) {
         is JavadocJarOption.None -> null
-        is JavadocJarOption.Empty -> emptyJavadocJar()
-        is JavadocJarOption.Javadoc -> plainJavadocJar()
-        is JavadocJarOption.Dokka -> dokkaJavadocJar(javadocJar.taskName)
+        is JavadocJarOption.Empty -> emptyJavadocJar(prefix)
+        is JavadocJarOption.Javadoc -> plainJavadocJar(prefix)
+        is JavadocJarOption.Dokka -> dokkaJavadocJar(prefix, javadocJar.taskName)
       }
     }
 
-    private fun Project.emptyJavadocJar(): TaskProvider<*> = tasks.register("emptyJavadocJar", JavadocJar::class.java)
+    private fun Project.emptyJavadocJar(prefix: String): TaskProvider<*> = tasks.register("${prefix}EmptyJavadocJar", JavadocJar::class.java) {
+      it.archiveBaseName.set("${prefix}-javadoc")
+    }
 
-    private fun Project.plainJavadocJar(): TaskProvider<*> {
-      return tasks.register("plainJavadocJar", JavadocJar::class.java) {
+    private fun Project.plainJavadocJar(prefix: String): TaskProvider<*> {
+      return tasks.register("${prefix}PlainJavadocJar", JavadocJar::class.java) {
         val task = tasks.named("javadoc")
         it.dependsOn(task)
         it.from(task)
+        it.archiveBaseName.set("${prefix}-javadoc")
       }
     }
 
-    private fun Project.dokkaJavadocJar(taskName: DokkaTaskName): TaskProvider<*> {
-      return tasks.register("dokkaJavadocJar", JavadocJar::class.java) {
+    private fun Project.dokkaJavadocJar(prefix: String, taskName: DokkaTaskName): TaskProvider<*> {
+      return tasks.register("${prefix}DokkaJavadocJar", JavadocJar::class.java) {
         val task = when (taskName) {
           is ProviderDokkaTaskName -> taskName.value.flatMap { name -> tasks.named(name) }
           is StringDokkaTaskName -> tasks.named(taskName.value)
         }
         it.dependsOn(task)
         it.from(task)
+        it.archiveBaseName.set("${prefix}-javadoc")
       }
     }
   }


### PR DESCRIPTION
This creates a separate javadocJar task per publication. This avoids an issue where Gradle gets confused and thinks the publish task, metadata task or sign task of one publication has an implicit dependency on the task. While this means there is a bit of additional work, zipping should generally be fast and the javadoc (or dokka) generation itself is still just run once.