### PR TITLE
Support using the snapshot plugins on user side

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,10 +23,6 @@ jobs:
           distribution: zulu
           java-version: 11
 
-      - name: Set version for tag
-        run: |
-          echo "ORG_GRADLE_PROJECT_VERSION_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
-
       - uses: gradle/actions/setup-gradle@v4
 
       - name: Publish

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -29,10 +29,6 @@ jobs:
           distribution: zulu
           java-version: 11
 
-      - name: Set version
-        run: |
-          echo "ORG_GRADLE_PROJECT_VERSION_NAME=$(git describe --tags --abbrev=0 | awk -F. '/[0-9]+\./{$NF++;print}' OFS=.)-SNAPSHOT" >> $GITHUB_ENV
-
       - uses: gradle/actions/setup-gradle@v4
 
       - name: Publish

--- a/README.md
+++ b/README.md
@@ -14,6 +14,32 @@ For modifying what is getting published see [configuring what to publish](https:
 There is also a [base plugin](https://vanniktech.github.io/gradle-maven-publish-plugin/base/) that doesn't apply any
 default configuration and allows the most customization.
 
+<details>
+<summary>Snapshots of the development version are available in Central Portal Snapshots.
+</summary>
+<p>
+
+```kotlin
+// Update this in your `settings.gradle.kts` file.
+pluginManagement {
+  repositories {
+    mavenCentral()
+    google()
+    // Add the snapshot repository.
+    maven("https://central.sonatype.com/repository/maven-snapshots/")
+  }
+}
+
+// Update this in your `build.gradle.kts` file.
+plugins {
+  // You can get the latest snapshot version from `VERSION_NAME` declared in https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/gradle.properties
+  id("com.vanniktech.maven.publish.base") version "<latest-snapshot-version>"
+}
+```
+
+</p>
+</details>
+
 # Supported plugins
 
 The output of the following Gradle plugins is supported to be published with this plugin:

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,11 +8,14 @@ org.gradle.configuration-cache.parallel=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx2g
 org.gradle.parallel=true
 
+########## Properties for publishing to Maven Central ##########
+
 mavenCentralAutomaticPublishing=true
 mavenCentralPublishing=true
 signAllPublications=true
 
 GROUP=com.vanniktech
+VERSION_NAME=0.35.0-SNAPSHOT
 
 POM_INCEPTION_YEAR=2018
 
@@ -28,6 +31,3 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=vanniktech
 POM_DEVELOPER_NAME=Niklas Baudy
 POM_DEVELOPER_URL=https://github.com/vanniktech/
-
-# only exists for integration tests, not used for actual publishing:
-VERSION_NAME=0.1.0-SNAPSHOT


### PR DESCRIPTION
The `VERSION_NAME` should be updated after each release to match the latest snapshots.

---

- [ ] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
