### PR TITLE
include project name in archivesBaseName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     - Removed support for the old `org.jetbrains.dokka-android` plugin
 - Remove usages of deprecated Gradle API that is scheduled to be removed in Gradle 9.0
 - Raised minimum supported Gradle version
+- Improve naming of javadoc jars
 
 #### Minimum supported versions
 - JDK 11

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocJar.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocJar.kt
@@ -27,7 +27,7 @@ open class JavadocJar : Jar() {
       "${prefix}EmptyJavadocJar",
       JavadocJar::class.java,
     ) {
-      it.archiveBaseName.set("$prefix-javadoc")
+      it.archiveBaseName.set("${project.name}-$prefix-javadoc")
     }
 
     private fun Project.plainJavadocJar(prefix: String): TaskProvider<*> {
@@ -35,7 +35,7 @@ open class JavadocJar : Jar() {
         val task = tasks.named("javadoc")
         it.dependsOn(task)
         it.from(task)
-        it.archiveBaseName.set("$prefix-javadoc")
+        it.archiveBaseName.set("${project.name}-$prefix-javadoc")
       }
     }
 
@@ -47,7 +47,7 @@ open class JavadocJar : Jar() {
         }
         it.dependsOn(task)
         it.from(task)
-        it.archiveBaseName.set("$prefix-javadoc")
+        it.archiveBaseName.set("${project.name}-$prefix-javadoc")
       }
     }
   }


### PR DESCRIPTION
Closes https://github.com/vanniktech/gradle-maven-publish-plugin/issues/821

We're setting `archiveBaseName` since each publication gets its own javadoc task, so we need unique names. However if you take the build artifacts directly they may then have the same name across modules. This just adds the project name to the name which is closer to the default.