### PR TITLE
Public `open` plugins and tasks could be `abstract`

### DIFF
--- a/plugin/api/plugin.api
+++ b/plugin/api/plugin.api
@@ -178,13 +178,13 @@ public abstract class com/vanniktech/maven/publish/MavenPublishBaseExtension {
 	public final fun signAllPublications ()V
 }
 
-public class com/vanniktech/maven/publish/MavenPublishBasePlugin : org/gradle/api/Plugin {
+public abstract class com/vanniktech/maven/publish/MavenPublishBasePlugin : org/gradle/api/Plugin {
 	public fun <init> ()V
 	public synthetic fun apply (Ljava/lang/Object;)V
 	public fun apply (Lorg/gradle/api/Project;)V
 }
 
-public class com/vanniktech/maven/publish/MavenPublishPlugin : org/gradle/api/Plugin {
+public abstract class com/vanniktech/maven/publish/MavenPublishPlugin : org/gradle/api/Plugin {
 	public fun <init> ()V
 	public synthetic fun apply (Ljava/lang/Object;)V
 	public fun apply (Lorg/gradle/api/Project;)V
@@ -203,7 +203,7 @@ public final class com/vanniktech/maven/publish/VersionCatalog : com/vanniktech/
 	public fun hashCode ()I
 }
 
-public class com/vanniktech/maven/publish/tasks/JavadocJar : org/gradle/jvm/tasks/Jar {
+public abstract class com/vanniktech/maven/publish/tasks/JavadocJar : org/gradle/jvm/tasks/Jar {
 	public fun <init> ()V
 }
 

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBasePlugin.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBasePlugin.kt
@@ -5,7 +5,7 @@ import org.gradle.api.Project
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin as GradleMavenPublishPlugin
 import org.gradle.util.GradleVersion
 
-public open class MavenPublishBasePlugin : Plugin<Project> {
+public abstract class MavenPublishBasePlugin : Plugin<Project> {
   override fun apply(project: Project) {
     project.plugins.apply(GradleMavenPublishPlugin::class.java)
 

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -3,7 +3,7 @@ package com.vanniktech.maven.publish
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-public open class MavenPublishPlugin : Plugin<Project> {
+public abstract class MavenPublishPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     project.plugins.apply(MavenPublishBasePlugin::class.java)
     val baseExtension = project.baseExtension

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocJar.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/tasks/JavadocJar.kt
@@ -10,7 +10,7 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.tasks.Jar
 
 @CacheableTask
-public open class JavadocJar : Jar() {
+public abstract class JavadocJar : Jar() {
   init {
     archiveClassifier.set("javadoc")
   }


### PR DESCRIPTION
---

- [ ] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
