### PR TITLE
Use per-project repositories for Central Portal publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [UNRELEASED](https://github.com/vanniktech/gradle-maven-publish-plugin/compare/0.33.0...HEAD) *(2025-xx-xx)*
 
+- Added configuration cache support for publishing.
 - Removed support for publishing through Sonatype OSSRH.
     - `SonatypeHost` has been removed from the DSL.
     - `SONATYPE_HOST` only supports `CENTRAL_PORTAL` now (it's recommended to use `mavenCentralPublishing=true` instead).

--- a/docs/central.md
+++ b/docs/central.md
@@ -292,14 +292,8 @@ The publishing process for Maven Central consists of several steps
 
 Run the following Gradle task:
 ```sh
-./gradlew publishToMavenCentral --no-configuration-cache
+./gradlew publishToMavenCentral
 ```
-
-!!! note "Configuration cache"
-
-    Configuration caching when uploading releases is currently not possible. Supporting it is
-    blocked by [Gradle issue #22779](https://github.com/gradle/gradle/issues/22779).
-
 
 Afterward go to [Deployments on the Central Portal website](https://central.sonatype.com/publishing/deployments)
 and click "Publish" on the deployment.
@@ -312,7 +306,7 @@ For automatic publishing use one of the following options
 
     Instead of running `publishToMavenCentral` as described above use:
     ```sh
-    ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
+    ./gradlew publishAndReleaseToMavenCentral
     ```
 
 === "build.gradle"
@@ -328,7 +322,7 @@ For automatic publishing use one of the following options
 
     To publish use
     ```sh
-    ./gradlew publishToMavenCentral --no-configuration-cache
+    ./gradlew publishToMavenCentral
     ```
 
 === "build.gradle.kts"
@@ -345,7 +339,7 @@ For automatic publishing use one of the following options
 
     To publish use
     ```sh
-    ./gradlew publishToMavenCentral --no-configuration-cache
+    ./gradlew publishToMavenCentral
     ```
 
 === "gradle.properties"
@@ -358,11 +352,5 @@ For automatic publishing use one of the following options
 
     To publish use
     ```sh
-    ./gradlew publishToMavenCentral --no-configuration-cache
+    ./gradlew publishToMavenCentral
     ```
-
-!!! note "Configuration cache"
-
-    Configuration caching when uploading releases is currently not possible. Supporting it is
-    blocked by [Gradle issue #22779](https://github.com/gradle/gradle/issues/22779).
-

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/central/MavenCentralProject.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/central/MavenCentralProject.kt
@@ -1,5 +1,8 @@
 package com.vanniktech.maven.publish.central
 
+import java.io.File
+
 internal data class MavenCentralProject(
   val coordinates: MavenCentralCoordinates,
+  val localRepository: File,
 )

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
@@ -35,8 +35,7 @@ internal abstract class CreateSonatypeRepositoryTask : DefaultTask() {
   fun registerProject() {
     val localRepository = localRepository.asFile.get()
 
-    // delete local repository from previous publishing attempts to ensure only current files
-    // are published
+    // delete local repository from previous publishing attempts to ensure only current files are published.
     if (localRepository.exists()) {
       localRepository.deleteRecursively()
     }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/CreateSonatypeRepositoryTask.kt
@@ -1,10 +1,15 @@
 package com.vanniktech.maven.publish.sonatype
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
@@ -19,12 +24,24 @@ internal abstract class CreateSonatypeRepositoryTask : DefaultTask() {
   @get:Input
   abstract val version: Property<String>
 
+  @get:InputDirectory
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val localRepository: DirectoryProperty
+
   @get:Internal
   abstract val buildService: Property<SonatypeRepositoryBuildService>
 
   @TaskAction
   fun registerProject() {
-    buildService.get().registerProject(projectGroup.get(), artifactId.get(), version.get())
+    val localRepository = localRepository.asFile.get()
+
+    // delete local repository from previous publishing attempts to ensure only current files
+    // are published
+    if (localRepository.exists()) {
+      localRepository.deleteRecursively()
+    }
+
+    buildService.get().registerProject(projectGroup.get(), artifactId.get(), version.get(), localRepository)
   }
 
   companion object {
@@ -35,12 +52,14 @@ internal abstract class CreateSonatypeRepositoryTask : DefaultTask() {
       group: Provider<String>,
       artifactId: Provider<String>,
       version: Provider<String>,
+      localRepository: Provider<Directory>,
     ): TaskProvider<CreateSonatypeRepositoryTask> = register(NAME, CreateSonatypeRepositoryTask::class.java) {
       it.description = "Create a staging repository on Sonatype OSS"
       it.group = "release"
       it.projectGroup.set(group)
       it.artifactId.set(artifactId)
       it.version.set(version)
+      it.localRepository.set(localRepository)
       it.buildService.set(buildService)
       it.usesService(buildService)
     }


### PR DESCRIPTION
- Each project publishes to a local directory in its own build folder
- Each project reports that folder to the build service
- When reporting the folder it also passes the version and we ignore snapshots
- The build service collects the artifacts from all reported folders

Advantages
- Configuration cache for publishing is now fully supported because we don't rely on setUrl being lazy anymore (closes #259)
- Supports some artifacts having a final and some having a SNASPHOT and some a final version. Only the final ones will be uploaded to Central Portal (closes #728, closes #978)

Other
- Instead of having a UUID for the publishing repo dir CreateStagingRepositoryTask will now just delete the local folder to ensure its fresh every time
