### PR TITLE
introduce MavenCentralProject

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/central/MavenCentralCoordinates.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/central/MavenCentralCoordinates.kt
@@ -1,0 +1,7 @@
+package com.vanniktech.maven.publish.central
+
+internal data class MavenCentralCoordinates(
+  val group: String,
+  val artifactId: String,
+  val version: String,
+)

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/central/MavenCentralProject.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/central/MavenCentralProject.kt
@@ -1,0 +1,5 @@
+package com.vanniktech.maven.publish.central
+
+internal data class MavenCentralProject(
+  val coordinates: MavenCentralCoordinates,
+)

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
@@ -23,8 +23,8 @@ internal abstract class CreateSonatypeRepositoryTask : DefaultTask() {
   abstract val buildService: Property<SonatypeRepositoryBuildService>
 
   @TaskAction
-  fun createStagingRepository() {
-    buildService.get().createStagingRepository(projectGroup.get(), artifactId.get(), version.get())
+  fun registerProject() {
+    buildService.get().registerProject(projectGroup.get(), artifactId.get(), version.get())
   }
 
   companion object {


### PR DESCRIPTION
Replaces the `Triple` for coordinates with a data class and adds an extra wrapper called `MavenCentralProject` to add more properties later. 

Also cleans up some outdated method naming.