### PR TITLE
Don't find POM properties from project hierarchy when Isolated Projects is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix misleading error message when Android library variant is not found.
 - Downgrade transitive OkHttp version.
 - Add support for validating deployments to Central Portal
+- Don't check project heirarchy for POM properties when Isolated proejcts is enabled.
 
 #### Minimum supported versions
 - JDK 11

--- a/plugin/api/plugin.api
+++ b/plugin/api/plugin.api
@@ -163,7 +163,7 @@ public final class com/vanniktech/maven/publish/KotlinMultiplatform : com/vannik
 }
 
 public abstract class com/vanniktech/maven/publish/MavenPublishBaseExtension {
-	public fun <init> (Lorg/gradle/api/Project;Lorg/gradle/build/event/BuildEventsListenerRegistry;)V
+	public fun <init> (Lorg/gradle/api/Project;Lorg/gradle/build/event/BuildEventsListenerRegistry;Lorg/gradle/api/configuration/BuildFeatures;)V
 	public final fun configure (Lcom/vanniktech/maven/publish/Platform;)V
 	public final fun configureBasedOnAppliedPlugins ()V
 	public final fun configureBasedOnAppliedPlugins (Z)V


### PR DESCRIPTION
The current use of `findProperty()` sometimes causes isolated projects violations. This PR disables the hierarchal behavior and searches only the root properties via the provider api.

---

- [x] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
