### PR TITLE
Correct the snippet for Android multiple variants

### DIFF
--- a/docs/what.md
+++ b/docs/what.md
@@ -27,9 +27,9 @@ For projects using the `com.android.library` plugin. This will publish all varia
       // the second whether to publish a javadoc jar
       configure(new AndroidMultiVariantLibrary(true, true))
       // or to limit which build types to include
-      configure(new AndroidMultiVariantLibrary(true, true, ["beta", "release"]))
+      configure(new AndroidMultiVariantLibrary(true, true, ["beta", "release"] as Set))
       // or to limit which flavors to include, the map key is a flavor dimension, the set contains the flavors
-      configure(new AndroidMultiVariantLibrary(true, true, ["beta", "release"], ["store": ["google", "samsung"]]))
+      configure(new AndroidMultiVariantLibrary(true, true, ["beta", "release"] as Set, ["store": ["google", "samsung"] as Set]))
     }
     ```
 


### PR DESCRIPTION
Fixes the ABI error:

```
* What went wrong:
A problem occurred evaluating project ':mmkv'.
> Could not find matching constructor for: com.vanniktech.maven.publish.AndroidMultiVariantLibrary(Boolean, Boolean, ArrayList, LinkedHashMap)
```