### PR TITLE
Remove invalid converter factories

### DIFF
--- a/central-portal/build.gradle.kts
+++ b/central-portal/build.gradle.kts
@@ -4,8 +4,5 @@ plugins {
 
 dependencies {
   implementation(libs.okhttp)
-  implementation(libs.moshi)
   implementation(libs.retrofit)
-  implementation(libs.retrofit.converter.moshi)
-  implementation(libs.retrofit.converter.scalars)
 }

--- a/central-portal/src/main/kotlin/com/vanniktech/maven/publish/portal/SonatypeCentralPortal.kt
+++ b/central-portal/src/main/kotlin/com/vanniktech/maven/publish/portal/SonatypeCentralPortal.kt
@@ -8,8 +8,6 @@ import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.asRequestBody
 import retrofit2.Retrofit
-import retrofit2.converter.moshi.MoshiConverterFactory
-import retrofit2.converter.scalars.ScalarsConverterFactory
 
 public class SonatypeCentralPortal(
   private val baseUrl: String,
@@ -29,8 +27,6 @@ public class SonatypeCentralPortal(
       .build()
     val retrofit = Retrofit
       .Builder()
-      .addConverterFactory(ScalarsConverterFactory.create())
-      .addConverterFactory(MoshiConverterFactory.create())
       .client(okHttpClient)
       .baseUrl(baseUrl)
       .build()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,11 +23,7 @@ kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", versi
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 
-moshi = "com.squareup.moshi:moshi:1.15.2"
-
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
-retrofit-converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit" }
-retrofit-converter-scalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit" }
 
 junit-jupiter = "org.junit.jupiter:junit-jupiter:5.13.3"
 junit-engine = { module = "org.junit.platform:junit-platform-engine", version.ref = "junit-platform" }


### PR DESCRIPTION
`ScalarsConverterFactory` and `MoshiConverterFactory` are outdated, Retrofit's builtin converts can handle all types in https://github.com/vanniktech/gradle-maven-publish-plugin/blob/19b5c29e18e2d1080e260aa0a4820cc56ea37c4d/central-portal/src/main/kotlin/com/vanniktech/maven/publish/portal/SonatypeCentralPortalService.kt#L16-L32, we can reduce their dependencies as well.

Refs #1006.

---

- [ ] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
