### PR TITLE
Pin Java release on 11

### DIFF
--- a/build-logic/src/main/kotlin/shared.gradle.kts
+++ b/build-logic/src/main/kotlin/shared.gradle.kts
@@ -17,11 +17,6 @@ repositories {
   google()
 }
 
-java {
-  sourceCompatibility = JavaVersion.VERSION_11
-  targetCompatibility = JavaVersion.VERSION_11
-}
-
 kotlin {
   explicitApi()
   @OptIn(ExperimentalAbiValidation::class)
@@ -30,10 +25,17 @@ kotlin {
   }
 }
 
+tasks.withType<JavaCompile>().configureEach {
+  options.release = libs.versions.jdkRelease
+    .get()
+    .toInt()
+}
+
 tasks.withType(KotlinCompile::class.java) {
   compilerOptions {
-    jvmTarget.set(JvmTarget.JVM_11)
+    jvmTarget.set(JvmTarget.fromTarget(libs.versions.jdkRelease.get()))
     languageVersion.set(KotlinVersion.KOTLIN_1_8)
+    freeCompilerArgs.add("-Xjdk-release=${libs.versions.jdkRelease.get()}")
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,6 @@
 [versions]
+jdkRelease = "11"
+
 gradle = "8.14.3"
 
 kotlin = "2.2.0"


### PR DESCRIPTION
Syncs from https://github.com/GradleUp/shadow/pull/1490.

---

- [ ] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
