### PR TITLE
stop passing automaticRelease to build service

### DIFF
--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt
@@ -35,11 +35,9 @@ internal abstract class SonatypeRepositoryBuildService :
   private val logger: Logger = Logging.getLogger(SonatypeRepositoryBuildService::class.java)
 
   internal interface Params : BuildServiceParameters {
-    val groupId: Property<String>
     val versionIsSnapshot: Property<Boolean>
     val repositoryUsername: Property<String>
     val repositoryPassword: Property<String>
-    val automaticRelease: Property<Boolean>
     val okhttpTimeoutSeconds: Property<Long>
     val closeTimeoutSeconds: Property<Long>
     val rootBuildDirectory: DirectoryProperty
@@ -102,9 +100,6 @@ internal abstract class SonatypeRepositoryBuildService :
     uploadId = UUID.randomUUID().toString()
 
     endOfBuildActions += EndOfBuildAction.Upload
-    if (parameters.automaticRelease.get()) {
-      endOfBuildActions += EndOfBuildAction.Publish
-    }
     endOfBuildActions += EndOfBuildAction.Drop(runAfterFailure = true)
   }
 
@@ -219,11 +214,9 @@ internal abstract class SonatypeRepositoryBuildService :
     private const val NAME = "sonatype-repository-build-service"
 
     fun Project.registerSonatypeRepositoryBuildService(
-      groupId: Provider<String>,
       versionIsSnapshot: Provider<Boolean>,
       repositoryUsername: Provider<String>,
       repositoryPassword: Provider<String>,
-      automaticRelease: Boolean,
       rootBuildDirectory: Provider<Directory>,
       buildEventsListenerRegistry: BuildEventsListenerRegistry,
     ): Provider<SonatypeRepositoryBuildService> {
@@ -237,11 +230,9 @@ internal abstract class SonatypeRepositoryBuildService :
         .orElse(60 * 15)
       val service = gradle.sharedServices.registerIfAbsent(NAME, SonatypeRepositoryBuildService::class.java) {
         it.maxParallelUsages.set(1)
-        it.parameters.groupId.set(groupId)
         it.parameters.versionIsSnapshot.set(versionIsSnapshot)
         it.parameters.repositoryUsername.set(repositoryUsername)
         it.parameters.repositoryPassword.set(repositoryPassword)
-        it.parameters.automaticRelease.set(automaticRelease)
         it.parameters.okhttpTimeoutSeconds.set(okhttpTimeout)
         it.parameters.closeTimeoutSeconds.set(closeTimeout)
         it.parameters.rootBuildDirectory.set(rootBuildDirectory)


### PR DESCRIPTION
Until now we would use `automaticRelease` directly in the build service to add the publish action. Additionally running the `releaseRepository` task would do the same. This changes the mechanism to always use `releaseRepository`. Based on `automaticRelease` we will add a task dependency from the publish tasks to the release task.
