### PR TITLE
Remove outdated org.gradle.vfs.watch flag

### DIFF
--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ProjectSpecRunner.kt
@@ -195,7 +195,6 @@ private fun writeSettingFile(path: Path) {
 private fun ProjectSpec.writeGradleProperties(path: Path, options: TestOptions) {
   path.writeText(
     buildString {
-      appendLine("org.gradle.vfs.watch=false")
       appendLine("kotlin.compiler.execution.strategy=in-process")
       appendLine("kotlin.jvm.target.validation.mode=ignore")
       appendLine("kotlin.mpp.androidSourceSetLayoutVersion1.nowarn=true")


### PR DESCRIPTION
It should be enabled by default.

---

- [ ] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
