### PR TITLE
replace ktlint plugin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,8 +16,6 @@ ij_kotlin_allow_trailing_comma_on_call_site=true
 ktlint_standard_annotation=disabled
 # too aggressive in wrapping and indenting the expression in an assignment
 ktlint_standard_multiline-expression-wrapping=disabled
-# depends on the previous one
-ktlint_standard_string-template-indent=disabled
 # make ktlint less eager to wrap function signatures and expression bodies
 ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than=unset
 ktlint_function_signature_body_expression_wrapping=default

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,23 +1,23 @@
-root = true
+root=true
 
 [*]
-indent_size = 2
-charset = utf-8
-trim_trailing_whitespace = true
-insert_final_newline = true
+indent_size=2
+charset=utf-8
+trim_trailing_whitespace=true
+insert_final_newline=true
 
 [*.{kt,kts}]
 ij_kotlin_imports_layout=*
 
-ij_kotlin_allow_trailing_comma = true
-ij_kotlin_allow_trailing_comma_on_call_site = true
+ij_kotlin_allow_trailing_comma=true
+ij_kotlin_allow_trailing_comma_on_call_site=true
 
 # makes constructor annotations indent the whole class
-ktlint_standard_annotation = disabled
+ktlint_standard_annotation=disabled
 # too aggressive in wrapping and indenting the expression in an assignment
-ktlint_standard_multiline-expression-wrapping = disabled
+ktlint_standard_multiline-expression-wrapping=disabled
 # depends on the previous one
-ktlint_standard_string-template-indent = disabled
+ktlint_standard_string-template-indent=disabled
 # make ktlint less eager to wrap function signatures and expression bodies
-ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than = 4
+ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than=unset
 ktlint_function_signature_body_expression_wrapping=default

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,5 +35,8 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v4
 
