### PR TITLE
support custom Sonatype hosts through Gradle property

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
@@ -29,7 +29,11 @@ data class SonatypeHost internal constructor(
       "DEFAULT" -> DEFAULT
       "S01" -> S01
       "CENTRAL_PORTAL" -> CENTRAL_PORTAL
-      else -> throw IllegalArgumentException("No SonatypeHost constant $sonatypeHost")
+      else -> if (sonatypeHost.startsWith("https://")) {
+        SonatypeHost(sonatypeHost)
+      } else {
+        throw IllegalArgumentException("No SonatypeHost constant $sonatypeHost")
+      }
     }
 
     @JvmField


### PR DESCRIPTION
Can be used for custom instances like Amazon's or Google's.

closes #833 