### PR TITLE
Add extra indents for the changelog items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@
   instructions if you haven't upgraded yet.
     - `SonatypeHost` has been removed from the DSL.
     - `SONATYPE_HOST` only supports `CENTRAL_PORTAL` now. It's recommended to use the following properties instead:
-      - `mavenCentralPublishing=true` replaces `SONATYPE_HOST=CENTRAL_PORTAL`.
-      - `mavenCentralAutomaticPublishing=true` replaces `SONATYPE_AUTOMATIC_RELEASE=true`.
+        - `mavenCentralPublishing=true` replaces `SONATYPE_HOST=CENTRAL_PORTAL`.
+        - `mavenCentralAutomaticPublishing=true` replaces `SONATYPE_AUTOMATIC_RELEASE=true`.
 - Update the Central Portal Publisher APIs to the latest.
 - It's now possible to mix SNAPSHOT versions and release versions when running `publish` tasks.
 - Fixed Gradle's deprecation warning caused by invalid URI.


### PR DESCRIPTION
Needs extra 4-space indents for MkDocs but 2-space indents for GFM.

Before:

<img width="1528" height="507" alt="image" src="https://github.com/user-attachments/assets/5546708b-cc3e-4a85-853c-11d8fd8b0d63" />

After:

<img width="1407" height="507" alt="image" src="https://github.com/user-attachments/assets/9a314b5a-0ae6-4e0f-ad45-8972dab685d2" />


---

- [ ] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
