### PR TITLE
make plugin compatible with Gradle 9.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED](https://github.com/vanniktech/gradle-maven-publish-plugin/compare/0.34.0...HEAD) *(2025-xx-xx)*
 
 - Add support for publishing Kotlin Multiplatform libraries that use `com.android.kotlin.multiplatform.library`.
+- Fix issue when using Gradle 9.2.0 in projects that use `java-test-fixtures`
 - Raise minimum Gradle version to 8.13
 - Do not unconditionally disable DocLint
 - Fail publishing if `SONATYPE_HOST` is not set to `CENTRAL_PORTAL`.
@@ -18,6 +19,7 @@
 - JDK 24
 - Gradle 8.14.3
 - Gradle 9.1.0
+- Gradle 9.2.0-milestone-2
 - Android Gradle Plugin 8.11.1
 - Android Gradle Plugin 8.12.0-rc01
 - Kotlin Gradle Plugin 2.2.20

--- a/gradle/alpha.versions.toml
+++ b/gradle/alpha.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-gradle = "9.1.0"
+gradle = "9.2.0-milestone-2"
 
 kotlin = "2.2.20"
 

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/workaround/TestFixtures.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/workaround/TestFixtures.kt
@@ -3,15 +3,17 @@
 package com.vanniktech.maven.publish.workaround
 
 import com.vanniktech.maven.publish.baseExtension
+import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.attributes.DocsType
+import org.gradle.api.component.AdhocComponentWithVariants
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.plugins.internal.JavaConfigurationVariantMapping
-import org.gradle.api.plugins.internal.JavaPluginHelper
 import org.gradle.api.plugins.internal.JvmPluginsHelper
+import org.gradle.api.provider.Provider
 import org.gradle.internal.component.external.model.ProjectDerivedCapability
-import org.gradle.jvm.component.internal.DefaultJvmSoftwareComponent
 import org.gradle.util.GradleVersion
 
 /**
@@ -32,18 +34,47 @@ internal fun addTestFixturesSourcesJar(project: Project) {
     ProjectDerivedCapability::class.java.getConstructor(Project::class.java, String::class.java)
   }.newInstance(projectInternal, "testFixtures")
 
-  val sourceElements = JvmPluginsHelper.createDocumentationVariantWithArtifact(
-    testFixturesSourceSet.sourcesElementsConfigurationName,
-    testFixtureSourceSetName,
-    DocsType.SOURCES,
-    setOf(projectDerivedCapability),
-    testFixturesSourceSet.sourcesJarTaskName,
-    testFixturesSourceSet.allSource,
-    projectInternal,
-  )
+  // use reflection because return type changed in Gradle 9.2.0-milestone-1
+  val sourceElements = JvmPluginsHelper::class.java
+    .getMethod(
+      "createDocumentationVariantWithArtifact",
+      String::class.java,
+      String::class.java,
+      String::class.java,
+      Set::class.java,
+      String::class.java,
+      Object::class.java,
+      ProjectInternal::class.java,
+    ).invoke(
+      null,
+      testFixturesSourceSet.sourcesElementsConfigurationName,
+      testFixtureSourceSetName,
+      DocsType.SOURCES,
+      setOf(projectDerivedCapability),
+      testFixturesSourceSet.sourcesJarTaskName,
+      testFixturesSourceSet.allSource,
+      projectInternal,
+    )
 
-  val component = JavaPluginHelper.getJavaComponent(project) as DefaultJvmSoftwareComponent
-  component.addVariantsFromConfiguration(sourceElements, JavaConfigurationVariantMapping("compile", true))
+  // the following is not using private APIs just needs to adapt to the API change in the method above
+  val component = project.components.findByName("java") as AdhocComponentWithVariants
+  if (GradleVersion.current() >= GradleVersion.version("9.2.0-milestone-1")) {
+    AdhocComponentWithVariants::class.java.getMethod(
+      "addVariantsFromConfiguration",
+      Provider::class.java,
+      Action::class.java,
+    )
+  } else {
+    AdhocComponentWithVariants::class.java.getMethod(
+      "addVariantsFromConfiguration",
+      Configuration::class.java,
+      Action::class.java,
+    )
+  }.invoke(
+    component,
+    sourceElements,
+    JavaConfigurationVariantMapping("compile", true),
+  )
 }
 
 /**


### PR DESCRIPTION
Adapts used internal APIs to changes in 9.2.0 https://github.com/gradle/gradle/commit/5728383e47c13eba4ac8d2e1a30e86e166b8fb3e

closes #1139
