### PR TITLE
Revert "Retry flaky tests on CI"

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -183,15 +183,6 @@ val integrationTest by tasks.registering(Test::class) {
       logger.lifecycle("Running test: ${this.className} ${this.displayName}")
     },
   )
-
-  develocity {
-    testRetry {
-      if (providers.environmentVariable("CI").isPresent) {
-        maxRetries = 2
-        maxFailures = 10
-      }
-    }
-  }
 }
 
 val quickIntegrationTest by tasks.registering {


### PR DESCRIPTION
The retry is useless for

```
* What went wrong:
Error resolving plugin [id: 'org.jetbrains.kotlin.jvm', version: '2.2.20-Beta1']
> Could not resolve all dependencies for configuration 'detachedConfiguration1'.
   > Timeout waiting to lock artifact cache (/home/runner/work/gradle-maven-publish-plugin/gradle-maven-publish-plugin/plugin/build/tmp/integrationTest/work/.gradle-test-kit/caches/modules-2). It is currently in use by this Gradle process.Owner Operation: unknown
    Our operation:
    Lock file: /home/runner/work/gradle-maven-publish-plugin/gradle-maven-publish-plugin/plugin/build/tmp/integrationTest/work/.gradle-test-kit/caches/modules-2/modules-2.lock
```

We can avoid these failures by not sharing `testKitDir`, which will slow down tests. I'm looking for another solution.

Reverts #1067.

---

- [ ] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
