### PR TITLE
replace configuration cache detection mechanism

### DIFF
--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -63,9 +63,8 @@ enum class GradleVersion(
   val firstUnsupportedJdkVersion: JavaVersion? = null,
 ) {
   // minimum supported
-  GRADLE_8_1(
-    value = "8.1",
-    firstUnsupportedJdkVersion = JavaVersion.VERSION_20,
+  GRADLE_8_5(
+    value = "8.5",
   ),
 
   // stable
@@ -76,6 +75,7 @@ enum class GradleVersion(
 
   companion object {
     // aliases for the skipped version to be able to reference the correct one in AgpVersion
+    val GRADLE_8_1 = GRADLE_8_5
     val GRADLE_8_6 = GRADLE_8_10
   }
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -67,10 +67,9 @@ abstract class MavenPublishBaseExtension(
       rootBuildDirectory = project.rootProject.layout.buildDirectory,
     )
 
-    val configCacheEnabled = project.configurationCache()
     project.gradlePublishing.repositories.maven { repo ->
       repo.name = "mavenCentral"
-      repo.setUrl(buildService.map { it.publishingUrl(configCacheEnabled) })
+      repo.setUrl(buildService.map { it.publishingUrl() })
       if (!host.isCentralPortal) {
         repo.credentials(PasswordCredentials::class.java)
       }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBasePlugin.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBasePlugin.kt
@@ -33,7 +33,7 @@ open class MavenPublishBasePlugin : Plugin<Project> {
   }
 
   private companion object {
-    val MIN_GRADLE_VERSION: GradleVersion = GradleVersion.version("8.1")
+    val MIN_GRADLE_VERSION: GradleVersion = GradleVersion.version("8.5")
     val KOTLIN_PLUGIN_IDS = listOf(
       "org.jetbrains.kotlin.jvm",
       "org.jetbrains.kotlin.multiplatform",

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -22,7 +22,6 @@ open class MavenPublishPlugin : Plugin<Project> {
 
     // afterEvaluate is too late for AGP which doesn't allow configuration after finalizeDsl
     project.plugins.withId("com.android.library") {
-      @Suppress("UnstableApiUsage")
       project.androidComponents.finalizeDsl {
         baseExtension.configureBasedOnAppliedPlugins()
       }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
@@ -79,8 +79,3 @@ internal fun Project.isAtLeastUsingAndroidGradleVersion(major: Int, minor: Int, 
     false
   }
 }
-
-@Suppress("UnstableApiUsage")
-internal fun Project.configurationCache(): Boolean {
-  return gradle.startParameter.isConfigurationCacheRequested
-}

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
@@ -11,7 +11,9 @@ import java.util.Base64
 import java.util.UUID
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
+import javax.inject.Inject
 import org.gradle.api.Project
+import org.gradle.api.configuration.BuildFeatures
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.logging.Logger
@@ -29,6 +31,10 @@ import org.gradle.tooling.events.OperationCompletionListener
 internal abstract class SonatypeRepositoryBuildService :
   BuildService<SonatypeRepositoryBuildService.Params>, AutoCloseable, OperationCompletionListener {
   private val logger: Logger = Logging.getLogger(SonatypeRepositoryBuildService::class.java)
+
+  @Suppress("UnstableApiUsage")
+  @get:Inject
+  internal abstract val buildFeatures: BuildFeatures
 
   internal interface Params : BuildServiceParameters {
     val sonatypeHost: Property<SonatypeHost>
@@ -171,7 +177,7 @@ internal abstract class SonatypeRepositoryBuildService :
     )
   }
 
-  internal fun publishingUrl(configCacheEnabled: Boolean): String {
+  internal fun publishingUrl(): String {
     return if (parameters.versionIsSnapshot.get()) {
       require(uploadId == null) {
         "Staging repositories are not supported for SNAPSHOT versions."
@@ -185,7 +191,8 @@ internal abstract class SonatypeRepositoryBuildService :
       "${host.rootUrl}/content/repositories/snapshots/"
     } else {
       val stagingRepositoryId = requireNotNull(uploadId) {
-        if (configCacheEnabled) {
+        @Suppress("UnstableApiUsage")
+        if (buildFeatures.configurationCache.active.get()) {
           "Publishing releases to Maven Central is not supported yet with configuration caching enabled, because of " +
             "this missing Gradle feature: https://github.com/gradle/gradle/issues/22779"
         } else {
@@ -246,7 +253,7 @@ internal abstract class SonatypeRepositoryBuildService :
           "USER_MANAGED"
         }
 
-        val directory = File(publishingUrl(false).substringAfter("://"))
+        val directory = File(publishingUrl().substringAfter("://"))
         val zipFile = File("${directory.absolutePath}.zip")
         val out = ZipOutputStream(FileOutputStream(zipFile))
         directory.walkTopDown().forEach {


### PR DESCRIPTION
Use the newer `BuildFeatures` API instead of the deprecated startParameter API. The newer one is also incubating but should be stabilized soon https://github.com/gradle/gradle/issues/26722