### PR TITLE
update message for not found Android variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Raise minimum Gradle version to 8.13
 - Do not unconditionally disable DocLint
 - Fail publishing if `SONATYPE_HOST` is not set to `CENTRAL_PORTAL`.
+- Fix misleading error message when Android library variant is not found.
 - Downgrade transitive OkHttp version.
 
 #### Minimum supported versions

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -574,6 +574,7 @@ private class MissingVariantException(
   name: String,
 ) : RuntimeException(
     "Invalid MavenPublish Configuration. Unable to find variant to publish named $name." +
-      " Try setting the 'androidVariantToPublish' property in the mavenPublish" +
-      " extension object to something that matches the variant that ought to be published.",
+      " By default the publish plugin will publish the variant called \"release\". To modify this behavior" +
+      " either call configure(AndroidSingleVariantLibrary(\"variant-to-publish\")) or " +
+      " configure(AndroidMultiVariantLibrary()) to publish all flavors.",
   )


### PR DESCRIPTION
See #1141. The mentioned property doesn't exist anymore. 

---

- [x] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
