### PR TITLE
Polish the doc sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ local.properties
 
 ### MkDocs ###
 docs/api
-site
-
-# file is copied automatically based on the readme
+docs/changelog.md
 docs/index.md
+site

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,12 +10,27 @@ copyright: 'Copyright (C) 2018 Vanniktech - Niklas Baudy'
 theme:
   name: 'material'
   palette:
-    primary: 'cyan'
-    accent: 'purple'
+    - media: '(prefers-color-scheme: light)'
+      scheme: default
+      primary: 'white'
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: '(prefers-color-scheme: dark)'
+      scheme: slate
+      primary: 'black'
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  font:
+    text: 'Lato'
+    code: 'JetBrains Mono'
   features:
     - navigation.sections
     - navigation.tracking
     - navigation.tabs
+    - content.code.copy
+    - content.code.select
     - content.tabs.link
     - toc.integrate
     - content.action.edit


### PR DESCRIPTION
Support light/dark themes, custom fonts, code copying, and so on. Copied the configs mostly from https://github.com/GradleUp/shadow/blob/c4c6e5db49ff36f6c6c937218b196747991281b1/mkdocs.yml#L12-L34.

<img width="1863" height="759" alt="image" src="https://github.com/user-attachments/assets/3f771e42-766e-467c-9946-4f55a7e4b498" />
<img width="1863" height="762" alt="image" src="https://github.com/user-attachments/assets/5db0ed46-62f5-44c2-80fa-423f8939527a" />


---

- [ ] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
