### PR TITLE
Remove usages of ImmutableList

### DIFF
--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptionsProvider.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/TestOptionsProvider.kt
@@ -1,50 +1,49 @@
 package com.vanniktech.maven.publish
 
-import com.google.common.collect.ImmutableList
 import com.google.testing.junit.testparameterinjector.junit5.TestParameterValuesProvider
 import com.vanniktech.maven.publish.IntegrationTestBuildConfig.QUICK_TEST
 import com.vanniktech.maven.publish.IntegrationTestBuildConfig.TEST_CONFIG_METHOD
 
 internal class TestOptionsConfigProvider : TestParameterValuesProvider() {
   override fun provideValues(context: Context?): List<*> = when {
-    QUICK_TEST -> ImmutableList.of(TestOptions.Config.BASE)
-    TEST_CONFIG_METHOD.isNotBlank() -> ImmutableList.of(TestOptions.Config.valueOf(TEST_CONFIG_METHOD))
-    else -> ImmutableList.copyOf(TestOptions.Config.values())
+    QUICK_TEST -> listOf(TestOptions.Config.BASE)
+    TEST_CONFIG_METHOD.isNotBlank() -> listOf(TestOptions.Config.valueOf(TEST_CONFIG_METHOD))
+    else -> TestOptions.Config.values().toList()
   }
 }
 
 internal class GradleVersionProvider : TestParameterValuesProvider() {
   override fun provideValues(context: Context?): List<*> {
     if (QUICK_TEST) {
-      return ImmutableList.of(GradleVersion.values().last())
+      return listOf(GradleVersion.values().last())
     }
-    return ImmutableList.copyOf(GradleVersion.values().distinctBy { it.value })
+    return GradleVersion.values().distinctBy { it.value }
   }
 }
 
 internal class AgpVersionProvider : TestParameterValuesProvider() {
   override fun provideValues(context: Context?): List<*> {
     if (QUICK_TEST) {
-      return ImmutableList.of(AgpVersion.values().last())
+      return listOf(AgpVersion.values().last())
     }
-    return ImmutableList.copyOf(AgpVersion.values().distinctBy { it.value })
+    return AgpVersion.values().distinctBy { it.value }
   }
 }
 
 internal class KotlinVersionProvider : TestParameterValuesProvider() {
   override fun provideValues(context: Context?): List<*> {
     if (QUICK_TEST) {
-      return ImmutableList.of(KotlinVersion.values().last())
+      return listOf(KotlinVersion.values().last())
     }
-    return ImmutableList.copyOf(KotlinVersion.values().distinctBy { it.value })
+    return KotlinVersion.values().distinctBy { it.value }
   }
 }
 
 internal class GradlePluginPublishVersionProvider : TestParameterValuesProvider() {
   override fun provideValues(context: Context?): List<*> {
     if (QUICK_TEST) {
-      return ImmutableList.of(GradlePluginPublish.values().last())
+      return listOf(GradlePluginPublish.values().last())
     }
-    return ImmutableList.copyOf(GradlePluginPublish.values().distinctBy { it.version })
+    return GradlePluginPublish.values().distinctBy { it.version }
   }
 }


### PR DESCRIPTION
No need to return `ImmutableList`s for `TestParameterValuesProvider`s.

---

- [ ] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
