### PR TITLE
Clean up toolchain usages in tests

### DIFF
--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/JavaPluginTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/JavaPluginTest.kt
@@ -177,9 +177,7 @@ class JavaPluginTest : BasePluginTest() {
       buildFileExtra =
         """
         java {
-            toolchain {
-                languageVersion = JavaLanguageVersion.of(8)
-            }
+          toolchain.languageVersion = JavaLanguageVersion.of(11)
         }
         """.trimIndent(),
     )

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecs.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecs.kt
@@ -198,9 +198,7 @@ fun kotlinMultiplatformWithAndroidLibraryProjectSpec(agpVersion: AgpVersion, kot
       kotlin {
         androidTarget {}
 
-        jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("8"))
-        }
+        jvmToolchain(11)
       }
       """.trimIndent(),
     // TODO remove when removing support for AGP 8.x, spec should be merged
@@ -302,9 +300,7 @@ fun androidLibraryKotlinProjectSpec(agpVersion: AgpVersion, kotlinVersion: Kotli
       """
 
       kotlin {
-          jvmToolchain {
-              languageVersion.set(JavaLanguageVersion.of("8"))
-          }
+        jvmToolchain(11)
       }
       """.trimIndent(),
   )


### PR DESCRIPTION
Based on #1184.

---

- [ ] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