+      - name: Run ktlint
+        run: ./kotlinw ktlint.main.kts --fail-on-changes
+
       - name: Build with Gradle
         run: ./gradlew build --stacktrace -DtestConfigMethod=${{ matrix.test_config_method }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Run ktlint
         run: ./kotlinw ktlint.main.kts --fail-on-changes
+        if: ${{ matrix.java_version != '11' }}
 
       - name: Build with Gradle
         run: ./gradlew build --stacktrace -DtestConfigMethod=${{ matrix.test_config_method }}

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -2,7 +2,6 @@ plugins { `kotlin-dsl` }
 
 dependencies {
   implementation(libs.kotlin.plugin)
-  implementation(libs.ktlint.plugin)
   implementation(libs.maven.publish.plugin)
   implementation(libs.bcv)
   // https://github.com/gradle/gradle/issues/15383#issuecomment-779893192

--- a/build-logic/src/main/kotlin/shared.gradle.kts
+++ b/build-logic/src/main/kotlin/shared.gradle.kts
@@ -10,7 +10,6 @@ plugins {
   id("org.jetbrains.kotlin.jvm")
   id("org.jetbrains.kotlin.kapt")
   id("com.vanniktech.maven.publish")
-  id("org.jlleitschuh.gradle.ktlint")
   id("org.jetbrains.kotlinx.binary-compatibility-validator")
 }
 

--- a/central-portal/src/main/kotlin/com/vanniktech/maven/publish/portal/SonatypeCentralPortal.kt
+++ b/central-portal/src/main/kotlin/com/vanniktech/maven/publish/portal/SonatypeCentralPortal.kt
@@ -20,13 +20,15 @@ public class SonatypeCentralPortal(
   private val closeTimeoutSeconds: Long,
 ) {
   private val service by lazy {
-    val okHttpClient = OkHttpClient.Builder()
+    val okHttpClient = OkHttpClient
+      .Builder()
       .addInterceptor(SonatypeCentralPortalOkHttpInterceptor(usertoken, userAgentName, userAgentVersion))
       .connectTimeout(okhttpTimeoutSeconds, TimeUnit.SECONDS)
       .readTimeout(okhttpTimeoutSeconds, TimeUnit.SECONDS)
       .writeTimeout(okhttpTimeoutSeconds, TimeUnit.SECONDS)
       .build()
-    val retrofit = Retrofit.Builder()
+    val retrofit = Retrofit
+      .Builder()
       .addConverterFactory(ScalarsConverterFactory.create())
       .addConverterFactory(MoshiConverterFactory.create())
       .client(okHttpClient)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,6 @@ truth = "1.4.4"
 okhttp = "com.squareup.okhttp3:okhttp:4.12.0"
 dokka = "org.jetbrains.dokka:dokka-gradle-plugin:2.0.0"
 android-plugin = "com.android.tools.build:gradle:8.10.1"
-ktlint-plugin = "org.jlleitschuh.gradle:ktlint-gradle:12.3.0"
 maven-publish-plugin = "com.vanniktech:gradle-maven-publish-plugin:0.32.0"
 bcv = "org.jetbrains.kotlinx:binary-compatibility-validator:0.17.0"
 

--- a/kotlinw
+++ b/kotlinw
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+ROOT_DIR="$(dirname "$0")"
+
+KOTLIN_VERSION="$(grep -m 1 '^kotlin \?=' "$ROOT_DIR/gradle/libs.versions.toml" | cut -d'"' -f2)"
+
+INSTALLATION_DIR="${HOME}/.kotlinw/${KOTLIN_VERSION}"
+BINARY_DIR="${INSTALLATION_DIR}/kotlinc/bin"
+
+if [ ! -f "${BINARY_DIR}/kotlin" ]; then
+  echo "Downloading Kotlin ${KOTLIN_VERSION}"
+  mkdir -p "${INSTALLATION_DIR}"
+  temp_file=$(mktemp /tmp/kotlin.zip.XXXXXX)
+  curl -sLo "${temp_file}" "https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip"
+  unzip -q "${temp_file}" -d "${INSTALLATION_DIR}"
+  rm -f "${temp_file}"
+fi
+
+# this works around an issue where the Kotlin compiler used by ktlint accesses code that JDK 12+ don't allow access to
+export JAVA_OPTS="--add-opens java.base/java.lang=ALL-UNNAMED"
+
+SCRIPT_FILE="$1"
+# will remove the first element of the $@ arguments array since we read it already above
+shift
+# uses kotlinc instead of kotlin because the latter doesn't allow specifying a jvm target and defaults to Java 8
+# the -- between SCRIPT_FILE and the other arguments is there so that the arguments are treated as arguments to the
+# script and not to kotlinc
+"${BINARY_DIR}/kotlinc" "-script" "$SCRIPT_FILE" "--" "${@}"

--- a/ktlint.main.kts
+++ b/ktlint.main.kts
@@ -1,0 +1,8 @@
+#!/usr/bin/env kotlin
+
+@file:DependsOn("com.freeletics.gradle:scripts-formatting:0.24.0")
+
+import com.freeletics.gradle.scripts.KtLintCli
+import com.github.ajalt.clikt.core.main
+
+KtLintCli().main(args)

--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt
@@ -18,13 +18,15 @@ public class Nexus(
   private val closeTimeoutSeconds: Long,
 ) {
   private val service by lazy {
-    val okHttpClient = OkHttpClient.Builder()
+    val okHttpClient = OkHttpClient
+      .Builder()
       .addInterceptor(NexusOkHttpInterceptor(username, password, userAgentName, userAgentVersion))
       .connectTimeout(okhttpTimeoutSeconds, TimeUnit.SECONDS)
       .readTimeout(okhttpTimeoutSeconds, TimeUnit.SECONDS)
       .writeTimeout(okhttpTimeoutSeconds, TimeUnit.SECONDS)
       .build()
-    val retrofit = Retrofit.Builder()
+    val retrofit = Retrofit
+      .Builder()
       .addConverterFactory(MoshiConverterFactory.create())
       .client(okHttpClient)
       .baseUrl(baseUrl)
@@ -180,9 +182,13 @@ public class Nexus(
         val properties = try {
           val response = service.getRepositoryActivity(repositoryId).execute()
           if (response.isSuccessful) {
-            response.body()?.find { it.name == "close" }
-              ?.events?.find { it.name == "ruleFailed" }
-              ?.properties?.filter { it.name == "failureMessage" }
+            response
+              .body()
+              ?.find { it.name == "close" }
+              ?.events
+              ?.find { it.name == "ruleFailed" }
+              ?.properties
+              ?.filter { it.name == "failureMessage" }
           } else {
             emptyList()
           }
@@ -214,14 +220,15 @@ public class Nexus(
 
   public fun releaseStagingRepository(repositoryId: String) {
     println("Releasing repository: $repositoryId")
-    val response = service.releaseRepository(
-      TransitionRepositoryInput(
-        TransitionRepositoryInputData(
-          stagedRepositoryIds = listOf(repositoryId),
-          autoDropAfterRelease = true,
+    val response = service
+      .releaseRepository(
+        TransitionRepositoryInput(
+          TransitionRepositoryInputData(
+            stagedRepositoryIds = listOf(repositoryId),
+            autoDropAfterRelease = true,
+          ),
         ),
-      ),
-    ).execute()
+      ).execute()
 
     if (!response.isSuccessful) {
       throw IOException("Cannot release repository: ${response.errorBody()?.string()}")
@@ -231,13 +238,14 @@ public class Nexus(
   }
 
   public fun dropStagingRepository(repositoryId: String) {
-    val response = service.dropRepository(
-      TransitionRepositoryInput(
-        TransitionRepositoryInputData(
-          stagedRepositoryIds = listOf(repositoryId),
+    val response = service
+      .dropRepository(
+        TransitionRepositoryInput(
+          TransitionRepositoryInputData(
+            stagedRepositoryIds = listOf(repositoryId),
+          ),
         ),
-      ),
-    ).execute()
+      ).execute()
 
     if (!response.isSuccessful) {
       throw IOException("Cannot drop repository: ${response.errorBody()?.string()}")

--- a/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusModel.kt
+++ b/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/NexusModel.kt
@@ -3,22 +3,35 @@ package com.vanniktech.maven.publish.nexus
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-internal data class StagingProfile(val id: String, val name: String)
+internal data class StagingProfile(
+  val id: String,
+  val name: String,
+)
 
 @JsonClass(generateAdapter = true)
-internal data class StagingProfilesResponse(val data: List<StagingProfile>)
+internal data class StagingProfilesResponse(
+  val data: List<StagingProfile>,
+)
 
 @JsonClass(generateAdapter = true)
-internal data class CreateRepositoryInputData(val description: String)
+internal data class CreateRepositoryInputData(
+  val description: String,
+)
 
 @JsonClass(generateAdapter = true)
-internal data class CreateRepositoryInput(val data: CreateRepositoryInputData)
+internal data class CreateRepositoryInput(
+  val data: CreateRepositoryInputData,
+)
 
 @JsonClass(generateAdapter = true)
-internal data class CreatedRepository(val stagedRepositoryId: String)
+internal data class CreatedRepository(
+  val stagedRepositoryId: String,
+)
 
 @JsonClass(generateAdapter = true)
-internal data class CreateRepositoryResponse(val data: CreatedRepository)
+internal data class CreateRepositoryResponse(
+  val data: CreatedRepository,
+)
 
 @JsonClass(generateAdapter = true)
 internal data class Repository(
@@ -29,19 +42,35 @@ internal data class Repository(
 )
 
 @JsonClass(generateAdapter = true)
-internal data class RepositoryEventProperty(val name: String, val value: String)
+internal data class RepositoryEventProperty(
+  val name: String,
+  val value: String,
+)
 
 @JsonClass(generateAdapter = true)
-internal data class RepositoryEvent(val name: String, val properties: List<RepositoryEventProperty>)
+internal data class RepositoryEvent(
+  val name: String,
+  val properties: List<RepositoryEventProperty>,
+)
 
 @JsonClass(generateAdapter = true)
-internal data class RepositoryActivity(val name: String, val events: List<RepositoryEvent>)
+internal data class RepositoryActivity(
+  val name: String,
+  val events: List<RepositoryEvent>,
+)
 
 @JsonClass(generateAdapter = true)
-internal data class ProfileRepositoriesResponse(val data: List<Repository>)
+internal data class ProfileRepositoriesResponse(
+  val data: List<Repository>,
+)
 
 @JsonClass(generateAdapter = true)
-internal data class TransitionRepositoryInputData(val stagedRepositoryIds: List<String>, val autoDropAfterRelease: Boolean? = null)
+internal data class TransitionRepositoryInputData(
+  val stagedRepositoryIds: List<String>,
+  val autoDropAfterRelease: Boolean? = null,
+)
 
 @JsonClass(generateAdapter = true)
-internal data class TransitionRepositoryInput(val data: TransitionRepositoryInputData)
+internal data class TransitionRepositoryInput(
+  val data: TransitionRepositoryInputData,
+)

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -38,22 +38,74 @@ buildConfig {
   buildConfigField("String", "VERSION", "\"${project.findProperty("VERSION_NAME") ?: "dev"}\"")
 
   sourceSets.getByName(integrationTestSourceSet.name) {
-    buildConfigField("GRADLE_ALPHA", alpha.versions.gradle.asProvider().get())
-    buildConfigField("GRADLE_BETA", beta.versions.gradle.asProvider().get())
-    buildConfigField("GRADLE_RC", rc.versions.gradle.asProvider().get())
-    buildConfigField("GRADLE_STABLE", libs.versions.gradle.asProvider().get())
-    buildConfigField("ANDROID_GRADLE_ALPHA", alpha.versions.android.gradle.get())
-    buildConfigField("ANDROID_GRADLE_BETA", beta.versions.android.gradle.get())
-    buildConfigField("ANDROID_GRADLE_RC", rc.versions.android.gradle.get())
-    buildConfigField("ANDROID_GRADLE_STABLE", libs.versions.android.gradle.get())
+    buildConfigField(
+      "GRADLE_ALPHA",
+      alpha.versions.gradle
+        .asProvider()
+        .get(),
+    )
+    buildConfigField(
+      "GRADLE_BETA",
+      beta.versions.gradle
+        .asProvider()
+        .get(),
+    )
+    buildConfigField(
+      "GRADLE_RC",
+      rc.versions.gradle
+        .asProvider()
+        .get(),
+    )
+    buildConfigField(
+      "GRADLE_STABLE",
+      libs.versions.gradle
+        .asProvider()
+        .get(),
+    )
+    buildConfigField(
+      "ANDROID_GRADLE_ALPHA",
+      alpha.versions.android.gradle
+        .get(),
+    )
+    buildConfigField(
+      "ANDROID_GRADLE_BETA",
+      beta.versions.android.gradle
+        .get(),
+    )
+    buildConfigField(
+      "ANDROID_GRADLE_RC",
+      rc.versions.android.gradle
+        .get(),
+    )
+    buildConfigField(
+      "ANDROID_GRADLE_STABLE",
+      libs.versions.android.gradle
+        .get(),
+    )
     buildConfigField("KOTLIN_ALPHA", alpha.versions.kotlin.get())
     buildConfigField("KOTLIN_BETA", beta.versions.kotlin.get())
     buildConfigField("KOTLIN_RC", rc.versions.kotlin.get())
     buildConfigField("KOTLIN_STABLE", libs.versions.kotlin.get())
-    buildConfigField("GRADLE_PUBLISH_ALPHA", alpha.versions.gradle.plugin.publish.get())
-    buildConfigField("GRADLE_PUBLISH_BETA", beta.versions.gradle.plugin.publish.get())
-    buildConfigField("GRADLE_PUBLISH_RC", rc.versions.gradle.plugin.publish.get())
-    buildConfigField("GRADLE_PUBLISH_STABLE", libs.versions.gradle.plugin.publish.get())
+    buildConfigField(
+      "GRADLE_PUBLISH_ALPHA",
+      alpha.versions.gradle.plugin.publish
+        .get(),
+    )
+    buildConfigField(
+      "GRADLE_PUBLISH_BETA",
+      beta.versions.gradle.plugin.publish
+        .get(),
+    )
+    buildConfigField(
+      "GRADLE_PUBLISH_RC",
+      rc.versions.gradle.plugin.publish
+        .get(),
+    )
+    buildConfigField(
+      "GRADLE_PUBLISH_STABLE",
+      libs.versions.gradle.plugin.publish
+        .get(),
+    )
   }
 }
 

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginPlatformTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginPlatformTest.kt
@@ -203,13 +203,14 @@ class MavenPublishPluginPlatformTest {
   @TestParameterInjectorTest
   fun javaLibraryWithToolchainProject() {
     val project = javaLibraryProjectSpec().copy(
-      buildFileExtra = """
+      buildFileExtra =
+        """
         java {
             toolchain {
                 languageVersion = JavaLanguageVersion.of(8)
             }
         }
-      """.trimIndent(),
+        """.trimIndent(),
     )
     val result = project.run(fixtures, testProjectDir, testOptions)
 

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginSpecialCaseTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenPublishPluginSpecialCaseTest.kt
@@ -170,10 +170,11 @@ class MavenPublishPluginSpecialCaseTest {
       group = null,
       artifactId = null,
       version = null,
-      buildFileExtra = """
+      buildFileExtra =
+        """
         group = "com.example.test2"
         version = "3.2.1"
-      """.trimIndent(),
+        """.trimIndent(),
     )
     val result = project.run(fixtures, testProjectDir, testOptions)
 

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpec.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpec.kt
@@ -38,7 +38,5 @@ data class SourceFile(
   val sourceSetFolder: String,
   val file: String,
 ) {
-  fun resolveIn(root: Path): Path {
-    return root.resolve("src/$sourceSet/$sourceSetFolder/$file")
-  }
+  fun resolveIn(root: Path): Path = root.resolve("src/$sourceSet/$sourceSetFolder/$file")
 }

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
@@ -24,7 +24,8 @@ fun ProjectSpec.run(fixtures: Path, temp: Path, options: TestOptions): ProjectRe
     arguments.add("--configuration-cache")
   }
 
-  val result = GradleRunner.create()
+  val result = GradleRunner
+    .create()
     .withGradleVersion(options.gradleVersion.value)
     .withProjectDir(project.toFile())
     .withDebug(true)
@@ -93,18 +94,17 @@ private fun ProjectSpec.pluginsBlock(options: TestOptions) = buildString {
   appendLine("}")
 }
 
-private fun ProjectSpec.publishingBlock(options: TestOptions): String {
-  return when (options.config) {
-    TestOptions.Config.PROPERTIES -> {
-      """
-        mavenPublishing {
-        }
-      """.trimIndent()
+private fun ProjectSpec.publishingBlock(options: TestOptions): String = when (options.config) {
+  TestOptions.Config.PROPERTIES -> {
+    """
+    mavenPublishing {
     }
-    TestOptions.Config.BASE,
-    TestOptions.Config.DSL,
-    -> listOfNotNull(
-      """
+    """.trimIndent()
+  }
+  TestOptions.Config.BASE,
+  TestOptions.Config.DSL,
+  -> listOfNotNull(
+    """
 
        mavenPublishing {
          ${if (options.config == TestOptions.Config.BASE) basePluginConfig else ""}
@@ -114,47 +114,46 @@ private fun ProjectSpec.publishingBlock(options: TestOptions): String {
 
          pom {
       """,
-      "    name = \"${properties["POM_NAME"]}\"".takeIf { properties.containsKey("POM_NAME") },
-      "    description = \"${properties["POM_DESCRIPTION"]}\"".takeIf { properties.containsKey("POM_DESCRIPTION") },
-      "    inceptionYear = \"${properties["POM_INCEPTION_YEAR"]}\"".takeIf { properties.containsKey("POM_INCEPTION_YEAR") },
-      "    url = \"${properties["POM_URL"]}\"".takeIf { properties.containsKey("POM_URL") },
-      """
-            licenses {
-              license {
-                name = "${properties["POM_LICENCE_NAME"]}"
-                url = "${properties["POM_LICENCE_URL"]}"
-                distribution = "${properties["POM_LICENCE_DIST"]}"
-              }
-            }
-      """.trimIndent().takeIf {
-        properties.containsKey("POM_LICENCE_NAME")
-      },
-      """
-            developers {
-              developer {
-                id = "${properties["POM_DEVELOPER_ID"]}"
-                name = "${properties["POM_DEVELOPER_NAME"]}"
-                url = "${properties["POM_DEVELOPER_URL"]}"
-              }
-            }
-      """.trimIndent().takeIf {
-        properties.containsKey("POM_DEVELOPER_ID")
-      },
-      """
-            scm {
-              url = "${properties["POM_SCM_URL"]}"
-              connection = "${properties["POM_SCM_CONNECTION"]}"
-              developerConnection = "${properties["POM_SCM_DEV_CONNECTION"]}"
-            }
-      """.trimIndent().takeIf {
-        properties.containsKey("POM_SCM_URL")
-      },
-      """
-         }
-       }
-      """.trimIndent(),
-    ).joinToString(separator = "\n")
-  }
+    "    name = \"${properties["POM_NAME"]}\"".takeIf { properties.containsKey("POM_NAME") },
+    "    description = \"${properties["POM_DESCRIPTION"]}\"".takeIf { properties.containsKey("POM_DESCRIPTION") },
+    "    inceptionYear = \"${properties["POM_INCEPTION_YEAR"]}\"".takeIf { properties.containsKey("POM_INCEPTION_YEAR") },
+    "    url = \"${properties["POM_URL"]}\"".takeIf { properties.containsKey("POM_URL") },
+    """
+    licenses {
+      license {
+        name = "${properties["POM_LICENCE_NAME"]}"
+        url = "${properties["POM_LICENCE_URL"]}"
+        distribution = "${properties["POM_LICENCE_DIST"]}"
+      }
+    }
+    """.trimIndent().takeIf {
+      properties.containsKey("POM_LICENCE_NAME")
+    },
+    """
+    developers {
+      developer {
+        id = "${properties["POM_DEVELOPER_ID"]}"
+        name = "${properties["POM_DEVELOPER_NAME"]}"
+        url = "${properties["POM_DEVELOPER_URL"]}"
+      }
+    }
+    """.trimIndent().takeIf {
+      properties.containsKey("POM_DEVELOPER_ID")
+    },
+    """
+    scm {
+      url = "${properties["POM_SCM_URL"]}"
+      connection = "${properties["POM_SCM_CONNECTION"]}"
+      developerConnection = "${properties["POM_SCM_DEV_CONNECTION"]}"
+    }
+    """.trimIndent().takeIf {
+      properties.containsKey("POM_SCM_URL")
+    },
+    """
+      }
+    }
+    """.trimIndent(),
+  ).joinToString(separator = "\n")
 }
 
 private fun writeSettingFile(path: Path) {

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecs.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecs.kt
@@ -288,12 +288,13 @@ fun androidFusedLibraryProjectSpec(version: AgpVersion) = ProjectSpec(
     SourceFile("main", "java", "com/vanniktech/maven/publish/test/JavaTestClass.java"),
   ),
   basePluginConfig = "configure(new AndroidFusedLibrary())",
-  buildFileExtra = """
+  buildFileExtra =
+    """
     androidFusedLibrary {
         namespace = "com.test.library"
         minSdk = 29
     }
-  """.trimIndent(),
+    """.trimIndent(),
 )
 
 fun javaPlatformProjectSpec() = ProjectSpec(

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecs.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecs.kt
@@ -75,7 +75,8 @@ fun javaGradlePluginProjectSpec() = ProjectSpec(
   sourceFiles = listOf(
     SourceFile("main", "java", "com/vanniktech/maven/publish/test/JavaTestClass.java"),
   ),
-  buildFileExtra = """
+  buildFileExtra =
+    """
     gradlePlugin {
         plugins {
             mavenPublishPlugin {
@@ -85,7 +86,7 @@ fun javaGradlePluginProjectSpec() = ProjectSpec(
             }
         }
     }
-  """.trimIndent(),
+    """.trimIndent(),
   basePluginConfig = "configure(new GradlePlugin(new JavadocJar.Empty(), true))",
 )
 
@@ -137,7 +138,8 @@ fun kotlinMultiplatformProjectSpec(version: KotlinVersion) = ProjectSpec(
     SourceFile("nodeJsMain", "kotlin", "com/vanniktech/maven/publish/test/ExpectedTestClass.kt"),
   ),
   basePluginConfig = "configure(new KotlinMultiplatform(new JavadocJar.Empty()))",
-  buildFileExtra = """
+  buildFileExtra =
+    """
     kotlin {
         jvm()
         js("nodeJs", "IR") {
@@ -164,7 +166,7 @@ fun kotlinMultiplatformProjectSpec(version: KotlinVersion) = ProjectSpec(
             }
         }
     }
-  """.trimIndent(),
+    """.trimIndent(),
 )
 
 fun kotlinMultiplatformWithAndroidLibraryProjectSpec(agpVersion: AgpVersion, kotlinVersion: KotlinVersion): ProjectSpec {
@@ -178,26 +180,27 @@ fun kotlinMultiplatformWithAndroidLibraryProjectSpec(agpVersion: AgpVersion, kot
     ),
     // needs to explicitly specify release to match the main plugin default behavior
     basePluginConfig = "configure(new KotlinMultiplatform(new JavadocJar.Empty(), true, [\"release\"]))",
-    buildFileExtra = baseProject.buildFileExtra + """
+    buildFileExtra = baseProject.buildFileExtra +
+      """
 
-        android {
-          compileSdkVersion = 31
-          namespace = "com.test"
+      android {
+        compileSdkVersion = 31
+        namespace = "com.test"
 
-          // resolves config cache issue, can be removed when AGP 8 becomes the minimum supported version
-          buildFeatures {
-              shaders = false
-          }
+        // resolves config cache issue, can be removed when AGP 8 becomes the minimum supported version
+        buildFeatures {
+            shaders = false
         }
+      }
 
-        kotlin {
-          androidTarget {}
+      kotlin {
+        androidTarget {}
 
-          jvmToolchain {
-              languageVersion.set(JavaLanguageVersion.of("8"))
-          }
+        jvmToolchain {
+            languageVersion.set(JavaLanguageVersion.of("8"))
         }
-    """.trimIndent(),
+      }
+      """.trimIndent(),
   )
 }
 
@@ -208,14 +211,15 @@ fun kotlinMultiplatformWithAndroidLibraryAndSpecifiedVariantsProjectSpec(
   val baseProject = kotlinMultiplatformWithAndroidLibraryProjectSpec(agpVersion, kotlinVersion)
   return baseProject.copy(
     basePluginConfig = "configure(new KotlinMultiplatform(new JavadocJar.Empty()))",
-    buildFileExtra = baseProject.buildFileExtra + """
+    buildFileExtra = baseProject.buildFileExtra +
+      """
 
-        kotlin {
-          androidTarget {
-            publishLibraryVariants("release", "debug")
-          }
+      kotlin {
+        androidTarget {
+          publishLibraryVariants("release", "debug")
         }
-    """.trimIndent(),
+      }
+      """.trimIndent(),
   )
 }
 
@@ -231,7 +235,8 @@ fun androidLibraryProjectSpec(version: AgpVersion) = ProjectSpec(
     SourceFile("main", "java", "com/vanniktech/maven/publish/test/JavaTestClass.java"),
   ),
   basePluginConfig = "configure(new AndroidSingleVariantLibrary(\"release\", true, true))",
-  buildFileExtra = """
+  buildFileExtra =
+    """
     android {
         namespace "com.test.library"
         compileSdkVersion 29
@@ -248,7 +253,7 @@ fun androidLibraryProjectSpec(version: AgpVersion) = ProjectSpec(
         it.enabled = false
       }
     }
-  """.trimIndent(),
+    """.trimIndent(),
 )
 
 fun androidLibraryKotlinProjectSpec(agpVersion: AgpVersion, kotlinVersion: KotlinVersion): ProjectSpec {
@@ -258,14 +263,15 @@ fun androidLibraryKotlinProjectSpec(agpVersion: AgpVersion, kotlinVersion: Kotli
     sourceFiles = plainAndroidProject.sourceFiles + listOf(
       SourceFile("main", "kotlin", "com/vanniktech/maven/publish/test/KotlinTestClass.kt"),
     ),
-    buildFileExtra = plainAndroidProject.buildFileExtra + """
+    buildFileExtra = plainAndroidProject.buildFileExtra +
+      """
 
       kotlin {
           jvmToolchain {
               languageVersion.set(JavaLanguageVersion.of("8"))
           }
       }
-    """.trimIndent(),
+      """.trimIndent(),
   )
 }
 
@@ -279,14 +285,15 @@ fun javaPlatformProjectSpec() = ProjectSpec(
   properties = defaultProperties,
   sourceFiles = emptyList(),
   basePluginConfig = "configure(new JavaPlatform())",
-  buildFileExtra = """
+  buildFileExtra =
+    """
     dependencies {
         constraints {
             api 'commons-httpclient:commons-httpclient:3.1'
             runtime 'org.postgresql:postgresql:42.2.5'
         }
     }
-  """.trimIndent(),
+    """.trimIndent(),
 )
 
 fun versionCatalogProjectSpec() = ProjectSpec(
@@ -299,11 +306,12 @@ fun versionCatalogProjectSpec() = ProjectSpec(
   properties = defaultProperties,
   sourceFiles = emptyList(),
   basePluginConfig = "configure(new VersionCatalog())",
-  buildFileExtra = """
+  buildFileExtra =
+    """
     catalog {
         versionCatalog {
             library('my-lib', 'com.mycompany:mylib:1.2')
         }
     }
-  """.trimIndent(),
+    """.trimIndent(),
 )

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/Subjects.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/Subjects.kt
@@ -35,56 +35,45 @@ class ProjectResultSubject private constructor(
 
     fun projectResult() = BUILD_RESULT_SUBJECT_FACTORY
 
-    fun assertThat(actual: ProjectResult): ProjectResultSubject {
-      return assertAbout(projectResult()).that(actual)
-    }
+    fun assertThat(actual: ProjectResult): ProjectResultSubject = assertAbout(projectResult()).that(actual)
   }
 
-  fun outcome(): BuildTaskSubject {
-    return check("outcome").about(buildResults())
-      .that(result.result)
-      .task(result.task)
-  }
+  fun outcome(): BuildTaskSubject = check("outcome")
+    .about(buildResults())
+    .that(result.result)
+    .task(result.task)
 
-  fun artifact(extension: String): ArtifactSubject {
-    return check("artifact").about(artifact())
-      .that(artifactPath("", extension) to result)
-  }
+  fun artifact(extension: String): ArtifactSubject = check("artifact")
+    .about(artifact())
+    .that(artifactPath("", extension) to result)
 
-  fun artifact(qualifier: String, extension: String): ArtifactSubject {
-    return check("artifact").about(artifact())
-      .that(artifactPath("-$qualifier", extension) to result)
-  }
+  fun artifact(qualifier: String, extension: String): ArtifactSubject = check("artifact")
+    .about(artifact())
+    .that(artifactPath("-$qualifier", extension) to result)
 
-  fun sourcesJar(): SourcesJarSubject {
-    return check("sourcesJar").about(sourcesJarSubject())
-      .that(artifactPath("-sources", "jar") to result)
-  }
+  fun sourcesJar(): SourcesJarSubject = check("sourcesJar")
+    .about(sourcesJarSubject())
+    .that(artifactPath("-sources", "jar") to result)
 
-  fun sourcesJar(qualifier: String): SourcesJarSubject {
-    return check("sourcesJar").about(sourcesJarSubject())
-      .that(artifactPath("-$qualifier-sources", "jar") to result)
-  }
+  fun sourcesJar(qualifier: String): SourcesJarSubject = check("sourcesJar")
+    .about(sourcesJarSubject())
+    .that(artifactPath("-$qualifier-sources", "jar") to result)
 
-  fun javadocJar(): ArtifactSubject {
-    return check("javadocJar").about(artifact())
-      .that(artifactPath("-javadoc", "jar") to result)
-  }
+  fun javadocJar(): ArtifactSubject = check("javadocJar")
+    .about(artifact())
+    .that(artifactPath("-javadoc", "jar") to result)
 
-  fun javadocJar(qualifier: String): ArtifactSubject {
-    return check("javadocJar").about(artifact())
-      .that(artifactPath("-$qualifier-javadoc", "jar") to result)
-  }
+  fun javadocJar(qualifier: String): ArtifactSubject = check("javadocJar")
+    .about(artifact())
+    .that(artifactPath("-$qualifier-javadoc", "jar") to result)
 
-  fun pom(): PomSubject {
-    return check("pom").about(pomSubject())
-      .that(artifactPath("", "pom") to result)
-  }
+  fun pom(): PomSubject = check("pom")
+    .about(pomSubject())
+    .that(artifactPath("", "pom") to result)
 
-  fun module(): ArtifactSubject {
-    return check("module").about(artifact())
-      .that(artifactPath("", "module") to result)
-  }
+  fun module(): ArtifactSubject = check("module")
+    .about(artifact())
+    .that(artifactPath("", "module") to result)
 
   private fun artifactPath(suffix: String, extension: String): Path = with(result.projectSpec) {
     return result.repo
@@ -109,14 +98,22 @@ open class ArtifactSubject internal constructor(
 
   fun exists() {
     if (!artifact.exists()) {
-      val files = result.repo.toFile().walkTopDown().filter { it.isFile }.toList()
+      val files = result.repo
+        .toFile()
+        .walkTopDown()
+        .filter { it.isFile }
+        .toList()
       failWithActual(fact("expected to exist", artifact), fact("but repo contained", files))
     }
   }
 
   fun doesNotExist() {
     if (artifact.exists()) {
-      val files = result.repo.toFile().walkTopDown().filter { it.isFile }.toList()
+      val files = result.repo
+        .toFile()
+        .walkTopDown()
+        .filter { it.isFile }
+        .toList()
       failWithActual(fact("expected not to exist", artifact), fact("but repo contained", files))
     }
   }
@@ -156,7 +153,8 @@ open class ArtifactSubject internal constructor(
     fileContent: (T) -> String?,
   ) {
     val zip = ZipFile(artifact.toFile())
-    val zipFiles = zip.entries()
+    val zipFiles = zip
+      .entries()
       .toList()
       .filter { zipEntry -> !zipEntry.isDirectory && filesToIgnore.none { zipEntry.name.contains(it) } }
       .toMutableList()
@@ -172,7 +170,11 @@ open class ArtifactSubject internal constructor(
       } else {
         zipFiles.remove(entry)
 
-        val content = zip.getInputStream(entry)?.reader()?.buffered()?.readText()
+        val content = zip
+          .getInputStream(entry)
+          ?.reader()
+          ?.buffered()
+          ?.readText()
         val expectedContent = fileContent(sourceFile)
         if (expectedContent != null && expectedContent != content) {
           notMatchingFiles += fact("expected ${fileDescriptor(sourceFile)} to equal", expectedContent)

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptions.kt
@@ -85,7 +85,9 @@ enum class GradleVersion(
   }
 }
 
-enum class GradlePluginPublish(val version: String) {
+enum class GradlePluginPublish(
+  val version: String,
+) {
   // minimum supported
   GRADLE_PLUGIN_PUBLISH_MIN("1.0.0"),
 

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -35,11 +35,14 @@ public abstract class MavenPublishBaseExtension @Inject constructor(
 
   private val sonatypeHost: Property<SonatypeHost> = project.objects.property(SonatypeHost::class.java)
   private val signing: Property<Boolean> = project.objects.property(Boolean::class.java)
-  internal val groupId: Property<String> = project.objects.property(String::class.java)
+  internal val groupId: Property<String> = project.objects
+    .property(String::class.java)
     .convention(project.provider { project.group.toString() })
-  internal val artifactId: Property<String> = project.objects.property(String::class.java)
+  internal val artifactId: Property<String> = project.objects
+    .property(String::class.java)
     .convention(project.provider { project.name.toString() })
-  internal val version: Property<String> = project.objects.property(String::class.java)
+  internal val version: Property<String> = project.objects
+    .property(String::class.java)
     .convention(project.provider { project.version.toString() })
   private val pomFromProperties: Property<Boolean> = project.objects.property(Boolean::class.java)
   private val platform: Property<Platform> = project.objects.property(Platform::class.java)

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -444,9 +444,13 @@ public sealed interface JavadocJar {
   ) : JavadocJar {
     internal sealed interface DokkaTaskName
 
-    internal data class StringDokkaTaskName(val value: String) : DokkaTaskName
+    internal data class StringDokkaTaskName(
+      val value: String,
+    ) : DokkaTaskName
 
-    internal data class ProviderDokkaTaskName(val value: Provider<String>) : DokkaTaskName
+    internal data class ProviderDokkaTaskName(
+      val value: Provider<String>,
+    ) : DokkaTaskName
 
     public constructor(taskName: String) : this(StringDokkaTaskName(taskName))
     public constructor(taskName: Provider<String>) : this(ProviderDokkaTaskName(taskName))
@@ -494,8 +498,10 @@ private fun setupTestFixtures(project: Project, sourcesJar: Boolean) {
   }
 }
 
-private class MissingVariantException(name: String) : RuntimeException(
-  "Invalid MavenPublish Configuration. Unable to find variant to publish named $name." +
-    " Try setting the 'androidVariantToPublish' property in the mavenPublish" +
-    " extension object to something that matches the variant that ought to be published.",
-)
+private class MissingVariantException(
+  name: String,
+) : RuntimeException(
+    "Invalid MavenPublish Configuration. Unable to find variant to publish named $name." +
+      " Try setting the 'androidVariantToPublish' property in the mavenPublish" +
+      " extension object to something that matches the variant that ought to be published.",
+  )

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
@@ -56,12 +56,7 @@ internal fun Project.javaVersion(): JavaVersion {
   return JavaVersion.current()
 }
 
-internal fun Project.isAtLeastKotlinVersion(
-  id: String,
-  major: Int,
-  minor: Int,
-  patch: Int,
-): Boolean {
+internal fun Project.isAtLeastKotlinVersion(id: String, major: Int, minor: Int, patch: Int): Boolean {
   val plugin = project.plugins.getPlugin(id) as KotlinBasePlugin
   val elements = plugin.pluginVersion.takeWhile { it != '-' }.split(".")
   val kgpMajor = elements[0].toInt()
@@ -69,18 +64,17 @@ internal fun Project.isAtLeastKotlinVersion(
   val kgpPatch = elements[2].toInt()
   return kgpMajor > major ||
     (
-      kgpMajor == major && (
-        kgpMinor > minor ||
-          (kgpMinor == minor && kgpPatch >= patch)
-      )
+      kgpMajor == major &&
+        (
+          kgpMinor > minor ||
+            (kgpMinor == minor && kgpPatch >= patch)
+        )
     )
 }
 
-internal fun Project.isAtLeastUsingAndroidGradleVersion(major: Int, minor: Int, patch: Int): Boolean {
-  return try {
-    androidComponents.pluginVersion >= AndroidPluginVersion(major, minor, patch)
-  } catch (e: NoClassDefFoundError) {
-    // was added in 7.0
-    false
-  }
+internal fun Project.isAtLeastUsingAndroidGradleVersion(major: Int, minor: Int, patch: Int): Boolean = try {
+  androidComponents.pluginVersion >= AndroidPluginVersion(major, minor, patch)
+} catch (e: NoClassDefFoundError) {
+  // was added in 7.0
+  false
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt
@@ -14,12 +14,10 @@ public data class SonatypeHost internal constructor(
 ) : Serializable {
   public constructor(rootUrl: String) : this(rootUrl, isCentralPortal = false)
 
-  internal fun apiBaseUrl(): String {
-    return if (isCentralPortal) {
-      "$rootUrl/api/v1/"
-    } else {
-      "$rootUrl/service/local/"
-    }
+  internal fun apiBaseUrl(): String = if (isCentralPortal) {
+    "$rootUrl/api/v1/"
+  } else {
+    "$rootUrl/service/local/"
   }
 
   public companion object {

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
@@ -68,16 +68,14 @@ internal abstract class CreateSonatypeRepositoryTask : DefaultTask() {
       group: Provider<String>,
       artifactId: Provider<String>,
       version: Provider<String>,
-    ): TaskProvider<CreateSonatypeRepositoryTask> {
-      return register(NAME, CreateSonatypeRepositoryTask::class.java) {
-        it.description = "Create a staging repository on Sonatype OSS"
-        it.group = "release"
-        it.projectGroup.set(group)
-        it.artifactId.set(artifactId)
-        it.version.set(version)
-        it.buildService.set(buildService)
-        it.usesService(buildService)
-      }
+    ): TaskProvider<CreateSonatypeRepositoryTask> = register(NAME, CreateSonatypeRepositoryTask::class.java) {
+      it.description = "Create a staging repository on Sonatype OSS"
+      it.group = "release"
+      it.projectGroup.set(group)
+      it.artifactId.set(artifactId)
+      it.version.set(version)
+      it.buildService.set(buildService)
+      it.usesService(buildService)
     }
   }
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/DropSonatypeRepositoryTask.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/DropSonatypeRepositoryTask.kt
@@ -32,14 +32,12 @@ internal abstract class DropSonatypeRepositoryTask : DefaultTask() {
     fun TaskContainer.registerDropRepository(
       buildService: Provider<SonatypeRepositoryBuildService>,
       createRepository: TaskProvider<CreateSonatypeRepositoryTask>,
-    ): TaskProvider<DropSonatypeRepositoryTask> {
-      return register(NAME, DropSonatypeRepositoryTask::class.java) {
-        it.description = "Drops a staging repository on Sonatype OSS"
-        it.group = "release"
-        it.buildService.set(buildService)
-        it.usesService(buildService)
-        it.mustRunAfter(createRepository)
-      }
+    ): TaskProvider<DropSonatypeRepositoryTask> = register(NAME, DropSonatypeRepositoryTask::class.java) {
+      it.description = "Drops a staging repository on Sonatype OSS"
+      it.group = "release"
+      it.buildService.set(buildService)
+      it.usesService(buildService)
+      it.mustRunAfter(createRepository)
     }
   }
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/ReleaseSonatypeRepositoryTask.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/ReleaseSonatypeRepositoryTask.kt
@@ -32,14 +32,12 @@ internal abstract class ReleaseSonatypeRepositoryTask : DefaultTask() {
     fun TaskContainer.registerReleaseRepository(
       buildService: Provider<SonatypeRepositoryBuildService>,
       createRepository: TaskProvider<CreateSonatypeRepositoryTask>,
-    ): TaskProvider<ReleaseSonatypeRepositoryTask> {
-      return register(NAME, ReleaseSonatypeRepositoryTask::class.java) {
-        it.description = "Releases a staging repository on Sonatype OSS"
-        it.group = "release"
-        it.buildService.set(buildService)
-        it.usesService(buildService)
-        it.mustRunAfter(createRepository)
-      }
+    ): TaskProvider<ReleaseSonatypeRepositoryTask> = register(NAME, ReleaseSonatypeRepositoryTask::class.java) {
+      it.description = "Releases a staging repository on Sonatype OSS"
+      it.group = "release"
+      it.buildService.set(buildService)
+      it.usesService(buildService)
+      it.mustRunAfter(createRepository)
     }
   }
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
@@ -26,7 +26,9 @@ import org.gradle.tooling.events.FinishEvent
 import org.gradle.tooling.events.OperationCompletionListener
 
 internal abstract class SonatypeRepositoryBuildService :
-  BuildService<SonatypeRepositoryBuildService.Params>, AutoCloseable, OperationCompletionListener {
+  BuildService<SonatypeRepositoryBuildService.Params>,
+  AutoCloseable,
+  OperationCompletionListener {
   private val logger: Logger = Logging.getLogger(SonatypeRepositoryBuildService::class.java)
 
   internal interface Params : BuildServiceParameters {
@@ -64,9 +66,11 @@ internal abstract class SonatypeRepositoryBuildService :
   private val centralPortal by lazy {
     SonatypeCentralPortal(
       baseUrl = parameters.sonatypeHost.get().apiBaseUrl(),
-      usertoken = Base64.getEncoder().encode(
-        "${parameters.repositoryUsername.get()}:${parameters.repositoryPassword.get()}".toByteArray(),
-      ).toString(Charsets.UTF_8),
+      usertoken = Base64
+        .getEncoder()
+        .encode(
+          "${parameters.repositoryUsername.get()}:${parameters.repositoryPassword.get()}".toByteArray(),
+        ).toString(Charsets.UTF_8),
       userAgentName = BuildConfig.NAME,
       userAgentVersion = BuildConfig.VERSION,
       okhttpTimeoutSeconds = parameters.okhttpTimeoutSeconds.get(),
@@ -175,34 +179,32 @@ internal abstract class SonatypeRepositoryBuildService :
     )
   }
 
-  internal fun publishingUrl(): String {
-    return if (parameters.versionIsSnapshot.get()) {
-      require(uploadId == null) {
-        "Staging repositories are not supported for SNAPSHOT versions."
-      }
+  internal fun publishingUrl(): String = if (parameters.versionIsSnapshot.get()) {
+    require(uploadId == null) {
+      "Staging repositories are not supported for SNAPSHOT versions."
+    }
 
-      val host = parameters.sonatypeHost.get()
-      if (host.isCentralPortal) {
-        "${host.rootUrl}/repository/maven-snapshots/"
-      } else {
-        "${host.rootUrl}/content/repositories/snapshots/"
-      }
+    val host = parameters.sonatypeHost.get()
+    if (host.isCentralPortal) {
+      "${host.rootUrl}/repository/maven-snapshots/"
     } else {
-      val stagingRepositoryId = requireNotNull(uploadId) {
-        if (parameters.configurationCacheActive.get()) {
-          "Publishing releases to Maven Central is not supported yet with configuration caching enabled, because of " +
-            "this missing Gradle feature: https://github.com/gradle/gradle/issues/22779"
-        } else {
-          "The staging repository was not created yet. Please open a bug with a build scan or build logs and stacktrace"
-        }
-      }
-
-      val host = parameters.sonatypeHost.get()
-      if (host.isCentralPortal) {
-        "file://${parameters.rootBuildDirectory.get()}/publish/staging/$stagingRepositoryId"
+      "${host.rootUrl}/content/repositories/snapshots/"
+    }
+  } else {
+    val stagingRepositoryId = requireNotNull(uploadId) {
+      if (parameters.configurationCacheActive.get()) {
+        "Publishing releases to Maven Central is not supported yet with configuration caching enabled, because of " +
+          "this missing Gradle feature: https://github.com/gradle/gradle/issues/22779"
       } else {
-        "${host.rootUrl}/service/local/staging/deployByRepositoryId/$stagingRepositoryId/"
+        "The staging repository was not created yet. Please open a bug with a build scan or build logs and stacktrace"
       }
+    }
+
+    val host = parameters.sonatypeHost.get()
+    if (host.isCentralPortal) {
+      "file://${parameters.rootBuildDirectory.get()}/publish/staging/$stagingRepositoryId"
+    } else {
+      "${host.rootUrl}/service/local/staging/deployByRepositoryId/$stagingRepositoryId/"
     }
   }
 
@@ -339,10 +341,12 @@ internal abstract class SonatypeRepositoryBuildService :
       buildEventsListenerRegistry: BuildEventsListenerRegistry,
       isConfigurationCacheActive: Provider<Boolean>,
     ): Provider<SonatypeRepositoryBuildService> {
-      val okhttpTimeout = project.providers.gradleProperty("SONATYPE_CONNECT_TIMEOUT_SECONDS")
+      val okhttpTimeout = project.providers
+        .gradleProperty("SONATYPE_CONNECT_TIMEOUT_SECONDS")
         .map { it.toLong() }
         .orElse(60)
-      val closeTimeout = project.providers.gradleProperty("SONATYPE_CLOSE_TIMEOUT_SECONDS")
+      val closeTimeout = project.providers
+        .gradleProperty("SONATYPE_CLOSE_TIMEOUT_SECONDS")
         .map { it.toLong() }
         .orElse(60 * 15)
       val service = gradle.sharedServices.registerIfAbsent(NAME, SonatypeRepositoryBuildService::class.java) {

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocJar.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocJar.kt
@@ -14,13 +14,11 @@ public open class JavadocJar : Jar() {
   }
 
   internal companion object {
-    internal fun Project.javadocJarTask(prefix: String, javadocJar: JavadocJarOption): TaskProvider<*>? {
-      return when (javadocJar) {
-        is JavadocJarOption.None -> null
-        is JavadocJarOption.Empty -> emptyJavadocJar(prefix)
-        is JavadocJarOption.Javadoc -> plainJavadocJar(prefix)
-        is JavadocJarOption.Dokka -> dokkaJavadocJar(prefix, javadocJar.taskName)
-      }
+    internal fun Project.javadocJarTask(prefix: String, javadocJar: JavadocJarOption): TaskProvider<*>? = when (javadocJar) {
+      is JavadocJarOption.None -> null
+      is JavadocJarOption.Empty -> emptyJavadocJar(prefix)
+      is JavadocJarOption.Javadoc -> plainJavadocJar(prefix)
+      is JavadocJarOption.Dokka -> dokkaJavadocJar(prefix, javadocJar.taskName)
     }
 
     private fun Project.emptyJavadocJar(prefix: String): TaskProvider<*> = tasks.register(
@@ -30,17 +28,16 @@ public open class JavadocJar : Jar() {
       it.archiveBaseName.set("${project.name}-$prefix-javadoc")
     }
 
-    private fun Project.plainJavadocJar(prefix: String): TaskProvider<*> {
-      return tasks.register("${prefix}PlainJavadocJar", JavadocJar::class.java) {
+    private fun Project.plainJavadocJar(prefix: String): TaskProvider<*> =
+      tasks.register("${prefix}PlainJavadocJar", JavadocJar::class.java) {
         val task = tasks.named("javadoc")
         it.dependsOn(task)
         it.from(task)
         it.archiveBaseName.set("${project.name}-$prefix-javadoc")
       }
-    }
 
-    private fun Project.dokkaJavadocJar(prefix: String, taskName: DokkaTaskName): TaskProvider<*> {
-      return tasks.register("${prefix}DokkaJavadocJar", JavadocJar::class.java) {
+    private fun Project.dokkaJavadocJar(prefix: String, taskName: DokkaTaskName): TaskProvider<*> =
+      tasks.register("${prefix}DokkaJavadocJar", JavadocJar::class.java) {
         val task = when (taskName) {
           is ProviderDokkaTaskName -> taskName.value.flatMap { name -> tasks.named(name) }
           is StringDokkaTaskName -> tasks.named(taskName.value)
@@ -49,6 +46,5 @@ public open class JavadocJar : Jar() {
         it.from(task)
         it.archiveBaseName.set("${project.name}-$prefix-javadoc")
       }
-    }
   }
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocJar.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocJar.kt
@@ -15,11 +15,10 @@ public open class JavadocJar : Jar() {
 
   internal companion object {
     internal fun Project.javadocJarTask(prefix: String, javadocJar: JavadocJarOption): TaskProvider<out Jar>? = when (javadocJar) {
-        is JavadocJarOption.None -> null
-        is JavadocJarOption.Empty -> emptyJavadocJar(prefix)
-        is JavadocJarOption.Javadoc -> plainJavadocJar(prefix)
-        is JavadocJarOption.Dokka -> dokkaJavadocJar(prefix, javadocJar.taskName)
-      }
+      is JavadocJarOption.None -> null
+      is JavadocJarOption.Empty -> emptyJavadocJar(prefix)
+      is JavadocJarOption.Javadoc -> plainJavadocJar(prefix)
+      is JavadocJarOption.Dokka -> dokkaJavadocJar(prefix, javadocJar.taskName)
     }
 
     private fun Project.emptyJavadocJar(prefix: String): TaskProvider<out Jar> = tasks.register(

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/WorkaroundSignatureType.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/WorkaroundSignatureType.kt
@@ -27,9 +27,7 @@ public class WorkaroundSignatureType(
     return super.sign(signatory, toSign)
   }
 
-  override fun getExtension(): String {
-    return actual.extension
-  }
+  override fun getExtension(): String = actual.extension
 
   override fun sign(signatory: Signatory?, toSign: InputStream?, destination: OutputStream?) {
     actual.sign(signatory, toSign, destination)

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/workaround/TestFixtures.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/workaround/TestFixtures.kt
@@ -44,25 +44,26 @@ internal fun addTestFixturesSourcesJar(project: Project) {
       projectInternal,
     )
   } else {
-    JvmPluginsHelper::class.java.getMethod(
-      "createDocumentationVariantWithArtifact",
-      String::class.java,
-      String::class.java,
-      String::class.java,
-      List::class.java,
-      String::class.java,
-      Object::class.java,
-      ProjectInternal::class.java,
-    ).invoke(
-      null,
-      testFixturesSourceSet.sourcesElementsConfigurationName,
-      testFixtureSourceSetName,
-      DocsType.SOURCES,
-      listOf(projectDerivedCapability),
-      testFixturesSourceSet.sourcesJarTaskName,
-      testFixturesSourceSet.allSource,
-      projectInternal,
-    ) as Configuration
+    JvmPluginsHelper::class.java
+      .getMethod(
+        "createDocumentationVariantWithArtifact",
+        String::class.java,
+        String::class.java,
+        String::class.java,
+        List::class.java,
+        String::class.java,
+        Object::class.java,
+        ProjectInternal::class.java,
+      ).invoke(
+        null,
+        testFixturesSourceSet.sourcesElementsConfigurationName,
+        testFixtureSourceSetName,
+        DocsType.SOURCES,
+        listOf(projectDerivedCapability),
+        testFixturesSourceSet.sourcesJarTaskName,
+        testFixturesSourceSet.allSource,
+        projectInternal,
+      ) as Configuration
   }
 
   val component = JavaPluginHelper.getJavaComponent(project) as DefaultJvmSoftwareComponent


### PR DESCRIPTION
Replaces running ktlint through Gradle with a Kotlin script, main motivation right now being that the ktlint plugin picks up sources generated by KSP (see #998).

Also brings in the latest ktlint version and some formatting changes related to that, some are a bit questionable but nothing too bad.