### PR TITLE
Fail publishing if SONATYPE_HOST is not set to CENTRAL_PORTAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add support for publishing Kotlin Multiplatform libraries that use `com.android.kotlin.multiplatform.library`.
 - Raise minimum Gradle version to 8.13
+- Fail publishing if `SONATYPE_HOST` is not set to `CENTRAL_PORTAL`.
 
 
 #### Minimum supported versions

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishPlugin.kt
@@ -39,7 +39,16 @@ public abstract class MavenPublishPlugin : Plugin<Project> {
     if (central != null) {
       return central.toBoolean()
     }
-    return providers.gradleProperty("SONATYPE_HOST").orNull == "CENTRAL_PORTAL"
+    return when (providers.gradleProperty("SONATYPE_HOST").orNull) {
+      null -> false
+      "CENTRAL_PORTAL" -> true
+      else -> error(
+        """
+        OSSRH was shut down on June 30, 2025. Migrate to CENTRAL_PORTAL instead.
+        See more info at https://central.sonatype.org/news/20250326_ossrh_sunset.
+        """.trimIndent(),
+      )
+    }
   }
 
   private fun Project.automaticRelease(): Boolean {


### PR DESCRIPTION
Closes #1108.

---

- [x] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
