### PR TITLE
add replacements for sonatype properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@
 - Deprecated `SonatypeHost`.
 
 Improvements
+- Added new Gradle properties
+   - `mavenCentralPublishing=true` replaces `SONATYPE_HOST=CENTRAL_PORTAL`
+   - `mavenCentralAutomaticPublishing=true` replaces `SONATYPE_AUTOMATIC_RELEASE=true`
+   - `signAllPublications=true` replaces `RELEASE_SIGNING_ENABLED=true`
+   - Note: The old properties continue to work and there are no plans to remove them
 - The base plugin is now compatible with isolated projects as long as `pomFromGradleProperties()` is
   not called.
 

--- a/docs/base.md
+++ b/docs/base.md
@@ -27,8 +27,11 @@ Add the plugin to any Gradle project that should be published
 ## General configuration
 
 Follow the steps of the [Maven Central](central.md) or [other Maven repositories](other.md) guides.
-Note that the `SONATYPE_HOST`, `SONATYPE_AUTOMATIC_RELEASE` and `RELEASE_SIGNING_ENABLED` are not
-considered by the base plugin and the appropriate DSL methods need to be called.
+
+!!! note
+
+    The `mavenCentralPublishing`, `mavenCentralAutomaticPublishing` and `signAllPublications` properties are not
+    considered by the base plugin and the appropriate DSL methods need to be called.
 
 For the pom configuration via Gradle properties the following needs to be enabled in the DSL:
 

--- a/docs/central.md
+++ b/docs/central.md
@@ -76,15 +76,15 @@ This can be done through either the DSL or by setting Gradle properties.
 === "gradle.properties"
 
     ```properties
-    SONATYPE_HOST=CENTRAL_PORTAL
+    mavenCentralPublishing=true
 
-    RELEASE_SIGNING_ENABLED=true
+    signAllPublications=true
     ```
 
 ## Configuring the POM
 
 The pom is published alongside the project and contains the project coordinates
-as well as some general information about the project like an url and the used
+as well as some general information about the project like a url and the used
 license.
 
 This configuration also determines the coordinates (`group:artifactId:version`) used to consume the library.
@@ -351,7 +351,7 @@ For automatic publishing use one of the following options
     Add the following to `gradle.properties` to make any publish task also take care of
     step 3.
     ```properties
-    SONATYPE_AUTOMATIC_RELEASE=true
+    mavenCentralAutomaticPublishing=true
     ```
 
     To publish use
@@ -363,3 +363,4 @@ For automatic publishing use one of the following options
 
     Configuration caching when uploading releases is currently not possible. Supporting it is
     blocked by [Gradle issue #22779](https://github.com/gradle/gradle/issues/22779).
+

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -44,9 +44,9 @@ public open class MavenPublishPlugin : Plugin<Project> {
     }
     val sonatypeHost = providers.gradleProperty("SONATYPE_HOST").getOrElse("")
     return if (!sonatypeHost.isNullOrBlank()) {
-       SonatypeHost.valueOf(sonatypeHost)
+      SonatypeHost.valueOf(sonatypeHost)
     } else {
-       null
+      null
     }
   }
 


### PR DESCRIPTION
Builds on top of #996.

In preparation of central portal becoming the only way to publish to Maven Central this adds alternatives for the existing Gradle properties. The naming has been updated to match the existing `mavenCentralUsername`/`mavenCentralPassword` that come from the Gradle credentials API.

I've also started using `providers.gradleProperty` for these. The limitation of that is that it doesn't read `gradle.properties` files of subprojects but since these properties are for project wide configurations this is fine.