### PR TITLE
Support passing lazy properties to MavenPublishBaseExtension.coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Updated minimum supported JDK, Gradle, Android Gradle Plugin and Kotlin versions.
 - Removed support for Dokka v1, it's now required to use Dokka in v2 mode.
 - Removed deprecated option of selecting which Android variant to publish for KMP libraries.
+- Support passing lazy properties to `MavenPublishBaseExtension.coordinates(...)`.
 
 **BREAKING**
 - Mark `DirectorySignatureType` internal.

--- a/plugin/api/plugin.api
+++ b/plugin/api/plugin.api
@@ -177,7 +177,9 @@ public abstract class com/vanniktech/maven/publish/MavenPublishBaseExtension {
 	public final fun configureBasedOnAppliedPlugins (ZZ)V
 	public static synthetic fun configureBasedOnAppliedPlugins$default (Lcom/vanniktech/maven/publish/MavenPublishBaseExtension;ZLcom/vanniktech/maven/publish/JavadocJar;ILjava/lang/Object;)V
 	public final fun coordinates (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun coordinates (Lorg/gradle/api/provider/Provider;Lorg/gradle/api/provider/Provider;Lorg/gradle/api/provider/Provider;)V
 	public static synthetic fun coordinates$default (Lcom/vanniktech/maven/publish/MavenPublishBaseExtension;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun coordinates$default (Lcom/vanniktech/maven/publish/MavenPublishBaseExtension;Lorg/gradle/api/provider/Provider;Lorg/gradle/api/provider/Provider;Lorg/gradle/api/provider/Provider;ILjava/lang/Object;)V
 	public final fun pom (Lorg/gradle/api/Action;)V
 	public final fun pomFromGradleProperties ()V
 	public final fun publishToMavenCentral ()V

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -13,6 +13,7 @@ import org.gradle.api.configuration.BuildFeatures
 import org.gradle.api.credentials.PasswordCredentials
 import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
@@ -189,8 +190,14 @@ public abstract class MavenPublishBaseExtension @Inject constructor(
     version?.also { version(it) }
   }
 
-  private fun groupId(groupId: String) {
-    this.groupId.set(groupId)
+  public fun coordinates(groupId: Provider<String>? = null, artifactId: Provider<String>? = null, version: Provider<String>? = null) {
+    groupId?.also { groupId(it) }
+    artifactId?.also { artifactId(it) }
+    version?.also { version(it) }
+  }
+
+  private fun groupId(groupId: Any) {
+    this.groupId.setAny(groupId)
     this.groupId.finalizeValueOnRead()
 
     // skip the plugin marker artifact which has its own group id based on the plugin id
@@ -199,8 +206,8 @@ public abstract class MavenPublishBaseExtension @Inject constructor(
     }
   }
 
-  private fun artifactId(artifactId: String) {
-    this.artifactId.set(artifactId)
+  private fun artifactId(artifactId: Any) {
+    this.artifactId.setAny(artifactId)
     this.artifactId.finalizeValueOnRead()
 
     // skip the plugin marker artifact which has its own artifact id based on the plugin id
@@ -209,10 +216,10 @@ public abstract class MavenPublishBaseExtension @Inject constructor(
       if (project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")) {
         // needed to avoid the mpp plugin writing over our artifact ids
         project.afterEvaluate { project ->
-          it.artifactId = artifactId.forMultiplatform(it, project)
+          it.artifactId = this.artifactId.get().forMultiplatform(it, project)
         }
       } else {
-        it.artifactId = artifactId
+        it.artifactId = this.artifactId.get()
       }
     }
   }
@@ -233,8 +240,8 @@ public abstract class MavenPublishBaseExtension @Inject constructor(
     }
   }
 
-  private fun version(version: String) {
-    this.version.set(version)
+  private fun version(version: Any) {
+    this.version.setAny(version)
     this.version.finalizeValueOnRead()
 
     project.mavenPublications {

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Properties.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Properties.kt
@@ -2,6 +2,8 @@ package com.vanniktech.maven.publish
 
 import kotlin.text.toBoolean
 import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 
 internal fun Project.mavenCentralPublishing(): Boolean {
   val central = providers.gradleProperty("mavenCentralPublishing").orNull
@@ -42,4 +44,16 @@ internal fun Project.signAllPublications(): Boolean {
     return sign.toBoolean()
   }
   return providers.gradleProperty("RELEASE_SIGNING_ENABLED").getOrElse("false").toBoolean()
+}
+
+internal inline fun <reified T : Any> Property<T>.setAny(
+  value: Any,
+  lazyMessage: () -> Any = { "value must be a ${T::class.java} or Provider<T>" },
+) {
+  @Suppress("UNCHECKED_CAST")
+  when (value) {
+    is Provider<*> -> set(value as Provider<T>)
+    is T -> set(value)
+    else -> throw IllegalArgumentException(lazyMessage().toString())
+  }
 }


### PR DESCRIPTION
Closes #1220.

---

- [x] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
