### PR TITLE
Allow setting Maven Central credentials via project extra properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [UNRELEASED](https://github.com/vanniktech/gradle-maven-publish-plugin/compare/0.36.0...HEAD) *(2026-xx-xx)*
 
+**Features**
+
+- `mavenCentralUsername` / `mavenCentralPassword` can now also be set via `extra["mavenCentralUsername"]` /
+  `extra["mavenCentralPassword"]` on the project, in addition to the existing Gradle property sources
+  (`gradle.properties`, `-P`, `ORG_GRADLE_PROJECT_*`). Gradle properties still take precedence, the extras
+  lookup is only used as a fallback. This makes it possible to set credentials from a secret manager inside
+  the build script.
 
 #### Minimum supported versions
 - JDK 17

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenCentralCredentialsTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/MavenCentralCredentialsTest.kt
@@ -1,0 +1,156 @@
+package com.vanniktech.maven.publish
+
+import com.google.common.truth.Truth.assertThat
+import com.google.testing.junit.testparameterinjector.junit5.TestParameter
+import com.google.testing.junit.testparameterinjector.junit5.TestParameterInjectorTest
+import com.vanniktech.maven.publish.util.GradleVersion
+import com.vanniktech.maven.publish.util.GradleVersionProvider
+import com.vanniktech.maven.publish.util.assumeSupportedJdkVersion
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.io.TempDir
+
+class MavenCentralCredentialsTest {
+  @TempDir
+  lateinit var testProjectDir: Path
+
+  @TestParameterInjectorTest
+  fun missingCredentialsFailWithHelpfulMessage(
+    @TestParameter(valuesProvider = GradleVersionProvider::class) gradleVersion: GradleVersion,
+  ) {
+    gradleVersion.assumeSupportedJdkVersion()
+
+    val result = runner(gradleVersion).buildAndFail()
+
+    assertThat(result.output).contains("mavenCentralUsername not found")
+  }
+
+  @TestParameterInjectorTest
+  fun credentialsFromGradleProperties(
+    @TestParameter(valuesProvider = GradleVersionProvider::class) gradleVersion: GradleVersion,
+  ) {
+    gradleVersion.assumeSupportedJdkVersion()
+
+    val result = runner(gradleVersion, gradleProperties = CREDENTIALS).build()
+
+    assertThat(result.task(TASK)?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+  }
+
+  @TestParameterInjectorTest
+  fun credentialsFromCommandLineProperty(
+    @TestParameter(valuesProvider = GradleVersionProvider::class) gradleVersion: GradleVersion,
+  ) {
+    gradleVersion.assumeSupportedJdkVersion()
+
+    val result = runner(gradleVersion, commandLineProperties = CREDENTIALS).build()
+
+    assertThat(result.task(TASK)?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+  }
+
+  @TestParameterInjectorTest
+  fun credentialsFromEnvironmentVariable(
+    @TestParameter(valuesProvider = GradleVersionProvider::class) gradleVersion: GradleVersion,
+  ) {
+    gradleVersion.assumeSupportedJdkVersion()
+
+    val environment = CREDENTIALS.mapKeys { "ORG_GRADLE_PROJECT_${it.key}" }
+    val result = runner(gradleVersion, environmentVariables = environment).build()
+
+    assertThat(result.task(TASK)?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+  }
+
+  @TestParameterInjectorTest
+  fun credentialsFromProjectExtraProperties(
+    @TestParameter(valuesProvider = GradleVersionProvider::class) gradleVersion: GradleVersion,
+  ) {
+    gradleVersion.assumeSupportedJdkVersion()
+
+    val result = runner(gradleVersion, extraProperties = CREDENTIALS).build()
+
+    assertThat(result.task(TASK)?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+  }
+
+  @TestParameterInjectorTest
+  fun credentialsResolveWhenSetInBothGradlePropertyAndExtra(
+    @TestParameter(valuesProvider = GradleVersionProvider::class) gradleVersion: GradleVersion,
+  ) {
+    gradleVersion.assumeSupportedJdkVersion()
+
+    val result = runner(gradleVersion, gradleProperties = CREDENTIALS, extraProperties = CREDENTIALS).build()
+
+    assertThat(result.task(TASK)?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+  }
+
+  private fun runner(
+    gradleVersion: GradleVersion,
+    gradleProperties: Map<String, String> = emptyMap(),
+    commandLineProperties: Map<String, String> = emptyMap(),
+    environmentVariables: Map<String, String> = emptyMap(),
+    extraProperties: Map<String, String> = emptyMap(),
+  ): GradleRunner {
+    testProjectDir.resolve("settings.gradle").writeText(
+      """
+      pluginManagement {
+        repositories {
+          mavenLocal()
+          mavenCentral()
+          gradlePluginPortal()
+        }
+      }
+
+      rootProject.name = "test-project"
+      """.trimIndent(),
+    )
+
+    val extraBlock = extraProperties.entries.joinToString(separator = "\n") { "ext[\"${it.key}\"] = \"${it.value}\"" }
+    testProjectDir.resolve("build.gradle").writeText(
+      """
+      plugins {
+        id "com.vanniktech.maven.publish.base" version "${IntegrationTestBuildConfig.VERSION_NAME}"
+      }
+
+      group = "com.example"
+      version = "1.0.0-SNAPSHOT"
+
+      $extraBlock
+
+      mavenPublishing {
+        publishToMavenCentral()
+      }
+      """.trimIndent(),
+    )
+
+    testProjectDir.resolve("gradle.properties").writeText(
+      buildString {
+        appendLine("org.gradle.vfs.watch=false")
+        gradleProperties.forEach { appendLine("${it.key}=${it.value}") }
+      },
+    )
+
+    val arguments = mutableListOf(TASK, "--stacktrace", "--configuration-cache")
+    commandLineProperties.forEach { arguments += "-P${it.key}=${it.value}" }
+
+    val environment = System.getenv().filterKeys { it !in CREDENTIAL_ENVIRONMENT_VARIABLES } + environmentVariables
+
+    return GradleRunner
+      .create()
+      .withGradleVersion(gradleVersion.value)
+      .withProjectDir(testProjectDir.toFile())
+      .withDebug(false)
+      .withEnvironment(environment)
+      .withArguments(arguments)
+  }
+
+  private companion object {
+    const val TASK = ":prepareMavenCentralPublishing"
+
+    val CREDENTIALS = mapOf(
+      "mavenCentralUsername" to "username",
+      "mavenCentralPassword" to "password",
+    )
+
+    val CREDENTIAL_ENVIRONMENT_VARIABLES = CREDENTIALS.keys.map { "ORG_GRADLE_PROJECT_$it" }.toSet()
+  }
+}

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -13,6 +13,7 @@ import org.gradle.api.configuration.BuildFeatures
 import org.gradle.api.credentials.PasswordCredentials
 import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
@@ -120,8 +121,8 @@ public abstract class MavenPublishBaseExtension @Inject constructor(
     }
 
     val buildService = project.registerMavenCentralBuildService(
-      repositoryUsername = project.providers.gradleProperty("mavenCentralUsername"),
-      repositoryPassword = project.providers.gradleProperty("mavenCentralPassword"),
+      repositoryUsername = credentialProperty("mavenCentralUsername"),
+      repositoryPassword = credentialProperty("mavenCentralPassword"),
       rootBuildDirectory = @Suppress("UnstableApiUsage") project.layout.settingsDirectory.dir("build"),
       buildEventsListenerRegistry = buildEventsListenerRegistry,
     )
@@ -480,4 +481,11 @@ public abstract class MavenPublishBaseExtension @Inject constructor(
     val extras = checkNotNull(project.extensions.findByType(ExtraPropertiesExtension::class.java))
     return if (extras.has(propertyName)) extras.get(propertyName)?.toString() else null
   }
+
+  // Resolves a credential value from a Gradle property, falling back to a value set on the
+  // extra properties of the project (for example set by extra["mavenCentralUsername"] = ...).
+  private fun credentialProperty(propertyName: String): Provider<String> =
+    project.providers.gradleProperty(propertyName).orElse(
+      project.provider { findOptionalProperty(propertyName) },
+    )
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -484,8 +484,7 @@ public abstract class MavenPublishBaseExtension @Inject constructor(
 
   // Resolves a credential value from a Gradle property, falling back to a value set on the
   // extra properties of the project (for example set by extra["mavenCentralUsername"] = ...).
-  private fun credentialProperty(propertyName: String): Provider<String> =
-    project.providers.gradleProperty(propertyName).orElse(
-      project.provider { findOptionalProperty(propertyName) },
-    )
+  private fun credentialProperty(propertyName: String): Provider<String> = project.providers.gradleProperty(propertyName).orElse(
+    project.provider { findOptionalProperty(propertyName) },
+  )
 }


### PR DESCRIPTION
`mavenCentralUsername` / `mavenCentralPassword` can now also be set via `extra["mavenCentralUsername"]` / `extra["mavenCentralPassword"]` on the project, in addition to the existing Gradle property sources (`gradle.properties`, `-P`, `ORG_GRADLE_PROJECT_*`). Gradle properties still take precedence, the extras lookup is only used as a fallback. This makes it possible to set credentials from a secret manager inside the build script.

Fixes #798
Fixes #887
Refs #281, #459, #1161

---

- [x] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
