### PR TITLE
Mark DirectorySignatureType internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Removed support for Dokka v1, it's now required to use Dokka in v2 mode.
 - Removed deprecated option of selecting which Android variant to publish for KMP libraries.
 
+**BREAKING**
+- Mark `DirectorySignatureType` internal.
+
 #### Minimum supported versions
 - JDK 17
 - Gradle 9.0.0

--- a/plugin/api/plugin.api
+++ b/plugin/api/plugin.api
@@ -207,13 +207,3 @@ public abstract class com/vanniktech/maven/publish/tasks/JavadocJar : org/gradle
 	public fun <init> ()V
 }
 
-public final class com/vanniktech/maven/publish/workaround/DirectorySignatureType : org/gradle/plugins/signing/type/AbstractSignatureType {
-	public fun <init> (Lorg/gradle/plugins/signing/type/SignatureType;Lorg/gradle/api/provider/Provider;)V
-	public fun fileFor (Ljava/io/File;)Ljava/io/File;
-	public final fun getActual ()Lorg/gradle/plugins/signing/type/SignatureType;
-	public final fun getDirectory ()Lorg/gradle/api/provider/Provider;
-	public fun getExtension ()Ljava/lang/String;
-	public fun sign (Lorg/gradle/plugins/signing/signatory/Signatory;Ljava/io/File;)Ljava/io/File;
-	public fun sign (Lorg/gradle/plugins/signing/signatory/Signatory;Ljava/io/InputStream;Ljava/io/OutputStream;)V
-}
-

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/workaround/DirectorySignatureType.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/workaround/DirectorySignatureType.kt
@@ -19,11 +19,11 @@ import org.gradle.plugins.signing.type.SignatureType
  * https://youtrack.jetbrains.com/issue/KT-61313/
  * https://github.com/gradle/gradle/issues/26132
  */
-public class DirectorySignatureType(
+internal class DirectorySignatureType(
   @Nested
-  public val actual: SignatureType,
+  val actual: SignatureType,
   @Internal
-  public val directory: Provider<Directory>,
+  val directory: Provider<Directory>,
 ) : AbstractSignatureType() {
   override fun fileFor(toSign: File): File {
     val original = super.fileFor(toSign)


### PR DESCRIPTION
APIs under `com.vanniktech.maven.publish.workaround` package shouldn't be public.

https://vanniktech.github.io/gradle-maven-publish-plugin/api/plugin/com.vanniktech.maven.publish.workaround/index.html

---

- [x] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
