### PR TITLE
Remove redundant Gradle dependencies

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -117,8 +117,6 @@ lint {
 }
 
 dependencies {
-  api(gradleApi())
-
   compileOnly(libs.dokka)
   compileOnly(libs.kotlin.plugin)
   compileOnly(libs.android.plugin)
@@ -126,7 +124,6 @@ dependencies {
   implementation(projects.centralPortal)
   implementation(projects.nexus)
 
-  testImplementation(gradleTestKit())
   testImplementation(libs.junit.jupiter)
   testImplementation(libs.junit.engine)
   testImplementation(libs.junit.launcher)


### PR DESCRIPTION
They are added by `java-gradle-plugin` by default.

---

- [ ] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
