### PR TITLE
Add edit button to pages in documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_url: https://vanniktech.github.io/gradle-maven-publish-plugin/
 repo_name: gradle-maven-publish-plugin
 repo_url: https://github.com/vanniktech/gradle-maven-publish-plugin
 site_author: Niklas Baudy
+edit_uri: edit/main/docs
 
 copyright: 'Copyright (C) 2018 Vanniktech - Niklas Baudy'
 
@@ -17,6 +18,7 @@ theme:
     - navigation.tabs
     - content.tabs.link
     - toc.integrate
+    - content.action.edit
 
 nav:
   - 'index.md'


### PR DESCRIPTION
This adds a button to the documentation that takes you straight to GitHub to edit a page.

<img width="183" height="152" alt="image" src="https://github.com/user-attachments/assets/b1c2ef21-d14d-4010-85aa-786f070ee451" />
https://github.com/vanniktech/gradle-maven-publish-plugin/edit/main/docs/central.md