### PR TITLE
Clean up android extensions in tests

### DIFF
--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecs.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecs.kt
@@ -188,11 +188,6 @@ fun kotlinMultiplatformWithAndroidLibraryProjectSpec(agpVersion: AgpVersion, kot
       android {
         compileSdk = 34
         namespace = "com.test.library"
-
-        // resolves config cache issue, can be removed when AGP 8 becomes the minimum supported version
-        buildFeatures {
-            shaders = false
-        }
       }
 
       kotlin {


### PR DESCRIPTION
https://developer.android.com/build/releases/gradle-plugin#api-level-support

---

- [ ] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
