### PR TITLE
remove Worker API from CreateSonatypeRepositoryTask

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
@@ -1,6 +1,5 @@
 package com.vanniktech.maven.publish.sonatype
 
-import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
@@ -9,10 +8,6 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.workers.WorkAction
-import org.gradle.workers.WorkParameters
-import org.gradle.workers.WorkQueue
-import org.gradle.workers.WorkerExecutor
 
 internal abstract class CreateSonatypeRepositoryTask : DefaultTask() {
   @get:Internal
@@ -27,37 +22,9 @@ internal abstract class CreateSonatypeRepositoryTask : DefaultTask() {
   @get:Internal
   abstract val buildService: Property<SonatypeRepositoryBuildService>
 
-  @Inject
-  abstract fun getWorkerExecutor(): WorkerExecutor
-
   @TaskAction
   fun createStagingRepository() {
-    val workQueue: WorkQueue = getWorkerExecutor().noIsolation()
-    workQueue.submit(CreateStagingRepository::class.java) {
-      requireNotNull(it)
-      it.group.set(projectGroup)
-      it.artifactId.set(artifactId)
-      it.version.set(version)
-      it.buildService.set(buildService)
-    }
-  }
-
-  internal interface CreateStagingRepositoryParameters : WorkParameters {
-    val buildService: Property<SonatypeRepositoryBuildService>
-    val group: Property<String>
-    val artifactId: Property<String>
-    val version: Property<String>
-  }
-
-  abstract class CreateStagingRepository : WorkAction<CreateStagingRepositoryParameters?> {
-    override fun execute() {
-      val parameters = requireNotNull(parameters)
-      val service = parameters.buildService.get()
-      val group = parameters.group.get()
-      val artifactId = parameters.artifactId.get()
-      val version = parameters.version.get()
-      service.createStagingRepository(group, artifactId, version)
-    }
+    buildService.get().createStagingRepository(projectGroup.get(), artifactId.get(), version.get())
   }
 
   companion object {


### PR DESCRIPTION
For Central Portal the task is not doing anything time consuming so with the removal of OSSRH we don't need the worker API anymore.