### PR TITLE
Align mavenCentralUsername and mavenCentralPassword configuration with other project properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [Unreleased]
+
+- Allow mavenCentralUsername and mavenCentralPassword to be set from any property type for added flexibility.
+
 ## 0.30.0 *(2024-10-13)*
 
 - Add support for Dokka 2.0.0-Beta

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -63,8 +63,8 @@ abstract class MavenPublishBaseExtension @Inject constructor(
       sonatypeHost = sonatypeHost,
       groupId = groupId,
       versionIsSnapshot = version.map { it.endsWith("-SNAPSHOT") },
-      repositoryUsername = project.providers.gradleProperty("mavenCentralUsername"),
-      repositoryPassword = project.providers.gradleProperty("mavenCentralPassword"),
+      repositoryUsername = project.provider { project.properties["mavenCentralUsername"]?.toString() },
+      repositoryPassword = project.provider { project.properties["mavenCentralPassword"]?.toString() },
       automaticRelease = automaticRelease,
       // TODO: stop accessing rootProject https://github.com/gradle/gradle/pull/26635
       rootBuildDirectory = project.rootProject.layout.buildDirectory,

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
@@ -332,10 +332,10 @@ internal abstract class SonatypeRepositoryBuildService :
       rootBuildDirectory: Provider<Directory>,
       buildEventsListenerRegistry: BuildEventsListenerRegistry,
     ): Provider<SonatypeRepositoryBuildService> {
-      val okhttpTimeout = project.providers.gradleProperty("SONATYPE_CONNECT_TIMEOUT_SECONDS")
+      val okhttpTimeout = project.provider<String> { project.properties["SONATYPE_CONNECT_TIMEOUT_SECONDS"]?.toString() }
         .map { it.toLong() }
         .orElse(60)
-      val closeTimeout = project.providers.gradleProperty("SONATYPE_CLOSE_TIMEOUT_SECONDS")
+      val closeTimeout = project.provider<String> { project.properties["SONATYPE_CLOSE_TIMEOUT_SECONDS"]?.toString() }
         .map { it.toLong() }
         .orElse(60 * 15)
       val service = gradle.sharedServices.registerIfAbsent(NAME, SonatypeRepositoryBuildService::class.java) {


### PR DESCRIPTION
Retains provider syntax while enabling `mavenCentralUsername` and `mavenCentralPassword` to be configured through a broader range of project properties, consistent with other properties in this plugin (e.g. `SONATYPE_HOST`).

My use case involves providing values decrypted in a Gradle task after the configuration phase, which is not currently feasible with standard Gradle properties. I believe this change would also benefit other scenarios, such as [loading values from a unique properties file](https://github.com/vanniktech/gradle-maven-publish-plugin/issues/798#issuecomment-2192088884) and other CI-centric configurations.

This PR may overlap with #824, but I believe my approach adds more general utility by allowing values to be set after the configuration phase and brings consistency to the way properties are configured across the plugin.

I attempted to run the tests using `./gradlew check`, but many failed in my development environment. However, I was able to confirm that the same tests passed and failed consistently before and after my changes.