### PR TITLE
Fix Renovate config for matchPackageNames and use json5 for syntax

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,7 +10,8 @@
       "allowedVersions": "!/(-alpha|-Alpha|-ALPHA|-beta|-Beta|-BETA|-rc|-RC|-milestone|-m|-SNAPSHOT)/"
     },
     {
-      "groupName": "Retrofit",
+      // See https://github.com/vanniktech/gradle-maven-publish-plugin/issues/1131.
+      "groupName": "Retrofit and OkHttp",
       "enabled": false,
       "matchPackageNames": [
         "/com.squareup.retrofit2:*/",


### PR DESCRIPTION
Closes #1179.

---

- [ ] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
