### PR TITLE
inject BuildEventsListenerRegistry

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -25,7 +25,7 @@ import org.jetbrains.dokka.gradle.DokkaTask
 
 abstract class MavenPublishBaseExtension @Inject constructor(
   private val project: Project,
-  private val buildEventsListenerRegistry: BuildEventsListenerRegistry
+  private val buildEventsListenerRegistry: BuildEventsListenerRegistry,
 ) {
   private val sonatypeHost: Property<SonatypeHost> = project.objects.property(SonatypeHost::class.java)
   private val signing: Property<Boolean> = project.objects.property(Boolean::class.java)

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
@@ -21,7 +21,6 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.build.event.BuildEventsListenerRegistry
-import org.gradle.configurationcache.extensions.serviceOf
 import org.gradle.tooling.events.FailureResult
 import org.gradle.tooling.events.FinishEvent
 import org.gradle.tooling.events.OperationCompletionListener
@@ -324,6 +323,7 @@ internal abstract class SonatypeRepositoryBuildService :
       repositoryPassword: Provider<String>,
       automaticRelease: Boolean,
       rootBuildDirectory: Provider<Directory>,
+      buildEventsListenerRegistry: BuildEventsListenerRegistry,
     ): Provider<SonatypeRepositoryBuildService> {
       val okhttpTimeout = project.providers.gradleProperty("SONATYPE_CONNECT_TIMEOUT_SECONDS")
         .map { it.toLong() }
@@ -343,7 +343,7 @@ internal abstract class SonatypeRepositoryBuildService :
         it.parameters.closeTimeoutSeconds.set(closeTimeout)
         it.parameters.rootBuildDirectory.set(rootBuildDirectory)
       }
-      project.serviceOf<BuildEventsListenerRegistry>().onTaskCompletion(service)
+      buildEventsListenerRegistry.onTaskCompletion(service)
       return service
     }
   }


### PR DESCRIPTION
Looks like `serviceOf` is an internal API which got removed in Gradle 8.10 which is why #808 is not building. Luckily it's an inline function so using the current version on Gradle 8.10 is still working.