### PR TITLE
Exclude kotlin-stdlib from plugin dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,7 @@
+# Omit automatic compile dependency on kotlin-stdlib.
+# https://kotlinlang.org/docs/gradle-configure-project.html#dependency-on-the-standard-library
+kotlin.stdlib.default.dependency=false
+
 org.gradle.caching=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx2g
 org.gradle.parallel=true

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -39,7 +39,6 @@ val integrationTestImplementation = configurations["integrationTestImplementatio
 
 dependencies {
   api(gradleApi())
-  api(libs.kotlin.stdlib)
 
   compileOnly(libs.dokka)
   compileOnly(libs.kotlin.plugin)


### PR DESCRIPTION
https://kotlinlang.org/docs/gradle-configure-project.html#dependency-on-the-standard-library

<details><summary>Full Diff</summary>
<p>

```diff
diff --color=auto -r before/central-portal/0.1.0-SNAPSHOT/central-portal-0.1.0-SNAPSHOT-javadoc.jar.asc after/central-portal/0.1.0-SNAPSHOT/central-portal-0.1.0-SNAPSHOT-javadoc.jar.asc
4,6c4,6
< iF4EABYKAAYFAmgGiXUACgkQAgvaYjxlHg7UigEAsj5LIEr4o2ADotgldK0mEjaR
< Q6mvcbug1bCnCtSLYH0BALSDusDqGsAy/8g/LgaWpTk5jlv7ESXsJiAam2WdWeUG
< =UY7R
---
> iF4EABYKAAYFAmgGij8ACgkQAgvaYjxlHg4b1gEAoNLR/Hp6NbUfrovMu5wLRu6V
> PQ0+9xDnCmGN1lcdwIAA/RV44cPtSAktZHt2+Ec4BJgqzA/qswJgnS4fAH98bDYE
> =LvIt
diff --color=auto -r before/central-portal/0.1.0-SNAPSHOT/central-portal-0.1.0-SNAPSHOT-sources.jar.asc after/central-portal/0.1.0-SNAPSHOT/central-portal-0.1.0-SNAPSHOT-sources.jar.asc
4,6c4,6
< iF4EABYKAAYFAmgGiXUACgkQAgvaYjxlHg4qgAEAsbV7kMGqYNtW3RqTR91Avxzp
< ay0QrwY+3nUNUgaPGK4BAJlqOyrcSKIvg7NgxrHL623oOjW6t0N1sgAOEHf15zsC
< =rxYy
---
> iF4EABYKAAYFAmgGij8ACgkQAgvaYjxlHg7fVwD/UL283BCRegxkNq19+AMHjy+q
> q8RDaoLG18aaXQBwmPABAO4waaYRAW3UQFV1fNlY+ZulIY0hTn5BV1mP/lxK8QQE
> =AH3f
diff --color=auto -r before/central-portal/0.1.0-SNAPSHOT/central-portal-0.1.0-SNAPSHOT.jar.asc after/central-portal/0.1.0-SNAPSHOT/central-portal-0.1.0-SNAPSHOT.jar.asc
4,6c4,6
< iF4EABYKAAYFAmgGiXUACgkQAgvaYjxlHg7RoAEA2z7Wc1laL8/gEQvNLe9No9EK
< TDnjvrTkKEk1CPeIqvUBAPDM0YvNeGTT8BC/1HRsDTJO9sWLZwHfQBINWM3QbKsJ
< =ylzk
---
> iF4EABYKAAYFAmgGij8ACgkQAgvaYjxlHg6IVwEAhWh7O9PQm1+74hLg0mtD3PEo
> dcaEkzlDk2W+Wq/fwfgA/iR+tFFcw05JUBVNGybHwyI7pVmG/BgcYHzcuMcvDfIO
> =vImH
diff --color=auto -r before/central-portal/0.1.0-SNAPSHOT/central-portal-0.1.0-SNAPSHOT.module after/central-portal/0.1.0-SNAPSHOT/central-portal-0.1.0-SNAPSHOT.module
28,36d27
<       "dependencies": [
<         {
<           "group": "org.jetbrains.kotlin",
<           "module": "kotlin-stdlib",
<           "version": {
<             "requires": "2.1.10"
<           }
<         }
<       ],
94,100d84
<           }
<         },
<         {
<           "group": "org.jetbrains.kotlin",
<           "module": "kotlin-stdlib",
<           "version": {
<             "requires": "2.1.10"
diff --color=auto -r before/central-portal/0.1.0-SNAPSHOT/central-portal-0.1.0-SNAPSHOT.module.asc after/central-portal/0.1.0-SNAPSHOT/central-portal-0.1.0-SNAPSHOT.module.asc
4,6c4,6
< iF4EABYKAAYFAmgGiXUACgkQAgvaYjxlHg7JvAD8Cu9X3axNKm4S4mCLLM53wHKM
< ZMPR0h+wLfSHSfYV6sQBALR+uqVdrMdNobPkj7hM6393jVX89x49Fm3NNKfAqXEM
< =D/0z
---
> iF4EABYKAAYFAmgGij8ACgkQAgvaYjxlHg7QDgEAylpthqx020kMFPXDXM+tLJTq
> rzP6a3XXdYSAFxidF70BAJUUjANTjtnN7hImnIIEyVTwvi6dnmasAf2fVnTdzQMP
> =+TGv
diff --color=auto -r before/central-portal/0.1.0-SNAPSHOT/central-portal-0.1.0-SNAPSHOT.pom after/central-portal/0.1.0-SNAPSHOT/central-portal-0.1.0-SNAPSHOT.pom
37,42d36
<       <groupId>org.jetbrains.kotlin</groupId>
<       <artifactId>kotlin-stdlib</artifactId>
<       <version>2.1.10</version>
<       <scope>compile</scope>
<     </dependency>
<     <dependency>
diff --color=auto -r before/central-portal/0.1.0-SNAPSHOT/central-portal-0.1.0-SNAPSHOT.pom.asc after/central-portal/0.1.0-SNAPSHOT/central-portal-0.1.0-SNAPSHOT.pom.asc
4,6c4,6
< iF4EABYKAAYFAmgGiXUACgkQAgvaYjxlHg7rCAD8CTiKNIl6yHyqKq4dJg6FLcSm
< 1GM1JuywiwnsRFpmjz4A/1aO7vHRheioKBGti5hcy3wl0NQg3cseXQuEbbSxJLsE
< =3xgL
---
> iF4EABYKAAYFAmgGij8ACgkQAgvaYjxlHg6y3gEA2W6YfcmkD/DayCKRrZi2mZZQ
> b39oY804yq6qkdreM2IA/RPde/MpF2XAEwpASFK17AUNFEGIeWJ1pUghwU/wgvcA
> =IFI/
diff --color=auto -r before/central-portal/0.1.0-SNAPSHOT/maven-metadata-local.xml after/central-portal/0.1.0-SNAPSHOT/maven-metadata-local.xml
6c6
<     <lastUpdated>20250421180749</lastUpdated>
---
>     <lastUpdated>20250421181846</lastUpdated>
12c12
<         <extension>jar</extension>
---
>         <extension>pom</extension>
14c14
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
17c17,22
<         <classifier>sources</classifier>
---
>         <extension>module.asc</extension>
>         <value>0.1.0-SNAPSHOT</value>
>         <updated>20250421181846</updated>
>       </snapshotVersion>
>       <snapshotVersion>
>         <classifier>javadoc</classifier>
20c25
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
23c28
<         <extension>jar.asc</extension>
---
>         <extension>jar</extension>
25c30
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
28c33
<         <classifier>sources</classifier>
---
>         <classifier>javadoc</classifier>
31c36
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
34c39
<         <extension>module</extension>
---
>         <extension>jar.asc</extension>
36c41
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
39c44,45
<         <extension>pom</extension>
---
>         <classifier>sources</classifier>
>         <extension>jar.asc</extension>
41c47
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
46c52
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
49,54c55
<         <extension>module.asc</extension>
<         <value>0.1.0-SNAPSHOT</value>
<         <updated>20250421180749</updated>
<       </snapshotVersion>
<       <snapshotVersion>
<         <classifier>javadoc</classifier>
---
>         <classifier>sources</classifier>
57c58
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
60,61c61
<         <classifier>javadoc</classifier>
<         <extension>jar.asc</extension>
---
>         <extension>module</extension>
63c63
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
diff --color=auto -r before/central-portal/maven-metadata-local.xml after/central-portal/maven-metadata-local.xml
10c10
<     <lastUpdated>20250421180749</lastUpdated>
---
>     <lastUpdated>20250421181846</lastUpdated>
diff --color=auto -r before/gradle-maven-publish-plugin/0.1.0-SNAPSHOT/gradle-maven-publish-plugin-0.1.0-SNAPSHOT-javadoc.jar.asc after/gradle-maven-publish-plugin/0.1.0-SNAPSHOT/gradle-maven-publish-plugin-0.1.0-SNAPSHOT-javadoc.jar.asc
4,6c4,6
< iF4EABYKAAYFAmgGiXsACgkQAgvaYjxlHg57jgD/TdmcxnNGqCJ9QGn3hOfUXS6h
< 74Cf5URHucaaui6MOR0A/0Z3HPOSgX0W+Try2sKXKnXuT4FC9z2okIJKOp6eyCUP
< =Eku2
---
> iF4EABYKAAYFAmgGjAYACgkQAgvaYjxlHg5CtQEA1hi923/Xb7s4JElHCP6OGThF
> KCQPWjgV9laUHFHHvCwBANMjuV+3Fe4nBdFagap/bq+kdv+J96mEJxYOqYuPw+UG
> =3raY
diff --color=auto -r before/gradle-maven-publish-plugin/0.1.0-SNAPSHOT/gradle-maven-publish-plugin-0.1.0-SNAPSHOT-sources.jar.asc after/gradle-maven-publish-plugin/0.1.0-SNAPSHOT/gradle-maven-publish-plugin-0.1.0-SNAPSHOT-sources.jar.asc
4,6c4,6
< iF4EABYKAAYFAmgGiXsACgkQAgvaYjxlHg5EQgEA0bPD6A0NyUBJbZaD24F9iWJH
< XMSK+avaRYRiEPDe4kkBANVTi42Tz/GvNJO7XDuldVWzp+6agbVMiG2pob9qPPQO
< =MKNK
---
> iF4EABYKAAYFAmgGjAYACgkQAgvaYjxlHg6IOQEAgaphrPYn2WWn4XdL1NdpCCXj
> 4iqRft2/Wkv7nTlFJF4BANATXTJYyRT+n6BEpKLKuuTveN0rvFz3hz/xHnN412YN
> =/Aql
diff --color=auto -r before/gradle-maven-publish-plugin/0.1.0-SNAPSHOT/gradle-maven-publish-plugin-0.1.0-SNAPSHOT.jar.asc after/gradle-maven-publish-plugin/0.1.0-SNAPSHOT/gradle-maven-publish-plugin-0.1.0-SNAPSHOT.jar.asc
4,6c4,6
< iF4EABYKAAYFAmgGiXsACgkQAgvaYjxlHg4HUwD+KK4oUSE/xiSCiuXdxJ7FN1SV
< d8mZOJLCor5zKvspl3cA/jwwhxL+735kfBSTS5/Fq+ZrcWKNOPu3locoSRLAP6EC
< =G6li
---
> iF4EABYKAAYFAmgGjAYACgkQAgvaYjxlHg64dQEAqszB71wvRAMED67+1Asxwge5
> 0P8XnWT8SUIz366EvrkA/0iNCzbgQKBXNkd+QXhoJWpRqSFGTS+1vZ+UyH//nEUE
> =NpIJ
diff --color=auto -r before/gradle-maven-publish-plugin/0.1.0-SNAPSHOT/gradle-maven-publish-plugin-0.1.0-SNAPSHOT.module after/gradle-maven-publish-plugin/0.1.0-SNAPSHOT/gradle-maven-publish-plugin-0.1.0-SNAPSHOT.module
28,36d27
<       "dependencies": [
<         {
<           "group": "org.jetbrains.kotlin",
<           "module": "kotlin-stdlib",
<           "version": {
<             "requires": "2.1.10"
<           }
<         }
<       ],
73,79d63
<           }
<         },
<         {
<           "group": "org.jetbrains.kotlin",
<           "module": "kotlin-stdlib",
<           "version": {
<             "requires": "2.1.10"
diff --color=auto -r before/gradle-maven-publish-plugin/0.1.0-SNAPSHOT/gradle-maven-publish-plugin-0.1.0-SNAPSHOT.module.asc after/gradle-maven-publish-plugin/0.1.0-SNAPSHOT/gradle-maven-publish-plugin-0.1.0-SNAPSHOT.module.asc
4,6c4,6
< iF4EABYKAAYFAmgGiXsACgkQAgvaYjxlHg6n4AEA/dhWgDIYArEMT9gGK7TIt8Jk
< gWXmaXpaSxIfI1z+Rm8A/irYXUWY9e51VcWYyte4h2ut9sRoil8gz0CUoPXN2HoI
< =2x3N
---
> iF4EABYKAAYFAmgGjAYACgkQAgvaYjxlHg4vGwEArxh8ODGZL846VahwxxxoEyFj
> Qj/NDJbbf5VdsRq4dTsA/1kDHgkiDqrDL1gAJ8NRnwwN/Q/AO/p/YAFo9Xz/jQYK
> =Mnuo
diff --color=auto -r before/gradle-maven-publish-plugin/0.1.0-SNAPSHOT/gradle-maven-publish-plugin-0.1.0-SNAPSHOT.pom after/gradle-maven-publish-plugin/0.1.0-SNAPSHOT/gradle-maven-publish-plugin-0.1.0-SNAPSHOT.pom
37,42d36
<       <groupId>org.jetbrains.kotlin</groupId>
<       <artifactId>kotlin-stdlib</artifactId>
<       <version>2.1.10</version>
<       <scope>compile</scope>
<     </dependency>
<     <dependency>
diff --color=auto -r before/gradle-maven-publish-plugin/0.1.0-SNAPSHOT/gradle-maven-publish-plugin-0.1.0-SNAPSHOT.pom.asc after/gradle-maven-publish-plugin/0.1.0-SNAPSHOT/gradle-maven-publish-plugin-0.1.0-SNAPSHOT.pom.asc
4,6c4,6
< iF4EABYKAAYFAmgGiXsACgkQAgvaYjxlHg4u2AD7Bwha+vpPEfeVztyW6f0qcwAZ
< ExHNe1zclHQVxfo273MBAPucSjXIGL/C5D6nQBRyC+740IvBcvZZ2m3gQeXIrsYB
< =Il8B
---
> iF4EABYKAAYFAmgGjAYACgkQAgvaYjxlHg4K4AD9GeBFA+B4/4ocXZh6B1yARv1t
> 19It7mhb2T6uv0xpf2QBANme89XS3KXsx1Na/bLaGoj67ydh5jb/0iAdHz7foUwE
> =P5Rp
diff --color=auto -r before/gradle-maven-publish-plugin/0.1.0-SNAPSHOT/maven-metadata-local.xml after/gradle-maven-publish-plugin/0.1.0-SNAPSHOT/maven-metadata-local.xml
6c6
<     <lastUpdated>20250421180755</lastUpdated>
---
>     <lastUpdated>20250421181846</lastUpdated>
12c12
<         <extension>module</extension>
---
>         <extension>jar</extension>
14c14
<         <updated>20250421180755</updated>
---
>         <updated>20250421181846</updated>
17,18c17
<         <classifier>sources</classifier>
<         <extension>jar</extension>
---
>         <extension>pom</extension>
20c19
<         <updated>20250421180755</updated>
---
>         <updated>20250421181846</updated>
23c22,23
<         <extension>pom</extension>
---
>         <classifier>sources</classifier>
>         <extension>jar.asc</extension>
25c25
<         <updated>20250421180755</updated>
---
>         <updated>20250421181846</updated>
28c28
<         <extension>jar</extension>
---
>         <extension>module.asc</extension>
30c30
<         <updated>20250421180755</updated>
---
>         <updated>20250421181846</updated>
33c33
<         <classifier>javadoc</classifier>
---
>         <classifier>sources</classifier>
36c36
<         <updated>20250421180755</updated>
---
>         <updated>20250421181846</updated>
42c42
<         <updated>20250421180755</updated>
---
>         <updated>20250421181846</updated>
45c45,46
<         <extension>pom.asc</extension>
---
>         <classifier>javadoc</classifier>
>         <extension>jar</extension>
47c48
<         <updated>20250421180755</updated>
---
>         <updated>20250421181846</updated>
50c51
<         <extension>module.asc</extension>
---
>         <extension>pom.asc</extension>
52c53
<         <updated>20250421180755</updated>
---
>         <updated>20250421181846</updated>
55d55
<         <classifier>sources</classifier>
58c58
<         <updated>20250421180755</updated>
---
>         <updated>20250421181846</updated>
61c61
<         <extension>jar.asc</extension>
---
>         <extension>module</extension>
63c63
<         <updated>20250421180755</updated>
---
>         <updated>20250421181846</updated>
diff --color=auto -r before/gradle-maven-publish-plugin/maven-metadata-local.xml after/gradle-maven-publish-plugin/maven-metadata-local.xml
10c10
<     <lastUpdated>20250421180755</lastUpdated>
---
>     <lastUpdated>20250421181846</lastUpdated>
diff --color=auto -r before/maven/publish/base/com.vanniktech.maven.publish.base.gradle.plugin/0.1.0-SNAPSHOT/maven-metadata-local.xml after/maven/publish/base/com.vanniktech.maven.publish.base.gradle.plugin/0.1.0-SNAPSHOT/maven-metadata-local.xml
6c6
<     <lastUpdated>20250421180741</lastUpdated>
---
>     <lastUpdated>20250421181846</lastUpdated>
12c12
<         <extension>pom.asc</extension>
---
>         <extension>pom</extension>
14c14
<         <updated>20250421180741</updated>
---
>         <updated>20250421181846</updated>
17c17
<         <extension>pom</extension>
---
>         <extension>pom.asc</extension>
19c19
<         <updated>20250421180741</updated>
---
>         <updated>20250421181846</updated>
diff --color=auto -r before/maven/publish/base/com.vanniktech.maven.publish.base.gradle.plugin/maven-metadata-local.xml after/maven/publish/base/com.vanniktech.maven.publish.base.gradle.plugin/maven-metadata-local.xml
10c10
<     <lastUpdated>20250421180741</lastUpdated>
---
>     <lastUpdated>20250421181846</lastUpdated>
diff --color=auto -r before/maven/publish/com.vanniktech.maven.publish.gradle.plugin/0.1.0-SNAPSHOT/maven-metadata-local.xml after/maven/publish/com.vanniktech.maven.publish.gradle.plugin/0.1.0-SNAPSHOT/maven-metadata-local.xml
6c6
<     <lastUpdated>20250421180741</lastUpdated>
---
>     <lastUpdated>20250421181846</lastUpdated>
12c12
<         <extension>pom.asc</extension>
---
>         <extension>pom</extension>
14c14
<         <updated>20250421180741</updated>
---
>         <updated>20250421181846</updated>
17c17
<         <extension>pom</extension>
---
>         <extension>pom.asc</extension>
19c19
<         <updated>20250421180741</updated>
---
>         <updated>20250421181846</updated>
diff --color=auto -r before/maven/publish/com.vanniktech.maven.publish.gradle.plugin/maven-metadata-local.xml after/maven/publish/com.vanniktech.maven.publish.gradle.plugin/maven-metadata-local.xml
10c10
<     <lastUpdated>20250421180741</lastUpdated>
---
>     <lastUpdated>20250421181846</lastUpdated>
diff --color=auto -r before/nexus/0.1.0-SNAPSHOT/maven-metadata-local.xml after/nexus/0.1.0-SNAPSHOT/maven-metadata-local.xml
6c6
<     <lastUpdated>20250421180749</lastUpdated>
---
>     <lastUpdated>20250421181846</lastUpdated>
14c14
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
17c17,18
<         <extension>pom.asc</extension>
---
>         <classifier>sources</classifier>
>         <extension>jar.asc</extension>
19c20
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
22c23,24
<         <extension>module.asc</extension>
---
>         <classifier>javadoc</classifier>
>         <extension>jar</extension>
24c26
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
29c31
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
32c34
<         <extension>pom</extension>
---
>         <extension>module</extension>
34c36
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
37c39
<         <classifier>javadoc</classifier>
---
>         <classifier>sources</classifier>
40c42
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
43,44c45
<         <classifier>sources</classifier>
<         <extension>jar</extension>
---
>         <extension>module.asc</extension>
46c47
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
49c50
<         <extension>module</extension>
---
>         <extension>pom.asc</extension>
51c52
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
54c55
<         <classifier>sources</classifier>
---
>         <classifier>javadoc</classifier>
57c58
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
60,61c61
<         <classifier>javadoc</classifier>
<         <extension>jar.asc</extension>
---
>         <extension>pom</extension>
63c63
<         <updated>20250421180749</updated>
---
>         <updated>20250421181846</updated>
diff --color=auto -r before/nexus/0.1.0-SNAPSHOT/nexus-0.1.0-SNAPSHOT-javadoc.jar.asc after/nexus/0.1.0-SNAPSHOT/nexus-0.1.0-SNAPSHOT-javadoc.jar.asc
4,6c4,6
< iF4EABYKAAYFAmgGiXUACgkQAgvaYjxlHg7UigEAsj5LIEr4o2ADotgldK0mEjaR
< Q6mvcbug1bCnCtSLYH0BALSDusDqGsAy/8g/LgaWpTk5jlv7ESXsJiAam2WdWeUG
< =UY7R
---
> iF4EABYKAAYFAmgGij8ACgkQAgvaYjxlHg4b1gEAoNLR/Hp6NbUfrovMu5wLRu6V
> PQ0+9xDnCmGN1lcdwIAA/RV44cPtSAktZHt2+Ec4BJgqzA/qswJgnS4fAH98bDYE
> =LvIt
diff --color=auto -r before/nexus/0.1.0-SNAPSHOT/nexus-0.1.0-SNAPSHOT-sources.jar.asc after/nexus/0.1.0-SNAPSHOT/nexus-0.1.0-SNAPSHOT-sources.jar.asc
4,6c4,6
< iF4EABYKAAYFAmgGiXUACgkQAgvaYjxlHg4u+wD+JofkXMrYPRNfjUJmgyA+cV7i
< vHX+5s9bRpF6qcRnblsBAJTU0VFuEpYIv/5u+YY4zhTAJEcZvRTSPKIrOMRe0c4E
< =8GBl
---
> iF4EABYKAAYFAmgGij8ACgkQAgvaYjxlHg4FsAD+NbhTNpg24Yw7wRkkSkhFcNIm
> JPpgNz2AyfSxUhNTGkYBAIar1SYHzgtNLRmU0PnQxqvKWku+9/tgi541opurE6sI
> =EsGQ
diff --color=auto -r before/nexus/0.1.0-SNAPSHOT/nexus-0.1.0-SNAPSHOT.jar.asc after/nexus/0.1.0-SNAPSHOT/nexus-0.1.0-SNAPSHOT.jar.asc
4,6c4,6
< iF4EABYKAAYFAmgGiXUACgkQAgvaYjxlHg5G0wEAhqGzEH6JqLSo4mwwDjaZ15XY
< 6q5VOrkOoeZiQyTfsRQBAJFPs+RWg7/y3I+acDvGSicboU+lAtlWUFzNU7vz420K
< =JmhW
---
> iF4EABYKAAYFAmgGij8ACgkQAgvaYjxlHg6i2QEAqT7Hs/HvoowEZ1U2c9M9abNx
> q1rIONlWf/vsmeGClu8A/23SS4GQ/ancT2Wasps2GZxOLetyZVOfVaoUFt1nvpEB
> =Frpc
diff --color=auto -r before/nexus/0.1.0-SNAPSHOT/nexus-0.1.0-SNAPSHOT.module after/nexus/0.1.0-SNAPSHOT/nexus-0.1.0-SNAPSHOT.module
28,36d27
<       "dependencies": [
<         {
<           "group": "org.jetbrains.kotlin",
<           "module": "kotlin-stdlib",
<           "version": {
<             "requires": "2.1.10"
<           }
<         }
<       ],
87,93d77
<           }
<         },
<         {
<           "group": "org.jetbrains.kotlin",
<           "module": "kotlin-stdlib",
<           "version": {
<             "requires": "2.1.10"
diff --color=auto -r before/nexus/0.1.0-SNAPSHOT/nexus-0.1.0-SNAPSHOT.module.asc after/nexus/0.1.0-SNAPSHOT/nexus-0.1.0-SNAPSHOT.module.asc
4,6c4,6
< iF4EABYKAAYFAmgGiXUACgkQAgvaYjxlHg5+tAD6A83nZEr8AnfDqJLtDuNczoi8
< 4OvqY341s8pq3MPoOdIA/R8hlqCEagX9VQg7JxguR4POFP22JiyfVzaArNtF/QEI
< =UzHj
---
> iF4EABYKAAYFAmgGij8ACgkQAgvaYjxlHg4ZUQD/cLVfGhWGO8Ux0y4NJtT6Ceda
> bxPh9cQVfCIwGIPnmM0BAO72cLC/9vTF8XtJaMPvD/iTz26d8AkCPar7ib7GgccI
> =v/8S
diff --color=auto -r before/nexus/0.1.0-SNAPSHOT/nexus-0.1.0-SNAPSHOT.pom after/nexus/0.1.0-SNAPSHOT/nexus-0.1.0-SNAPSHOT.pom
37,42d36
<       <groupId>org.jetbrains.kotlin</groupId>
<       <artifactId>kotlin-stdlib</artifactId>
<       <version>2.1.10</version>
<       <scope>compile</scope>
<     </dependency>
<     <dependency>
diff --color=auto -r before/nexus/0.1.0-SNAPSHOT/nexus-0.1.0-SNAPSHOT.pom.asc after/nexus/0.1.0-SNAPSHOT/nexus-0.1.0-SNAPSHOT.pom.asc
4,6c4,6
< iF4EABYKAAYFAmgGiXUACgkQAgvaYjxlHg6figEAmYpyvpjQi11WTOGUwH6Vhrbe
< Enf6cAyJce2rYnWnx4IA/jkX/sx9dInNWkMS7XKGVJJvjvvRwQPmm7sUvRROW1AO
< =dCSN
---
> iF4EABYKAAYFAmgGij8ACgkQAgvaYjxlHg7ATAD+J5Qa2OYZ/h7RzwXIy7tHF2kZ
> uzJJOZJ+JQCHvSpT7/MBAIxtaNlDF9nFHDexV0HQUPWfINa7xJTbHltGrV7xbUEP
> =UXjK
diff --color=auto -r before/nexus/maven-metadata-local.xml after/nexus/maven-metadata-local.xml
10c10
<     <lastUpdated>20250421180749</lastUpdated>
---
>     <lastUpdated>20250421181846</lastUpdated>
```

</p>
</details>