### PR TITLE
Fix deprecation warning caused by invalid URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [UNRELEASED](https://github.com/vanniktech/gradle-maven-publish-plugin/compare/0.33.0...HEAD) *(2025-xx-xx)*
 
-No changes
+- Fixed Gradle's deprecation warning caused by invalid URI.
 
 #### Minimum supported versions
 - JDK 11

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
@@ -146,7 +146,11 @@ internal abstract class SonatypeRepositoryBuildService :
       "The staging repository was not created yet. Please open a bug with a build scan or build logs and stacktrace"
     }
 
-    val rootBuildDirectory = parameters.rootBuildDirectory.get().toString().replace('\\', '/')
+    val rootBuildDirectory = parameters
+      .rootBuildDirectory
+      .get()
+      .toString()
+      .replace('\\', '/')
     "file:///$rootBuildDirectory/publish/staging/$id"
   }
 

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
@@ -146,7 +146,8 @@ internal abstract class SonatypeRepositoryBuildService :
       "The staging repository was not created yet. Please open a bug with a build scan or build logs and stacktrace"
     }
 
-    "file://${parameters.rootBuildDirectory.get()}/publish/staging/$id"
+    val rootBuildDirectory = parameters.rootBuildDirectory.get().toString().replace('\\', '/')
+    "file:///$rootBuildDirectory/publish/staging/$id"
   }
 
   override fun onFinish(event: FinishEvent) {


### PR DESCRIPTION
Fixes #1057.

---

- [x] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.