### PR TITLE
automate test version updates

### DIFF
--- a/gradle/alpha.versions.toml
+++ b/gradle/alpha.versions.toml
@@ -1,0 +1,10 @@
+[versions]
+gradle = "8.13"
+kotlin = "2.1.20-RC"
+android-gradle = "8.10.0-alpha07"
+gradle-plugin-publish = "1.3.1"
+
+[plugins]
+kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+android-library = { id = "com.android.library", version.ref = "android-gradle" }
+gradle-plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "gradle-plugin-publish" }

--- a/gradle/beta.versions.toml
+++ b/gradle/beta.versions.toml
@@ -1,0 +1,10 @@
+[versions]
+gradle = "8.13"
+kotlin = "2.1.20-RC"
+android-gradle = "8.9.0"
+gradle-plugin-publish = "1.3.1"
+
+[plugins]
+kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+android-library = { id = "com.android.library", version.ref = "android-gradle" }
+gradle-plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "gradle-plugin-publish" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,8 @@
 [versions]
+gradle = "8.13"
 kotlin = "2.1.10"
+android-gradle = "8.9.0"
+gradle-plugin-publish = "1.3.1"
 moshi = "1.15.2"
 retrofit = "2.11.0"
 junit = "5.11.4"
@@ -38,3 +41,5 @@ kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version = "5.6.2" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+android-library = { id = "com.android.library", version.ref = "android-gradle" }
+gradle-plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "gradle-plugin-publish" }

--- a/gradle/rc.versions.toml
+++ b/gradle/rc.versions.toml
@@ -1,0 +1,10 @@
+[versions]
+gradle = "8.13"
+kotlin = "2.1.20-RC"
+android-gradle = "8.9.0"
+gradle-plugin-publish = "1.3.1"
+
+[plugins]
+kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+android-library = { id = "com.android.library", version.ref = "android-gradle" }
+gradle-plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "gradle-plugin-publish" }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -23,12 +23,6 @@ gradlePlugin {
   }
 }
 
