### PR TITLE
Remove JsonClass annotation usage

### DIFF
--- a/central-portal/src/main/kotlin/com/vanniktech/maven/publish/portal/DeploymentStatus.kt
+++ b/central-portal/src/main/kotlin/com/vanniktech/maven/publish/portal/DeploymentStatus.kt
@@ -1,12 +1,9 @@
 package com.vanniktech.maven.publish.portal
 
-import com.squareup.moshi.JsonClass
-
 /**
  * Response from the Central Portal API status endpoint.
  * See https://central.sonatype.org/publish/publish-portal-api/#verify-status-of-the-deployment
  */
-@JsonClass(generateAdapter = true)
 internal data class DeploymentStatusResponse(
   val deploymentId: String,
   val deploymentName: String,


### PR DESCRIPTION
`DeploymentStatusResponse` is deserialized by the reflection instead of KSP, https://github.com/vanniktech/gradle-maven-publish-plugin/blob/229213487ed04cccbae8df21f18406ff610fb43a/central-portal/src/main/kotlin/com/vanniktech/maven/publish/portal/SonatypeCentralPortal.kt#L33

---

- [ ] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
