### PR TITLE
Remove SonatypeHost from docs

### DIFF
--- a/docs/central.md
+++ b/docs/central.md
@@ -52,8 +52,6 @@ This can be done through either the DSL or by setting Gradle properties.
 === "build.gradle"
 
     ```groovy
-    import com.vanniktech.maven.publish.SonatypeHost
-
     mavenPublishing {
       publishToMavenCentral()
 
@@ -64,8 +62,6 @@ This can be done through either the DSL or by setting Gradle properties.
 === "build.gradle.kts"
 
     ```kotlin
-    import com.vanniktech.maven.publish.SonatypeHost
-
     mavenPublishing {
       publishToMavenCentral()
 


### PR DESCRIPTION
Closes #1221.

---

- [ ] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
