### PR TITLE
Bump min Java requirement to 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,7 @@ jobs:
     strategy:
       matrix:
         test_java_version:
-          - 11 # Minimum supported version.
-          - 17 # Supported by all tests.
+          - 17 # Minimum supported version.
           - latest # Latest supported version, the value syncs with the .java-version file.
         test_config_method: ["DSL", "PROPERTIES", "BASE"]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## [UNRELEASED](https://github.com/vanniktech/gradle-maven-publish-plugin/compare/0.34.0...HEAD) *(2025-xx-xx)*
 
+- Bump min Java requirement to 17.
+
 #### Minimum supported versions
-- JDK 11
+- JDK 17
 - Gradle 8.13
 - Android Gradle Plugin 8.2.2
 - Kotlin Gradle Plugin 1.9.20

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-jdkRelease = "11"
+jdkRelease = "17"
 minGradle = "8.13"
 
 gradle = "9.2.0"

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -117,13 +117,6 @@ tasks.validatePlugins {
   enableStricterValidation = true
 }
 
-tasks.whenTaskAdded {
-  if (name.contains("lint") && this::class.java.name.contains("com.android.build")) {
-    // TODO: lints can be run on Java 17 or above, remove this once we bump the min Java version to 17.
-    enabled = JavaVersion.current() >= JavaVersion.VERSION_17
-  }
-}
-
 val integrationTest by tasks.registering(Test::class) {
   dependsOn(
     tasks.publishToMavenLocal,


### PR DESCRIPTION
Consider bumping the min Gradle requirement to 9.0.0 in a new PR.

---

- [x] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