-buildConfig {
-  packageName("com.vanniktech.maven.publish")
-  buildConfigField("String", "NAME", "\"com.vanniktech.maven.publish\"")
-  buildConfigField("String", "VERSION", "\"${project.findProperty("VERSION_NAME") ?: "dev"}\"")
-}
-
 val integrationTestSourceSet = sourceSets.create("integrationTest") {
   compileClasspath += sourceSets["main"].output
   compileClasspath += configurations.testRuntimeClasspath.get()
@@ -36,6 +30,31 @@ val integrationTestSourceSet = sourceSets.create("integrationTest") {
 }
 val integrationTestImplementation = configurations["integrationTestImplementation"]
   .extendsFrom(configurations.testImplementation.get())
+
+buildConfig {
+  packageName("com.vanniktech.maven.publish")
+  buildConfigField("String", "NAME", "\"com.vanniktech.maven.publish\"")
+  buildConfigField("String", "VERSION", "\"${project.findProperty("VERSION_NAME") ?: "dev"}\"")
+
+  sourceSets.getByName(integrationTestSourceSet.name) {
+    buildConfigField("GRADLE_ALPHA", alpha.versions.gradle.asProvider().get())
+    buildConfigField("GRADLE_BETA", beta.versions.gradle.asProvider().get())
+    buildConfigField("GRADLE_RC", rc.versions.gradle.asProvider().get())
+    buildConfigField("GRADLE_STABLE", libs.versions.gradle.asProvider().get())
+    buildConfigField("ANDROID_GRADLE_ALPHA", alpha.versions.android.gradle.get())
+    buildConfigField("ANDROID_GRADLE_BETA", beta.versions.android.gradle.get())
+    buildConfigField("ANDROID_GRADLE_RC", rc.versions.android.gradle.get())
+    buildConfigField("ANDROID_GRADLE_STABLE", libs.versions.android.gradle.get())
+    buildConfigField("KOTLIN_ALPHA", alpha.versions.kotlin.get())
+    buildConfigField("KOTLIN_BETA", beta.versions.kotlin.get())
+    buildConfigField("KOTLIN_RC", rc.versions.kotlin.get())
+    buildConfigField("KOTLIN_STABLE", libs.versions.kotlin.get())
+    buildConfigField("GRADLE_PUBLISH_ALPHA", alpha.versions.gradle.plugin.publish.get())
+    buildConfigField("GRADLE_PUBLISH_BETA", beta.versions.gradle.plugin.publish.get())
+    buildConfigField("GRADLE_PUBLISH_RC", rc.versions.gradle.plugin.publish.get())
+    buildConfigField("GRADLE_PUBLISH_STABLE", libs.versions.gradle.plugin.publish.get())
+  }
+}
 
 dependencies {
   api(gradleApi())

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginPlatformTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginPlatformTest.kt
@@ -136,7 +136,7 @@ class MavenPublishPluginPlatformTest {
 
   @TestParameterInjectorTest
   fun javaGradlePluginWithPluginPublishProject(
-    @TestParameter gradlePluginPublish: GradlePluginPublish,
+    @TestParameter(valuesProvider = GradlePluginPublishVersionProvider::class) gradlePluginPublish: GradlePluginPublish,
   ) {
     val project = javaGradlePluginWithGradlePluginPublish(gradlePluginPublish)
     val result = project.run(fixtures, testProjectDir, testOptions)

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -32,18 +32,11 @@ enum class AgpVersion(
     value = "8.0.0",
     minGradleVersion = GradleVersion.GRADLE_8_1,
   ),
-
-  // stable
-  AGP_8_9(
-    value = "8.9.0",
-    minGradleVersion = GradleVersion.GRADLE_8_10,
-  ),
-
-  // canary channel
-  AGP_8_10(
-    value = "8.10.0-alpha07",
-    minGradleVersion = GradleVersion.GRADLE_8_10,
-  ),
+  // latest versions of each type
+  AGP_STABLE(IntegrationTestBuildConfig.ANDROID_GRADLE_STABLE, GradleVersion.GRADLE_STABLE),
+  AGP_RC(IntegrationTestBuildConfig.ANDROID_GRADLE_RC, GradleVersion.GRADLE_STABLE),
+  AGP_BETA(IntegrationTestBuildConfig.ANDROID_GRADLE_BETA, GradleVersion.GRADLE_STABLE),
+  AGP_ALPHA(IntegrationTestBuildConfig.ANDROID_GRADLE_ALPHA, GradleVersion.GRADLE_STABLE),
 }
 
 enum class KotlinVersion(
@@ -53,12 +46,11 @@ enum class KotlinVersion(
 ) {
   // minimum supported
   KT_1_9_24("1.9.24"),
-
-  // stable
-  KT_2_1_10("2.1.10"),
-
-  // beta
-  KT_2_1_20("2.1.20-RC"),
+  // latest versions of each type
+  KOTLIN_STABLE(IntegrationTestBuildConfig.KOTLIN_STABLE),
+  KOTLIN_RC(IntegrationTestBuildConfig.KOTLIN_RC),
+  KOTLIN_BETA(IntegrationTestBuildConfig.KOTLIN_BETA),
+  KOTLIN_ALPHA(IntegrationTestBuildConfig.KOTLIN_ALPHA),
 }
 
 enum class GradleVersion(
@@ -70,28 +62,28 @@ enum class GradleVersion(
     value = "8.5",
     firstUnsupportedJdkVersion = JavaVersion.VERSION_22,
   ),
-
-  // stable
-  GRADLE_8_13(
-    value = "8.13",
-  ),
+  // latest versions of each type
+  GRADLE_STABLE(IntegrationTestBuildConfig.GRADLE_STABLE),
+  GRADLE_RC(IntegrationTestBuildConfig.GRADLE_RC),
+  GRADLE_BETA(IntegrationTestBuildConfig.GRADLE_BETA),
+  GRADLE_ALPHA(IntegrationTestBuildConfig.GRADLE_ALPHA),
   ;
 
   companion object {
-    // aliases for the skipped version to be able to reference the correct one in AgpVersion
+    // aliases for the skipped version to be able to reference the correct one in AgpVersion or conditions
     val GRADLE_8_1 = GRADLE_8_5
-    val GRADLE_8_9 = GRADLE_8_13
-    val GRADLE_8_10 = GRADLE_8_13
-    val GRADLE_8_12 = GRADLE_8_13
+    val GRADLE_8_12 = GRADLE_STABLE
   }
 }
 
 enum class GradlePluginPublish(val version: String) {
   // minimum supported
-  GRADLE_PLUGIN_PUBLISH_1_0("1.0.0"),
-
-  // stable
-  GRADLE_PLUGIN_PUBLISH_1_2("1.3.1"),
+  GRADLE_PLUGIN_PUBLISH_MIN("1.0.0"),
+  // latest versions of each type
+  GRADLE_PLUGIN_PUBLISH_STABLE(IntegrationTestBuildConfig.GRADLE_PUBLISH_STABLE),
+  GRADLE_PLUGIN_PUBLISH_RC(IntegrationTestBuildConfig.GRADLE_PUBLISH_RC),
+  GRADLE_PLUGIN_PUBLISH_BETA(IntegrationTestBuildConfig.GRADLE_PUBLISH_BETA),
+  GRADLE_PLUGIN_PUBLISH_ALPHA(IntegrationTestBuildConfig.GRADLE_PUBLISH_ALPHA),
 }
 
 fun GradleVersion.assumeSupportedJdkVersion() {

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -32,6 +32,7 @@ enum class AgpVersion(
     value = "8.0.0",
     minGradleVersion = GradleVersion.GRADLE_8_1,
   ),
+
   // latest versions of each type
   AGP_STABLE(IntegrationTestBuildConfig.ANDROID_GRADLE_STABLE, GradleVersion.GRADLE_STABLE),
   AGP_RC(IntegrationTestBuildConfig.ANDROID_GRADLE_RC, GradleVersion.GRADLE_STABLE),
@@ -46,6 +47,7 @@ enum class KotlinVersion(
 ) {
   // minimum supported
   KT_1_9_24("1.9.24"),
+
   // latest versions of each type
   KOTLIN_STABLE(IntegrationTestBuildConfig.KOTLIN_STABLE),
   KOTLIN_RC(IntegrationTestBuildConfig.KOTLIN_RC),
@@ -62,6 +64,7 @@ enum class GradleVersion(
     value = "8.5",
     firstUnsupportedJdkVersion = JavaVersion.VERSION_22,
   ),
+
   // latest versions of each type
   GRADLE_STABLE(IntegrationTestBuildConfig.GRADLE_STABLE),
   GRADLE_RC(IntegrationTestBuildConfig.GRADLE_RC),
@@ -79,6 +82,7 @@ enum class GradleVersion(
 enum class GradlePluginPublish(val version: String) {
   // minimum supported
   GRADLE_PLUGIN_PUBLISH_MIN("1.0.0"),
+
   // latest versions of each type
   GRADLE_PLUGIN_PUBLISH_STABLE(IntegrationTestBuildConfig.GRADLE_PUBLISH_STABLE),
   GRADLE_PLUGIN_PUBLISH_RC(IntegrationTestBuildConfig.GRADLE_PUBLISH_RC),

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptionsProvider.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptionsProvider.kt
@@ -23,7 +23,7 @@ internal class GradleVersionProvider : TestParameterValuesProvider() {
     if (quickTestProperty.isNotBlank()) {
       return ImmutableList.of(GradleVersion.entries.last())
     }
-    return ImmutableList.copyOf(GradleVersion.entries)
+    return ImmutableList.copyOf(GradleVersion.entries.distinctBy { it.value })
   }
 }
 
@@ -32,7 +32,7 @@ internal class AgpVersionProvider : TestParameterValuesProvider() {
     if (quickTestProperty.isNotBlank()) {
       return ImmutableList.of(AgpVersion.entries.last())
     }
-    return ImmutableList.copyOf(AgpVersion.entries)
+    return ImmutableList.copyOf(AgpVersion.entries.distinctBy { it.value })
   }
 }
 
@@ -41,6 +41,15 @@ internal class KotlinVersionProvider : TestParameterValuesProvider() {
     if (quickTestProperty.isNotBlank()) {
       return ImmutableList.of(KotlinVersion.entries.last())
     }
-    return ImmutableList.copyOf(KotlinVersion.entries)
+    return ImmutableList.copyOf(KotlinVersion.entries.distinctBy { it.value })
+  }
+}
+
+internal class GradlePluginPublishVersionProvider : TestParameterValuesProvider() {
+  override fun provideValues(context: Context?): List<*> {
+    if (quickTestProperty.isNotBlank()) {
+      return ImmutableList.of(GradlePluginPublish.entries.last())
+    }
+    return ImmutableList.copyOf(GradlePluginPublish.entries.distinctBy { it.version })
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,33 @@
 {
   "extends": [
     "config:base"
+  ],
+  "ignoreUnstable": false,
+  "packageRules": [
+    {
+      "matchPackagePatterns": [".*"],
+      "allowedVersions": "!/(alpha|Alpha|ALPHA|beta|Beta|BETA|rc|RC|milestone|SNAPSHOT)/"
+    },
+    {
+      "matchFileNames": ["**/alpha.versions.toml"],
+      "allowedVersions": "!/(SNAPSHOT)/"
+    },
+    {
+      "matchFileNames": ["**/beta.versions.toml"],
+      "allowedVersions": "!/(alpha|Alpha|ALPHA|milestone|SNAPSHOT)/"
+    },
+    {
+      "matchFileNames": ["**/rc.versions.toml"],
+      "allowedVersions": "!/(alpha|Alpha|ALPHA|beta|Beta|BETA|milestone|SNAPSHOT)/"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["\\.versions.toml$"],
+      "matchStrings": ["(^|\n)(?<depName>gradle) *= *\"(?<currentValue>.*)\""],
+      "depNameTemplate": "gradle",
+      "datasourceTemplate": "gradle-version"
+    }
   ]
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,20 @@ develocity {
   }
 }
 
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("alpha") {
+      from(files("gradle/alpha.versions.toml"))
+    }
+    create("beta") {
+      from(files("gradle/beta.versions.toml"))
+    }
+    create("rc") {
+      from(files("gradle/rc.versions.toml"))
+    }
+  }
+}
+
 include(":plugin")
 include(":nexus")
 include(":central-portal")


### PR DESCRIPTION
This is done by adding extra version catalogs and then configuring renovate to allow different kinds of suffixes for each of them. We then generate constants for the version catalog version and use those in tests. The tests will also filter duplicate versions so that we don't run the same version twice if there is for example no alpha version for something.

I'm using the current versions, so that renovate should update Gradle, Kotlin and AGP to the latest versions after this is merged.