### PR TITLE
fix test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         if: ${{ matrix.java_version != '11' }}
 
       - name: Build with Gradle
-        run: ./gradlew build --stacktrace -DtestJavaVersion=${{ matrix.java_version }} -DtestConfigMethod=${{ matrix.test_config_method }}
+        run: ./gradlew build --stacktrace -PtestJavaVersion=${{ matrix.java_version }} -PtestConfigMethod=${{ matrix.test_config_method }}
 
   # Status check that is required in branch protection rules.
   build-status:

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -130,7 +130,7 @@ val integrationTest by tasks.registering(Test::class) {
   testClassesDirs = integrationTestSourceSet.output.classesDirs
   classpath = integrationTestSourceSet.runtimeClasspath
 
-  val testJavaVersion = System.getProperty("testJavaVersion")
+  val testJavaVersion = providers.gradleProperty("testJavaVersion").orNull
   if (testJavaVersion != null) {
     javaLauncher = javaToolchains.launcherFor {
       languageVersion = JavaLanguageVersion.of(testJavaVersion.toInt())


### PR DESCRIPTION
#1173 changed to a Gradle property but the CI config was passing `testConfigMethod` as System property. meaning each shard was running all 3 methods. Also changed `testJavaVersion` to a Gradle property for consistency.