### PR TITLE
improve javadoc jar naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Improvements
   - Note: The old properties continue to work and there are no plans to remove them
 - The base plugin is now compatible with isolated projects as long as `pomFromGradleProperties()` is
   not called.
+- It's possible to pass a `TaskProvider` to `JavadocJar.Dokka`
+- Improved naming of produced `-javadoc` jars (locally, the name of the published artifact is unchanged)
 - Resolve issue that caused `version` to be read too early when publishing to
   Central Portal.
 

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -60,7 +60,7 @@ public data class JavaLibrary @JvmOverloads constructor(
     project.gradlePublishing.publications.create(PUBLICATION_NAME, MavenPublication::class.java) {
       it.from(project.components.getByName("java"))
       it.withJavaSourcesJar(sourcesJar, project)
-      it.withJavadocJar(javadocJar, project)
+      it.withJavadocJar(javadocJar, project, multipleTasks = false)
     }
 
     setupTestFixtures(project, sourcesJar)
@@ -91,7 +91,7 @@ public data class GradlePlugin @JvmOverloads constructor(
 
     project.mavenPublicationsWithoutPluginMarker {
       it.withJavaSourcesJar(sourcesJar, project)
-      it.withJavadocJar(javadocJar, project)
+      it.withJavadocJar(javadocJar, project, multipleTasks = false)
     }
   }
 }
@@ -278,7 +278,7 @@ public class AndroidFusedLibrary : Platform() {
     }
 
     project.mavenPublications {
-      it.withJavadocJar(javadocJar, project, configureArchives = true)
+      it.withJavadocJar(javadocJar, project, multipleTasks = false, configureArchives = true)
       it.withJavaSourcesJar(sourcesJar, project, configureArchives = true)
     }
   }
@@ -318,7 +318,7 @@ public data class KotlinMultiplatform internal constructor(
     }
 
     project.mavenPublications {
-      it.withJavadocJar(javadocJar, project)
+      it.withJavadocJar(javadocJar, project, multipleTasks = true)
     }
 
     project.extensions.configure(KotlinMultiplatformExtension::class.java) {
@@ -367,7 +367,7 @@ public data class KotlinJvm @JvmOverloads constructor(
     project.gradlePublishing.publications.create(PUBLICATION_NAME, MavenPublication::class.java) {
       it.from(project.components.getByName("java"))
       it.withJavaSourcesJar(sourcesJar, project)
-      it.withJavadocJar(javadocJar, project)
+      it.withJavadocJar(javadocJar, project, multipleTasks = false)
     }
 
     setupTestFixtures(project, sourcesJar)
@@ -529,8 +529,13 @@ private fun MavenPublication.withJavaSourcesJar(enabled: Boolean, project: Proje
   }
 }
 
-private fun MavenPublication.withJavadocJar(javadocJar: JavadocJar, project: Project, configureArchives: Boolean = false) {
-  val task = project.javadocJarTask(name, javadocJar)
+private fun MavenPublication.withJavadocJar(
+  javadocJar: JavadocJar,
+  project: Project,
+  multipleTasks: Boolean,
+  configureArchives: Boolean = false,
+) {
+  val task = project.javadocJarTask(javadocJar, prefix = name.takeIf { multipleTasks })
   if (task != null) {
     artifact(task)
 

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocJar.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocJar.kt
@@ -2,6 +2,8 @@ package com.vanniktech.maven.publish.tasks
 
 import com.vanniktech.maven.publish.JavadocJar as JavadocJarOption
 import com.vanniktech.maven.publish.JavadocJar.Dokka.DokkaTaskWrapper
+import com.vanniktech.maven.publish.baseExtension
+import java.util.Locale
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.tasks.Jar
@@ -12,34 +14,46 @@ public open class JavadocJar : Jar() {
   }
 
   internal companion object {
-    internal fun Project.javadocJarTask(prefix: String, javadocJar: JavadocJarOption): TaskProvider<out Jar>? = when (javadocJar) {
+    internal fun Project.javadocJarTask(javadocJar: JavadocJarOption, prefix: String?): TaskProvider<out Jar>? = when (javadocJar) {
       is JavadocJarOption.None -> null
       is JavadocJarOption.Empty -> emptyJavadocJar(prefix)
       is JavadocJarOption.Javadoc -> plainJavadocJar(prefix)
       is JavadocJarOption.Dokka -> dokkaJavadocJar(prefix, javadocJar.wrapper)
     }
 
-    private fun Project.emptyJavadocJar(prefix: String): TaskProvider<out Jar> = tasks.register(
-      "${prefix}EmptyJavadocJar",
+    private fun Project.emptyJavadocJar(prefix: String?): TaskProvider<out Jar> = tasks.register(
+      prefixedTaskName("emptyJavadocJar", prefix),
       JavadocJar::class.java,
     ) {
-      it.archiveBaseName.set("${project.name}-$prefix-javadoc")
+      it.updateArchivesBaseNameWithPrefix(project, prefix)
     }
 
-    private fun Project.plainJavadocJar(prefix: String): TaskProvider<out Jar> =
-      tasks.register("${prefix}PlainJavadocJar", JavadocJar::class.java) {
-        val task = tasks.named("javadoc")
-        it.dependsOn(task)
-        it.from(task)
-        it.archiveBaseName.set("${project.name}-$prefix-javadoc")
+    private fun Project.plainJavadocJar(prefix: String?): TaskProvider<out Jar> =
+      tasks.register(prefixedTaskName("plainJavadocJar", prefix), JavadocJar::class.java) {
+        val javadocTask = tasks.named("javadoc")
+        it.dependsOn(javadocTask)
+        it.from(javadocTask)
+        it.updateArchivesBaseNameWithPrefix(project, prefix)
       }
 
-    private fun Project.dokkaJavadocJar(prefix: String, dokkaTaskWrapper: DokkaTaskWrapper): TaskProvider<out Jar> =
-      tasks.register("${prefix}DokkaJavadocJar", JavadocJar::class.java) {
+    private fun Project.dokkaJavadocJar(prefix: String?, dokkaTaskWrapper: DokkaTaskWrapper): TaskProvider<out Jar> =
+      tasks.register(prefixedTaskName("dokkaJavadocJar", prefix), JavadocJar::class.java) {
         val dokkaTask = dokkaTaskWrapper.asProvider(project)
         it.dependsOn(dokkaTask)
         it.from(dokkaTask)
-        it.archiveBaseName.set("${project.name}-$prefix-javadoc")
+        it.updateArchivesBaseNameWithPrefix(project, prefix)
       }
+
+    private fun prefixedTaskName(name: String, prefix: String?): String = if (prefix != null) {
+      "${prefix}${name.replaceFirstChar { it.titlecase(Locale.US) }}"
+    } else {
+      name
+    }
+
+    private fun Jar.updateArchivesBaseNameWithPrefix(project: Project, prefix: String?) {
+      if (prefix != null) {
+        archiveBaseName.set(project.baseExtension.artifactId.map { "$it-$prefix" })
+      }
+    }
   }
 }


### PR DESCRIPTION
Closes #966 

When #852 introduced the unique naming it was to avoid multiple plublications having overlaps. This improves the mechanism in 2 ways:
- only use it for projects that have multiple publications (KMP projects)
- use the artifact id in the name and remove the duplicate javadoc prefix

This way most projects get the default naming and in KMP you get something closer to the default.