### PR TITLE
cleanup EndOfBuildAction

### DIFF
--- a/central-portal/api/central-portal.api
+++ b/central-portal/api/central-portal.api
@@ -2,6 +2,13 @@ public final class com/vanniktech/maven/publish/portal/SonatypeCentralPortal {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJ)V
 	public final fun deleteDeployment (Ljava/lang/String;)V
 	public final fun publishDeployment (Ljava/lang/String;)V
-	public final fun upload (Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Ljava/lang/String;
+	public final fun upload (Ljava/lang/String;Lcom/vanniktech/maven/publish/portal/SonatypeCentralPortal$PublishingType;Ljava/io/File;)Ljava/lang/String;
+}
+
+public final class com/vanniktech/maven/publish/portal/SonatypeCentralPortal$PublishingType : java/lang/Enum {
+	public static final field AUTOMATIC Lcom/vanniktech/maven/publish/portal/SonatypeCentralPortal$PublishingType;
+	public static final field USER_MANAGED Lcom/vanniktech/maven/publish/portal/SonatypeCentralPortal$PublishingType;
+	public static fun valueOf (Ljava/lang/String;)Lcom/vanniktech/maven/publish/portal/SonatypeCentralPortal$PublishingType;
+	public static fun values ()[Lcom/vanniktech/maven/publish/portal/SonatypeCentralPortal$PublishingType;
 }
 

--- a/central-portal/src/main/kotlin/com/vanniktech/maven/publish/portal/SonatypeCentralPortal.kt
+++ b/central-portal/src/main/kotlin/com/vanniktech/maven/publish/portal/SonatypeCentralPortal.kt
@@ -56,7 +56,7 @@ public class SonatypeCentralPortal(
     }
   }
 
-  public fun upload(name: String, publishingType: String, file: File): String {
+  public fun upload(name: String, publishingType: PublishingType, file: File): String {
     val uploadFile = file.asRequestBody("application/octet-stream".toMediaType())
     val multipart = MultipartBody.Part.createFormData("bundle", file.name, uploadFile)
     val uploadResponse = service.uploadBundle(name, publishingType, multipart).execute()
@@ -65,5 +65,10 @@ public class SonatypeCentralPortal(
     } else {
       throw IOException("Upload failed: ${uploadResponse.errorBody()?.string()}")
     }
+  }
+
+  public enum class PublishingType {
+    AUTOMATIC,
+    USER_MANAGED,
   }
 }

--- a/central-portal/src/main/kotlin/com/vanniktech/maven/publish/portal/SonatypeCentralPortalService.kt
+++ b/central-portal/src/main/kotlin/com/vanniktech/maven/publish/portal/SonatypeCentralPortalService.kt
@@ -27,7 +27,7 @@ internal interface SonatypeCentralPortalService {
   @POST("api/v1/publisher/upload")
   fun uploadBundle(
     @Query("name") name: String,
-    @Query("publishingType") publishingType: String,
+    @Query("publishingType") publishingType: SonatypeCentralPortal.PublishingType,
     @Part input: MultipartBody.Part,
   ): Call<String>
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -98,8 +98,8 @@ public abstract class MavenPublishBaseExtension @Inject constructor(
       }
     }
 
-    val releaseRepository = project.tasks.registerReleaseRepository(buildService, createRepository)
-    project.tasks.registerDropRepository(buildService, createRepository)
+    val releaseRepository = project.tasks.registerReleaseRepository(buildService)
+    project.tasks.registerDropRepository(buildService)
 
     project.tasks.register("publishToMavenCentral") {
       it.description = "Publishes to a staging repository on Sonatype OSS"

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/central/EndOfBuildAction.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/central/EndOfBuildAction.kt
@@ -3,18 +3,15 @@ package com.vanniktech.maven.publish.central
 internal sealed interface EndOfBuildAction {
   val runAfterFailure: Boolean
 
-  data class Close(
-    val searchForRepositoryIfNoIdPresent: Boolean,
-  ) : EndOfBuildAction {
+  object Upload : EndOfBuildAction {
     override val runAfterFailure: Boolean = false
   }
 
-  object ReleaseAfterClose : EndOfBuildAction {
+  object Publish : EndOfBuildAction {
     override val runAfterFailure: Boolean = false
   }
 
   data class Drop(
     override val runAfterFailure: Boolean,
-    val searchForRepositoryIfNoIdPresent: Boolean,
   ) : EndOfBuildAction
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/DropSonatypeRepositoryTask.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/DropSonatypeRepositoryTask.kt
@@ -22,8 +22,7 @@ internal abstract class DropSonatypeRepositoryTask : DefaultTask() {
 
   @TaskAction
   fun closeAndReleaseRepository() {
-    val service = this.buildService.get()
-    service.shouldDropRepository(manualStagingRepositoryId)
+    buildService.get().shouldDropRepository(manualStagingRepositoryId)
   }
 
   companion object {
@@ -31,13 +30,11 @@ internal abstract class DropSonatypeRepositoryTask : DefaultTask() {
 
     fun TaskContainer.registerDropRepository(
       buildService: Provider<SonatypeRepositoryBuildService>,
-      createRepository: TaskProvider<CreateSonatypeRepositoryTask>,
     ): TaskProvider<DropSonatypeRepositoryTask> = register(NAME, DropSonatypeRepositoryTask::class.java) {
       it.description = "Drops a staging repository on Sonatype OSS"
       it.group = "release"
       it.buildService.set(buildService)
       it.usesService(buildService)
-      it.mustRunAfter(createRepository)
     }
   }
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/ReleaseSonatypeRepositoryTask.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/ReleaseSonatypeRepositoryTask.kt
@@ -3,27 +3,18 @@ package com.vanniktech.maven.publish.sonatype
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.api.tasks.options.Option
 
 internal abstract class ReleaseSonatypeRepositoryTask : DefaultTask() {
   @get:Internal
   abstract val buildService: Property<SonatypeRepositoryBuildService>
 
-  @Option(option = "repository", description = "Specify which staging repository to close and release.")
-  @Input
-  @Optional
-  var manualStagingRepositoryId: String? = null
-
   @TaskAction
-  fun closeAndReleaseRepository() {
-    val service = this.buildService.get()
-    service.shouldCloseAndReleaseRepository(manualStagingRepositoryId)
+  fun enableAutomaticPublishing() {
+    buildService.get().enableAutomaticPublishing()
   }
 
   companion object {
@@ -31,13 +22,11 @@ internal abstract class ReleaseSonatypeRepositoryTask : DefaultTask() {
 
     fun TaskContainer.registerReleaseRepository(
       buildService: Provider<SonatypeRepositoryBuildService>,
-      createRepository: TaskProvider<CreateSonatypeRepositoryTask>,
     ): TaskProvider<ReleaseSonatypeRepositoryTask> = register(NAME, ReleaseSonatypeRepositoryTask::class.java) {
       it.description = "Releases a staging repository on Sonatype OSS"
       it.group = "release"
       it.buildService.set(buildService)
       it.usesService(buildService)
-      it.mustRunAfter(createRepository)
     }
   }
 }


### PR DESCRIPTION
- update names to better match Central Portal actions
- rename task actions for the same purpose
- remove unneccessary ordering constraints
- remove `searchForRepositoryIfNoIdPresent` option since it's not supported for central portal
- simplify usage in build service