### PR TITLE
use temporary test-kit-dir

### DIFF
--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
@@ -32,6 +32,7 @@ fun ProjectSpec.run(fixtures: Path, temp: Path, options: TestOptions): ProjectRe
     .withProjectDir(project.toFile())
     .withDebug(true)
     .withArguments(arguments)
+    .withTestKitDir(temp.resolve("test-kit-dir").toFile())
     .build()
 
   return ProjectResult(


### PR DESCRIPTION
This will put the test kit directory into the temporary folder of each test. This is slower because it will re-download dependecies/gradle for individual tests but it solves the GHA runners running out of space because of this directory getting to big (seems to be mostly transform caches that take up space).