### PR TITLE
change default publishToMavenCentral behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@
 - Deprecated `SonatypeHost`.
 
 Improvements
+- Added new Gradle properties
+   - `mavenCentralPublishing=true` replaces `SONATYPE_HOST=CENTRAL_PORTAL`
+   - `mavenCentralAutomaticPublishing=true` replaces `SONATYPE_AUTOMATIC_RELEASE=true`
+   - `signAllPublications=true` replaces `RELEASE_SIGNING_ENABLED=true`
+   - Note: The old properties continue to work and there are no plans to remove them
 - The base plugin is now compatible with isolated projects as long as `pomFromGradleProperties()` is
   not called.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 ## [UNRELEASED](https://github.com/vanniktech/gradle-maven-publish-plugin/compare/0.32.0...HEAD) *(2025-xx-xx)*
 
+> [!CAUTION]
+> Sonatype OSSRH (oss.sonatype.org and s01.oss.sonatype.org) will be shut down on June 30, 2025.
+>
+> Migration steps:
+> 1. Sign in to the [Central Portal](https://central.sonatype.com) with your existing Sonatype account
+> 2. Go to [Namespaces](https://central.sonatype.com/publishing/namespaces) and click "Migrate Namespace"
+>    for the relevant namespace. Confirm the migration and wait for it to complete.
+> 3. Optional: If you want to publish snapshots of your project tap the 3 dots next to your namespace and
+>    select "Enable SNAPSHOTs"
+> 4. Go to [Account](https://central.sonatype.com/account) and select "Generate User Token". Use the shown
+>    "Username" and "Password" as values for `mavenCentralUsername` and `mavenCentralPassword`.
+> 5. Configure this plugin to publish to Central Portal. Either update your `SONATYPE_HOST` property from
+>    `DEFAULT` or `S01` to `CENTRAL_PORTAL` or call `publishToMavenCentral()`/publishToMavenCentral(automaticRelease)
+>    without a `SonatypeHost` parameter.
+
+**BREAKING**
+- `publishToMavenCentral()` and `publishToMavenCentral(automaticRelease)` without `SonatypeHost` will
+  now publish through the Central Portal.
+- Deprecated overloads of `publishToMavenCentral` that take a `SonatypeHost` parameter.
+- Deprecated `SonatypeHost`.
+
+Improvements
+- The base plugin is now compatible with isolated projects as long as `pomFromGradleProperties()` is
+  not called.
+
+
+Thanks to @Goooler and @solrudev for their contributions to this release.
+
+#### Minimum supported versions
+- JDK 11
+- Gradle 8.5
+- Android Gradle Plugin 8.0.0
+- Kotlin Gradle Plugin 1.9.20
+
+#### Compatibility tested up to
+- JDK 24
+- Gradle 8.14.2
+- Gradle 9.0-rc1
+- Android Gradle Plugin 8.10.0
+- Android Gradle Plugin 8.11.0-rc02
+- Android Gradle Plugin 8.12.0-alpha06
+- Kotlin Gradle Plugin 2.1.21
+- Kotlin Gradle Plugin 2.2.0-RC3
+
 
 ## [0.32.0](https://github.com/vanniktech/gradle-maven-publish-plugin/releases/tag/0.32.0) *(2025-05-15)*
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,8 @@ plugin directly integrate with, so why should you use this plugin?
   that works regardless of whether this is a Gradle plugin, an Android library or a Kotlin Multiplatform project. This
   is especially useful for projects that combine multiple of these.
 - **Maven central integration**. The plugin makes it easy to configure publishing to Maven Central with dedicated
-  APIs to set it up and configure everything that is required. It also avoids issues like having multiple staging
-  repositories on Sonatype OSS and supports automatic releasing without requiring any interaction with the web
-  interface.
+  APIs to set it up and configure everything that is required. It also supports automatic releasing without requiring
+  any interaction with the web interface.
 - **In memory GPG signing keys**. Easily sign artifacts on CI by simply setting the required environment variables,
   no extra setup required.
 - **Gradle property based config**. Easily configure the plugin with Gradle properties that will apply to all

--- a/docs/base.md
+++ b/docs/base.md
@@ -27,8 +27,11 @@ Add the plugin to any Gradle project that should be published
 ## General configuration
 
 Follow the steps of the [Maven Central](central.md) or [other Maven repositories](other.md) guides.
-Note that the `SONATYPE_HOST`, `SONATYPE_AUTOMATIC_RELEASE` and `RELEASE_SIGNING_ENABLED` are not
-considered by the base plugin and the appropriate DSL methods need to be called.
+
+!!! note
+
+    The `mavenCentralPublishing`, `mavenCentralAutomaticPublishing` and `signAllPublications` properties are not
+    considered by the base plugin and the appropriate DSL methods need to be called.
 
 For the pom configuration via Gradle properties the following needs to be enabled in the DSL:
 

--- a/docs/central.md
+++ b/docs/central.md
@@ -76,15 +76,15 @@ This can be done through either the DSL or by setting Gradle properties.
 === "gradle.properties"
 
     ```properties
-    SONATYPE_HOST=CENTRAL_PORTAL
+    mavenCentralPublishing=true
 
-    RELEASE_SIGNING_ENABLED=true
+    signAllPublications=true
     ```
 
 ## Configuring the POM
 
 The pom is published alongside the project and contains the project coordinates
-as well as some general information about the project like an url and the used
+as well as some general information about the project like a url and the used
 license.
 
 This configuration also determines the coordinates (`group:artifactId:version`) used to consume the library.
@@ -351,7 +351,7 @@ For automatic publishing use one of the following options
     Add the following to `gradle.properties` to make any publish task also take care of
     step 3.
     ```properties
-    SONATYPE_AUTOMATIC_RELEASE=true
+    mavenCentralAutomaticPublishing=true
     ```
 
     To publish use
@@ -363,3 +363,4 @@ For automatic publishing use one of the following options
 
     Configuration caching when uploading releases is currently not possible. Supporting it is
     blocked by [Gradle issue #22779](https://github.com/gradle/gradle/issues/22779).
+

--- a/docs/central.md
+++ b/docs/central.md
@@ -43,22 +43,6 @@ To modify these defaults it is possible to call `configure` in the DSL. For
 more check out the [what to publish page](what.md) which contains a detailed
 description of available options for each project type.
 
-=== "build.gradle"
-
-    ```groovy
-    mavenPublishing {
-      configure(...)
-    }
-    ```
-
-=== "build.gradle.kts"
-
-    ```kotlin
-    mavenPublishing {
-      configure(...)
-    }
-    ```
-
 ## Configuring Maven Central
 
 After applying the plugin the first step is to enable publishing to Maven Central
@@ -71,11 +55,7 @@ This can be done through either the DSL or by setting Gradle properties.
     import com.vanniktech.maven.publish.SonatypeHost
 
     mavenPublishing {
-      publishToMavenCentral(SonatypeHost.DEFAULT)
-      // or when publishing to https://s01.oss.sonatype.org
-      publishToMavenCentral(SonatypeHost.S01)
-      // or when publishing to https://central.sonatype.com/
-      publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+      publishToMavenCentral()
 
       signAllPublications()
     }
@@ -87,11 +67,7 @@ This can be done through either the DSL or by setting Gradle properties.
     import com.vanniktech.maven.publish.SonatypeHost
 
     mavenPublishing {
-      publishToMavenCentral(SonatypeHost.DEFAULT)
-      // or when publishing to https://s01.oss.sonatype.org
-      publishToMavenCentral(SonatypeHost.S01)
-      // or when publishing to https://central.sonatype.com/
-      publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+      publishToMavenCentral()
 
       signAllPublications()
     }
@@ -100,10 +76,6 @@ This can be done through either the DSL or by setting Gradle properties.
 === "gradle.properties"
 
     ```properties
-    SONATYPE_HOST=DEFAULT
-    # or when publishing to https://s01.oss.sonatype.org
-    SONATYPE_HOST=S01
-    # or when publishing to https://central.sonatype.com/
     SONATYPE_HOST=CENTRAL_PORTAL
 
     RELEASE_SIGNING_ENABLED=true
@@ -290,14 +262,11 @@ Snapshots can be published by setting the version to something ending with `-SNA
 and then running the following Gradle task:
 
 ```
-./gradlew publishAllPublicationsToMavenCentralRepository
+./gradlew publishToMavenCentral
 ```
 
-The snapshot will be automatically available in Sonatype's
-[snapshot repository](https://oss.sonatype.org/content/repositories/snapshots/), or the
-[S01 snapshot repository](https://s01.oss.sonatype.org/content/repositories/snapshots/), or the
-[Central Portal snapshot repository](https://central.sonatype.com/repository/maven-snapshots/) directly after the
-task finished.
+The snapshot will be automatically available in the [Central Portal snapshot repository](https://central.sonatype.com/repository/maven-snapshots/) directly
+after the task finished.
 
 Signing is not required for snapshot builds, but if the configuration is present the build
 will still be signed.
@@ -307,69 +276,20 @@ will still be signed.
 
 The publishing process for Maven Central consists of several steps
 
-1. A staging repository is created on Sonatype OSS
-2. The artifacts are uploaded/published to this staging repository
-3. The staging repository is closed
-4. The staging repository is released
-5. All artifacts in the released repository will be synchronized to maven central
+1. *Plugin*: The artifacts are uploaded to a new deployment
+2. *Sonatype*: The deployment is validated
+3. *Plugin/Manual*: The deployment is published to Maven Central
+4. *Sonatype* The published artifacts are available in Maven Central
 
-The plugin will always do steps 1 to 3. Step 4 is only taken care of if automatic releases are enabled.
+!!! note
 
-After the staging repository has been released, either manually or automatically, the artifacts will
-be synced to Maven Central. This process usually takes around 10-30 minutes and only when it completes
-the artifacts are available for download.
+    Step 4 can take 10 to 30 minutes and only after it completed the published
+    artifacts will be available for download.
 
-### Automatic release
+### Uploading with manual publishing
 
-Run the following task to let the plugin handle all steps automatically:
-
-```
-./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
-```
-
-!!! note "Configuration cache"
-
-    Configuration caching when uploading releases is currently not possible. Supporting it is
-    blocked by [Gradle issue #22779](https://github.com/gradle/gradle/issues/22779).
-
-It is possible to permanently enable the automatic releases so that regular publishing tasks
-like `publish` and `publishToMavenCentral` will also always do the release step:
-
-=== "build.gradle"
-
-    ```groovy
-    import com.vanniktech.maven.publish.SonatypeHost
-
-    mavenPublishing {
-      publishToMavenCentral(SonatypeHost.DEFAULT, true)
-      // or when publishing to https://s01.oss.sonatype.org
-      publishToMavenCentral(SonatypeHost.S01, true)
-    }
-    ```
-
-=== "build.gradle.kts"
-
-    ```kotlin
-    import com.vanniktech.maven.publish.SonatypeHost
-
-    mavenPublishing {
-      publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
-      // or when publishing to https://s01.oss.sonatype.org
-      publishToMavenCentral(SonatypeHost.S01, automaticRelease = true)
-    }
-    ```
-
-=== "gradle.properties"
-
-    ```properties
-    SONATYPE_AUTOMATIC_RELEASE=true
-    ```
-
-### Manual release
-
-The release (step 4) can be done manually by running the following command, so that the plugin will
-only do step 1 to 3:
-```
+Run the following Gradle task:
+```sh
 ./gradlew publishToMavenCentral --no-configuration-cache
 ```
 
@@ -378,16 +298,68 @@ only do step 1 to 3:
     Configuration caching when uploading releases is currently not possible. Supporting it is
     blocked by [Gradle issue #22779](https://github.com/gradle/gradle/issues/22779).
 
-### Timeouts
 
-From time to time Sonatype tends to time out during staging operations. The default timeouts of the plugin
-are long already, but can be modified if needed. The timeout for HTTP requests can be modified with
-`SONATYPE_CONNECT_TIMEOUT_SECONDS` which defaults to 1 minute. After a staging repository gets closed,
-Sonatype will run several validations on it and the plugin needs to wait for those to finish, before it can
-release the repository. The timeout for how long it is waiting for the close operation to finish can be
-modified by `SONATYPE_CLOSE_TIMEOUT_SECONDS` and defaults to 15 minutes.
+Afterward go to [Deployments on the Central Portal website](https://central.sonatype.com/publishing/deployments)
+and click "Publish" on the deployment.
 
-```properties
-SONATYPE_CONNECT_TIMEOUT_SECONDS=60
-SONATYPE_CLOSE_TIMEOUT_SECONDS=900
-```
+### Uploading with automatic publishing
+
+For automatic publishing use one of the following options
+
+=== "Command"
+
+    Instead of running `publishToMavenCentral` as described above use:
+    ```sh
+    ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
+    ```
+
+=== "build.gradle"
+
+    When calling `publishToMavenCentral` in the DSL add `true` as a parameter.
+    ```groovy
+    mavenPublishing {
+      publishToMavenCentral(true)
+
+      // rest of publishing config
+    }
+    ```
+
+    To publish use
+    ```sh
+    ./gradlew publishToMavenCentral --no-configuration-cache
+    ```
+
+=== "build.gradle.kts"
+
+    When calling `publishToMavenCentral` in the DSL add `automaticRelease = true` as a parameter to
+    make any publish task also take care of step 3.
+    ```properties
+    mavenPublishing {
+      publishToMavenCentral(automaticRelease = true)
+
+      // rest of publishing config
+    }
+    ```
+
+    To publish use
+    ```sh
+    ./gradlew publishToMavenCentral --no-configuration-cache
+    ```
+
+=== "gradle.properties"
+
+    Add the following to `gradle.properties` to make any publish task also take care of
+    step 3.
+    ```properties
+    SONATYPE_AUTOMATIC_RELEASE=true
+    ```
+
+    To publish use
+    ```sh
+    ./gradlew publishToMavenCentral --no-configuration-cache
+    ```
+
+!!! note "Configuration cache"
+
+    Configuration caching when uploading releases is currently not possible. Supporting it is
+    blocked by [Gradle issue #22779](https://github.com/gradle/gradle/issues/22779).

--- a/plugin/api/plugin.api
+++ b/plugin/api/plugin.api
@@ -168,8 +168,9 @@ public abstract class com/vanniktech/maven/publish/MavenPublishBaseExtension {
 	public final fun publishToMavenCentral (Lcom/vanniktech/maven/publish/SonatypeHost;Z)V
 	public final synthetic fun publishToMavenCentral (Ljava/lang/String;)V
 	public final synthetic fun publishToMavenCentral (Ljava/lang/String;Z)V
-	public static synthetic fun publishToMavenCentral$default (Lcom/vanniktech/maven/publish/MavenPublishBaseExtension;Lcom/vanniktech/maven/publish/SonatypeHost;ZILjava/lang/Object;)V
+	public final fun publishToMavenCentral (Z)V
 	public static synthetic fun publishToMavenCentral$default (Lcom/vanniktech/maven/publish/MavenPublishBaseExtension;Ljava/lang/String;ZILjava/lang/Object;)V
+	public static synthetic fun publishToMavenCentral$default (Lcom/vanniktech/maven/publish/MavenPublishBaseExtension;ZILjava/lang/Object;)V
 	public final fun signAllPublications ()V
 }
 

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -47,6 +47,30 @@ public abstract class MavenPublishBaseExtension @Inject constructor(
   /**
    * Sets up Maven Central publishing through Sonatype OSSRH by configuring the target repository. Gradle will then
    * automatically create a `publishAllPublicationsToMavenCentralRepository` task as well as include it in the general
+   * `publish` task.
+   *
+   * When the [automaticRelease] parameter is `true` the created deployment will be released automatically to
+   * Maven Central without any additional manual steps needed. When [automaticRelease] is not set or `false`
+   * the deployment has to be manually released through the [Central Portal website](https://central.sonatype.com/publishing/deployments).
+   *
+   * If the current version ends with `-SNAPSHOT` the artifacts will be published to Sonatype's snapshot
+   * repository instead.
+   *
+   * This expects you provide the username and password of a user token through Gradle properties called
+   * `mavenCentralUsername` and `mavenCentralPassword`. See [here](https://central.sonatype.org/publish/generate-portal-token/)
+   * for how to obtain a user token.
+   *
+   * @param automaticRelease whether a non SNAPSHOT build should be released automatically at the end of the build
+   */
+  @JvmOverloads
+  public fun publishToMavenCentral(automaticRelease: Boolean = false) {
+    @Suppress("DEPRECATION")
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease)
+  }
+
+  /**
+   * Sets up Maven Central publishing through Sonatype OSSRH by configuring the target repository. Gradle will then
+   * automatically create a `publishAllPublicationsToMavenCentralRepository` task as well as include it in the general
    * `publish` task. As part of running publish the plugin will automatically create a staging repository on Sonatype
    * to which all artifacts will be published. At the end of the build this staging repository will be automatically
    * closed. When the [automaticRelease] parameter is `true` the staging repository will also be released
@@ -62,8 +86,47 @@ public abstract class MavenPublishBaseExtension @Inject constructor(
    * @param host the instance of Sonatype OSSRH to use
    * @param automaticRelease whether a non SNAPSHOT build should be released automatically at the end of the build
    */
-  @JvmOverloads
-  public fun publishToMavenCentral(host: SonatypeHost = SonatypeHost.DEFAULT, automaticRelease: Boolean = false) {
+  @Deprecated(
+    message = "OSSRH will be shut down after June 30, 2025. Migrate to Central Portal instead. " +
+      "See more info at https://central.sonatype.org/news/20250326_ossrh_sunset . After migrating " +
+      "your account remove the SonatypeHost parameter and update your user token to one created in " +
+      "the Central Portal.\n" +
+      "If you are already calling this method with CENTRAL_PORTAL, you can simply remove the parameter.",
+    replaceWith = ReplaceWith("publishToMavenCentral()")
+  )
+  public fun publishToMavenCentral(host: SonatypeHost) {
+    @Suppress("DEPRECATION")
+    publishToMavenCentral(host, automaticRelease = false)
+
+  }
+
+  /**
+   * Sets up Maven Central publishing through Sonatype OSSRH by configuring the target repository. Gradle will then
+   * automatically create a `publishAllPublicationsToMavenCentralRepository` task as well as include it in the general
+   * `publish` task. As part of running publish the plugin will automatically create a staging repository on Sonatype
+   * to which all artifacts will be published. At the end of the build this staging repository will be automatically
+   * closed. When the [automaticRelease] parameter is `true` the staging repository will also be released
+   * automatically afterwards.
+   * If the current version ends with `-SNAPSHOT` the artifacts will be published to Sonatype's snapshot
+   * repository instead.
+   *
+   * This expects you provide your Sonatype username and password through Gradle properties called
+   * `mavenCentralUsername` and `mavenCentralPassword`.
+   *
+   * The `closeAndReleaseRepository` task is automatically configured for Sonatype OSSRH using the same credentials.
+   *
+   * @param host the instance of Sonatype OSSRH to use
+   * @param automaticRelease whether a non SNAPSHOT build should be released automatically at the end of the build
+   */
+  @Deprecated(
+    message = "OSSRH will be shut down after June 30, 2025. Migrate to Central Portal instead. " +
+      "See more info at https://central.sonatype.org/news/20250326_ossrh_sunset . After migrating " +
+      "your account remove the SonatypeHost parameter and update your user token to one created in " +
+      "the Central Portal.\n" +
+      "If you are already calling this method with CENTRAL_PORTAL, you can simply remove the parameter.",
+    replaceWith = ReplaceWith("publishToMavenCentral()")
+  )
+  public fun publishToMavenCentral(host: SonatypeHost, automaticRelease: Boolean) {
     sonatypeHost.set(host)
     sonatypeHost.finalizeValue()
 

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -92,12 +92,11 @@ public abstract class MavenPublishBaseExtension @Inject constructor(
       "your account remove the SonatypeHost parameter and update your user token to one created in " +
       "the Central Portal.\n" +
       "If you are already calling this method with CENTRAL_PORTAL, you can simply remove the parameter.",
-    replaceWith = ReplaceWith("publishToMavenCentral()")
+    replaceWith = ReplaceWith("publishToMavenCentral()"),
   )
   public fun publishToMavenCentral(host: SonatypeHost) {
     @Suppress("DEPRECATION")
     publishToMavenCentral(host, automaticRelease = false)
-
   }
 
   /**
@@ -124,7 +123,7 @@ public abstract class MavenPublishBaseExtension @Inject constructor(
       "your account remove the SonatypeHost parameter and update your user token to one created in " +
       "the Central Portal.\n" +
       "If you are already calling this method with CENTRAL_PORTAL, you can simply remove the parameter.",
-    replaceWith = ReplaceWith("publishToMavenCentral()")
+    replaceWith = ReplaceWith("publishToMavenCentral()"),
   )
   public fun publishToMavenCentral(host: SonatypeHost, automaticRelease: Boolean) {
     sonatypeHost.set(host)

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -8,13 +8,12 @@ public open class MavenPublishPlugin : Plugin<Project> {
     project.plugins.apply(MavenPublishBasePlugin::class.java)
     val baseExtension = project.baseExtension
 
-    val sonatypeHost = project.findOptionalProperty("SONATYPE_HOST")
-    if (!sonatypeHost.isNullOrBlank()) {
-      val automaticRelease = project.findOptionalProperty("SONATYPE_AUTOMATIC_RELEASE").toBoolean()
-      baseExtension.publishToMavenCentral(SonatypeHost.valueOf(sonatypeHost), automaticRelease)
+    val sonatypeHost = project.sonatypeHost()
+    if (sonatypeHost != null) {
+      baseExtension.publishToMavenCentral(sonatypeHost, project.automaticRelease())
     }
-    val releaseSigning = project.findOptionalProperty("RELEASE_SIGNING_ENABLED").toBoolean()
-    if (releaseSigning) {
+
+    if (project.signAllPublications()) {
       baseExtension.signAllPublications()
     }
 
@@ -31,5 +30,47 @@ public open class MavenPublishPlugin : Plugin<Project> {
       // will no-op if it was already called
       baseExtension.configureBasedOnAppliedPlugins()
     }
+  }
+
+  @Suppress("DEPRECATION")
+  private fun Project.sonatypeHost(): SonatypeHost? {
+    val central = providers.gradleProperty("mavenCentralPublishing").orNull
+    if (central != null) {
+      return if (central.toBoolean()) {
+        SonatypeHost.CENTRAL_PORTAL
+      } else {
+        null
+      }
+    }
+    val sonatypeHost = providers.gradleProperty("SONATYPE_HOST").getOrElse("")
+    return if (!sonatypeHost.isNullOrBlank()) {
+      SonatypeHost.valueOf(sonatypeHost)
+    } else {
+      null
+    }
+  }
+
+  private fun Project.automaticRelease(): Boolean {
+    val automatic = providers.gradleProperty("mavenCentralAutomaticPublishing").orNull
+    if (automatic != null) {
+      return automatic.toBoolean()
+    }
+    val sonatypeAutomatic = providers.gradleProperty("SONATYPE_AUTOMATIC_RELEASE").orNull
+    if (sonatypeAutomatic != null) {
+      return sonatypeAutomatic.toBoolean()
+    }
+    return false
+  }
+
+  private fun Project.signAllPublications(): Boolean {
+    val sign = providers.gradleProperty("signAllPublications").orNull
+    if (sign != null) {
+      return sign.toBoolean()
+    }
+    val singRelease = providers.gradleProperty("RELEASE_SIGNING_ENABLED").orNull
+    if (singRelease != null) {
+      return singRelease.toBoolean()
+    }
+    return false
   }
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
@@ -8,6 +8,11 @@ import java.io.Serializable
  *
  * https://central.sonatype.org/articles/2021/Feb/23/new-users-on-s01osssonatypeorg/
  */
+@Deprecated(
+  message = "OSSRH will be shut down after June 30, 2025. Use the publishToMavenCentral() method" +
+    "without a SonatypeHost parameter instead. " +
+    "See more info at https://central.sonatype.org/news/20250326_ossrh_sunset.",
+)
 public data class SonatypeHost internal constructor(
   internal val rootUrl: String,
   internal val isCentralPortal: Boolean,


### PR DESCRIPTION
Since we're only a bit over a week away from the shut down this changes the default behavior of `publishToMavenCentral` with no specified `SonatypeHost` to publish to the central portal. The overloads with `SonatypeHost` are deprecated.