### PR TITLE
Migrate BCV to the Kotlin's builtin

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -4,7 +4,6 @@ dependencies {
   implementation(libs.kotlin.plugin)
   implementation(libs.kotlin.ksp)
   implementation(libs.maven.publish.plugin)
-  implementation(libs.bcv)
   // https://github.com/gradle/gradle/issues/15383#issuecomment-779893192
   implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }

--- a/build-logic/src/main/kotlin/shared.gradle.kts
+++ b/build-logic/src/main/kotlin/shared.gradle.kts
@@ -1,6 +1,7 @@
 import org.gradle.accessors.dm.LibrariesForLibs
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val libs = the<LibrariesForLibs>()
@@ -10,7 +11,6 @@ plugins {
   id("org.jetbrains.kotlin.jvm")
   id("com.google.devtools.ksp")
   id("com.vanniktech.maven.publish")
-  id("org.jetbrains.kotlinx.binary-compatibility-validator")
 }
 
 repositories {
@@ -25,6 +25,10 @@ java {
 
 kotlin {
   explicitApi()
+  @OptIn(ExperimentalAbiValidation::class)
+  abiValidation {
+    enabled = true
+  }
 }
 
 tasks.withType(KotlinCompile::class.java) {
@@ -32,6 +36,13 @@ tasks.withType(KotlinCompile::class.java) {
     jvmTarget.set(JvmTarget.JVM_11)
     languageVersion.set(KotlinVersion.KOTLIN_1_8)
   }
+}
+
+tasks.check {
+  dependsOn(
+    // TODO: https://youtrack.jetbrains.com/issue/KT-78525
+    tasks.checkLegacyAbi,
+  )
 }
 
 configurations.all {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,6 @@ okhttp = "com.squareup.okhttp3:okhttp:5.0.0"
 dokka = "org.jetbrains.dokka:dokka-gradle-plugin:2.0.0"
 android-plugin = "com.android.tools.build:gradle:8.11.0"
 maven-publish-plugin = "com.vanniktech:gradle-maven-publish-plugin:0.33.0"
-bcv = "org.jetbrains.kotlinx:binary-compatibility-validator:0.18.0"
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }


### PR DESCRIPTION
https://kotlinlang.org/docs/whatsnew22.html#binary-compatibility-validation-included-in-kotlin-gradle-plugin

---

- [ ] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
