### PR TITLE
Tweak .editorconfig rules a bit

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,21 +1,27 @@
-root=true
+root = true
 
 [*]
-indent_size=2
-charset=utf-8
-trim_trailing_whitespace=true
-insert_final_newline=true
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
 
 [*.{kt,kts}]
-ij_kotlin_imports_layout=*
+ij_kotlin_imports_layout = *
 
-ij_kotlin_allow_trailing_comma=true
-ij_kotlin_allow_trailing_comma_on_call_site=true
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = true
 
+# Disable wildcard imports entirely.
+ij_kotlin_name_count_to_use_star_import = 2147483647
+ij_kotlin_name_count_to_use_star_import_for_members = 2147483647
+ij_kotlin_packages_to_use_import_on_demand = unset
+
+ktlint_code_style = ktlint_official
 # makes constructor annotations indent the whole class
-ktlint_standard_annotation=disabled
+ktlint_standard_annotation = disabled
 # too aggressive in wrapping and indenting the expression in an assignment
-ktlint_standard_multiline-expression-wrapping=disabled
+ktlint_standard_multiline-expression-wrapping = disabled
 # make ktlint less eager to wrap function signatures and expression bodies
-ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than=unset
-ktlint_function_signature_body_expression_wrapping=default
+ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than = unset
+ktlint_function_signature_body_expression_wrapping = default


### PR DESCRIPTION
This is honored by Ktlnt CLI, we can run checks and formats in both `ktlint.main.kts` and the CLI.

---

- [ ] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
