### PR TITLE
Exclude unneccessary checksum files when publishing to Maven Central

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [UNRELEASED](https://github.com/vanniktech/gradle-maven-publish-plugin/compare/0.36.0...HEAD) *(2026-xx-xx)*
 
+- When publishing to Maven Central, redundant checksum files are now excluded by default: checksums of `.asc`
+  signature files ([gradle/gradle#20232](https://github.com/gradle/gradle/issues/20232)) and the `sha256`/`sha512`
+  checksums, which are never read by Gradle or Maven Central. The published checksums can be configured through
+  `checksums(...)` in the DSL or the `mavenCentralChecksums` Gradle property (default `md5,sha1`). Signature checksum
+  exclusion can be controlled through `excludeSignatureChecksums()` or the `mavenCentralExcludeSignatureChecksums`
+  Gradle property.
 
 #### Minimum supported versions
 - JDK 17

--- a/docs/central.md
+++ b/docs/central.md
@@ -77,6 +77,45 @@ This can be done through either the DSL or by setting Gradle properties.
     signAllPublications=true
     ```
 
+## Redundant checksum files
+
+Gradle generates a `md5`, `sha1`, `sha256` and `sha512` checksum for every
+published file, including for the `.asc` signature files. Maven Central does not
+need most of these, so by default the plugin:
+
+* excludes checksums of signature files (`.asc.md5`, `.asc.sha1`, `.asc.sha256`,
+  `.asc.sha512`), see [gradle/gradle#20232](https://github.com/gradle/gradle/issues/20232)
+* only publishes `md5` and `sha1` checksums, as `sha256` and `sha512` are never
+  read by Gradle or Maven Central
+
+The set of published checksums can be changed and the signature checksum
+exclusion can be turned off if needed.
+
+=== "build.gradle"
+
+    ```groovy
+    mavenPublishing {
+      checksums(Checksum.MD5, Checksum.SHA1, Checksum.SHA256, Checksum.SHA512)
+      excludeSignatureChecksums(false)
+    }
+    ```
+
+=== "build.gradle.kts"
+
+    ```kotlin
+    mavenPublishing {
+      checksums(Checksum.MD5, Checksum.SHA1, Checksum.SHA256, Checksum.SHA512)
+      excludeSignatureChecksums(false)
+    }
+    ```
+
+=== "gradle.properties"
+
+    ```properties
+    mavenCentralChecksums=md5,sha1,sha256,sha512
+    mavenCentralExcludeSignatureChecksums=false
+    ```
+
 ## Configuring the POM
 
 The pom is published alongside the project and contains the project coordinates

--- a/plugin/api/plugin.api
+++ b/plugin/api/plugin.api
@@ -56,6 +56,16 @@ public final class com/vanniktech/maven/publish/AndroidSingleVariantLibrary : co
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/vanniktech/maven/publish/Checksum : java/lang/Enum {
+	public static final field MD5 Lcom/vanniktech/maven/publish/Checksum;
+	public static final field SHA1 Lcom/vanniktech/maven/publish/Checksum;
+	public static final field SHA256 Lcom/vanniktech/maven/publish/Checksum;
+	public static final field SHA512 Lcom/vanniktech/maven/publish/Checksum;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/vanniktech/maven/publish/Checksum;
+	public static fun values ()[Lcom/vanniktech/maven/publish/Checksum;
+}
+
 public final class com/vanniktech/maven/publish/DeploymentValidation : java/lang/Enum {
 	public static final field NONE Lcom/vanniktech/maven/publish/DeploymentValidation;
 	public static final field PUBLISHED Lcom/vanniktech/maven/publish/DeploymentValidation;
@@ -189,6 +199,7 @@ public final class com/vanniktech/maven/publish/KotlinMultiplatform : com/vannik
 
 public abstract class com/vanniktech/maven/publish/MavenPublishBaseExtension {
 	public fun <init> (Lorg/gradle/api/Project;Lorg/gradle/build/event/BuildEventsListenerRegistry;Lorg/gradle/api/configuration/BuildFeatures;)V
+	public final fun checksums ([Lcom/vanniktech/maven/publish/Checksum;)V
 	public final fun configure (Lcom/vanniktech/maven/publish/Platform;)V
 	public final fun configureBasedOnAppliedPlugins ()V
 	public final fun configureBasedOnAppliedPlugins (Lcom/vanniktech/maven/publish/JavadocJar;)V
@@ -197,6 +208,9 @@ public abstract class com/vanniktech/maven/publish/MavenPublishBaseExtension {
 	public static synthetic fun configureBasedOnAppliedPlugins$default (Lcom/vanniktech/maven/publish/MavenPublishBaseExtension;Lcom/vanniktech/maven/publish/JavadocJar;Lcom/vanniktech/maven/publish/SourcesJar;ILjava/lang/Object;)V
 	public final fun coordinates (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public static synthetic fun coordinates$default (Lcom/vanniktech/maven/publish/MavenPublishBaseExtension;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun excludeSignatureChecksums ()V
+	public final fun excludeSignatureChecksums (Z)V
+	public static synthetic fun excludeSignatureChecksums$default (Lcom/vanniktech/maven/publish/MavenPublishBaseExtension;ZILjava/lang/Object;)V
 	public final fun pom (Lorg/gradle/api/Action;)V
 	public final fun pomFromGradleProperties ()V
 	public final fun publishToMavenCentral ()V

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -175,6 +175,7 @@ val integrationTest by tasks.registering(Test::class) {
 }
 
 tasks.test {
+  useJUnitPlatform()
   // The generated build config fails the test task.
   failOnNoDiscoveredTests = false
 }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Checksum.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Checksum.kt
@@ -1,0 +1,24 @@
+package com.vanniktech.maven.publish
+
+/**
+ * Checksum types that Gradle generates for published files. [SHA256] and [SHA512] are not read by Gradle or
+ * Maven Central and are therefore not published by default.
+ */
+public enum class Checksum(
+  internal val extension: String,
+) {
+  MD5("md5"),
+  SHA1("sha1"),
+  SHA256("sha256"),
+  SHA512("sha512"),
+  ;
+
+  internal companion object {
+    val DEFAULT: List<Checksum> = listOf(MD5, SHA1)
+
+    fun fromExtension(extension: String): Checksum = entries.firstOrNull { it.extension == extension }
+      ?: throw IllegalArgumentException(
+        "Unknown checksum \"$extension\". Valid values are: ${entries.joinToString { it.extension }}.",
+      )
+  }
+}

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -13,6 +13,7 @@ import org.gradle.api.configuration.BuildFeatures
 import org.gradle.api.credentials.PasswordCredentials
 import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
@@ -39,6 +40,12 @@ public abstract class MavenPublishBaseExtension @Inject constructor(
     .convention(project.provider { project.version.toString() })
   private val pomFromProperties: Property<Boolean> = project.objects.property(Boolean::class.java)
   private val platform: Property<Platform> = project.objects.property(Platform::class.java)
+  private val excludeSignatureChecksums: Property<Boolean> = project.objects
+    .property(Boolean::class.java)
+    .convention(project.provider { project.excludeSignatureChecksums() })
+  private val checksums: SetProperty<Checksum> = project.objects
+    .setProperty(Checksum::class.java)
+    .convention(project.provider { project.checksums() })
 
   /**
    * Sets up Maven Central publishing through Sonatype OSSRH by configuring the target repository. Gradle will then
@@ -126,7 +133,15 @@ public abstract class MavenPublishBaseExtension @Inject constructor(
       buildEventsListenerRegistry = buildEventsListenerRegistry,
     )
 
-    val prepareTask = project.tasks.registerPrepareMavenCentralPublishingTask(buildService, groupId, artifactId, version, localRepository)
+    val prepareTask = project.tasks.registerPrepareMavenCentralPublishingTask(
+      buildService,
+      groupId,
+      artifactId,
+      version,
+      localRepository,
+      excludeSignatureChecksums,
+      checksums.map { checksums -> checksums.map { it.extension }.toSet() },
+    )
     val enableAutomaticTask = project.tasks.registerEnableAutomaticMavenCentralPublishingTask(buildService, validateDeployment)
 
     project.tasks.withType(PublishToMavenRepository::class.java).configureEach { publishTask ->
@@ -151,6 +166,40 @@ public abstract class MavenPublishBaseExtension @Inject constructor(
     }
 
     project.tasks.registerDropMavenCentralDeploymentTask(buildService)
+  }
+
+  /**
+   * Controls whether checksum files for signature (`.asc`) files are excluded when publishing to Maven Central.
+   *
+   * Gradle generates `.asc.md5`, `.asc.sha1`, `.asc.sha256` and `.asc.sha512` files for every signature, but these
+   * are not needed by Maven Central. See [gradle/gradle#20232](https://github.com/gradle/gradle/issues/20232).
+   *
+   * This is enabled by default and can also be controlled through the `mavenCentralExcludeSignatureChecksums`
+   * Gradle property.
+   *
+   * @param exclude whether to exclude signature checksum files from the deployment
+   */
+  @JvmOverloads
+  public fun excludeSignatureChecksums(exclude: Boolean = true) {
+    excludeSignatureChecksums.set(exclude)
+    excludeSignatureChecksums.finalizeValue()
+  }
+
+  /**
+   * Sets which checksum files are published to Maven Central.
+   *
+   * Gradle generates [Checksum.MD5], [Checksum.SHA1], [Checksum.SHA256] and [Checksum.SHA512] checksums for every
+   * published file, but neither Gradle nor Maven Central read the `sha256` and `sha512` ones. By default only
+   * [Checksum.MD5] and [Checksum.SHA1] are published.
+   *
+   * This can also be controlled through the `mavenCentralChecksums` Gradle property as a comma separated list, e.g.
+   * `mavenCentralChecksums=md5,sha1`.
+   *
+   * @param checksums the checksum files to publish
+   */
+  public fun checksums(vararg checksums: Checksum) {
+    this.checksums.set(checksums.toSet())
+    this.checksums.finalizeValue()
   }
 
   /**

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Properties.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Properties.kt
@@ -46,6 +46,26 @@ private fun String.toDeploymentValidation() = when (this) {
   else -> DeploymentValidation.valueOf(this)
 }
 
+internal fun Project.excludeSignatureChecksums(): Boolean {
+  val exclude = providers.gradleProperty("mavenCentralExcludeSignatureChecksums").orNull
+  if (exclude != null) {
+    return exclude.toBoolean()
+  }
+  return true
+}
+
+internal fun Project.checksums(): List<Checksum> {
+  val checksums = providers.gradleProperty("mavenCentralChecksums").orNull
+  if (checksums != null) {
+    return checksums
+      .split(",")
+      .map { it.trim() }
+      .filter { it.isNotEmpty() }
+      .map { Checksum.fromExtension(it) }
+  }
+  return Checksum.DEFAULT
+}
+
 internal fun Project.signAllPublications(): Boolean {
   val sign = providers.gradleProperty("signAllPublications").orNull
   if (sign != null) {

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/central/DeploymentFiles.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/central/DeploymentFiles.kt
@@ -1,0 +1,35 @@
+package com.vanniktech.maven.publish.central
+
+import com.vanniktech.maven.publish.Checksum
+
+private val CHECKSUM_EXTENSIONS = Checksum.entries.map { it.extension }
+
+// The checksum extension of a file (e.g. "sha256" for "foo.jar.sha256"), or null if it is not a checksum file.
+internal fun checksumExtensionOrNull(fileName: String): String? = CHECKSUM_EXTENSIONS.firstOrNull { fileName.endsWith(".$it") }
+
+/**
+ * Decides whether a file from the local repository should be included in the Maven Central deployment.
+ *
+ * @param fileName the name of the file
+ * @param excludeSignatureChecksums whether checksums of signature (`.asc`) files should be excluded,
+ *   see [gradle/gradle#20232](https://github.com/gradle/gradle/issues/20232)
+ * @param allowedChecksumExtensions the checksum extensions (e.g. `md5`, `sha1`) that should be published
+ */
+internal fun shouldIncludeInDeployment(
+  fileName: String,
+  excludeSignatureChecksums: Boolean,
+  allowedChecksumExtensions: Set<String>,
+): Boolean {
+  // maven-metadata files are not needed by Maven Central.
+  if (fileName.contains("maven-metadata")) {
+    return false
+  }
+
+  val checksumExtension = checksumExtensionOrNull(fileName) ?: return true
+
+  if (excludeSignatureChecksums && fileName.removeSuffix(".$checksumExtension").endsWith(".asc")) {
+    return false
+  }
+
+  return checksumExtension in allowedChecksumExtensions
+}

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/central/MavenCentralBuildService.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/central/MavenCentralBuildService.kt
@@ -69,13 +69,20 @@ internal abstract class MavenCentralBuildService :
   /**
    * Is only allowed to be called from task actions.
    */
-  fun registerProject(group: String, artifactId: String, version: String, localRepository: File) {
+  fun registerProject(
+    group: String,
+    artifactId: String,
+    version: String,
+    localRepository: File,
+    excludeSignatureChecksums: Boolean,
+    allowedChecksumExtensions: Set<String>,
+  ) {
     if (version.endsWith("-SNAPSHOT")) {
       return
     }
 
     val coordinates = MavenCentralCoordinates(group, artifactId, version)
-    val project = MavenCentralProject(coordinates, localRepository)
+    val project = MavenCentralProject(coordinates, localRepository, excludeSignatureChecksums, allowedChecksumExtensions)
     projectsToPublish.add(project)
 
     endOfBuildActions += EndOfBuildAction.Upload
@@ -152,7 +159,8 @@ internal abstract class MavenCentralBuildService :
       projectsToPublish.forEach { project ->
         project.localRepository
           .walkTopDown()
-          .filter { it.isFile && !it.name.contains("maven-metadata") }
+          .filter { it.isFile }
+          .filter { shouldIncludeInDeployment(it.name, project.excludeSignatureChecksums, project.allowedChecksumExtensions) }
           .forEach {
             val entry = ZipEntry(it.toRelativeString(project.localRepository))
             out.putNextEntry(entry)

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/central/MavenCentralProject.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/central/MavenCentralProject.kt
@@ -5,4 +5,6 @@ import java.io.File
 internal data class MavenCentralProject(
   val coordinates: MavenCentralCoordinates,
   val localRepository: File,
+  val excludeSignatureChecksums: Boolean,
+  val allowedChecksumExtensions: Set<String>,
 )

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/central/PrepareMavenCentralPublishingTask.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/central/PrepareMavenCentralPublishingTask.kt
@@ -5,6 +5,7 @@ import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
@@ -25,6 +26,12 @@ internal abstract class PrepareMavenCentralPublishingTask : DefaultTask() {
 
   @get:Internal
   abstract val localRepository: DirectoryProperty
+
+  @get:Input
+  abstract val excludeSignatureChecksums: Property<Boolean>
+
+  @get:Input
+  abstract val allowedChecksumExtensions: SetProperty<String>
 
   @get:Internal
   abstract val buildService: Property<MavenCentralBuildService>
@@ -53,7 +60,14 @@ internal abstract class PrepareMavenCentralPublishingTask : DefaultTask() {
       "mavenCentralPassword not found, which is required for publishing to Maven Central."
     }
 
-    buildService.get().registerProject(projectGroup.get(), artifactId.get(), version.get(), localRepository)
+    buildService.get().registerProject(
+      projectGroup.get(),
+      artifactId.get(),
+      version.get(),
+      localRepository,
+      excludeSignatureChecksums.get(),
+      allowedChecksumExtensions.get(),
+    )
   }
 
   companion object {
@@ -65,12 +79,16 @@ internal abstract class PrepareMavenCentralPublishingTask : DefaultTask() {
       artifactId: Provider<String>,
       version: Provider<String>,
       localRepository: Provider<Directory>,
+      excludeSignatureChecksums: Provider<Boolean>,
+      allowedChecksumExtensions: Provider<out Set<String>>,
     ): TaskProvider<PrepareMavenCentralPublishingTask> = register(NAME, PrepareMavenCentralPublishingTask::class.java) {
       it.description = "Prepare for publishing to Maven Central"
       it.projectGroup.set(group)
       it.artifactId.set(artifactId)
       it.version.set(version)
       it.localRepository.set(localRepository)
+      it.excludeSignatureChecksums.set(excludeSignatureChecksums)
+      it.allowedChecksumExtensions.set(allowedChecksumExtensions)
       it.buildService.set(buildService)
       it.usesService(buildService)
     }

--- a/plugin/src/test/kotlin/com/vanniktech/maven/publish/ChecksumTest.kt
+++ b/plugin/src/test/kotlin/com/vanniktech/maven/publish/ChecksumTest.kt
@@ -1,0 +1,35 @@
+package com.vanniktech.maven.publish
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class ChecksumTest {
+  @Test
+  fun `default is md5 and sha1`() {
+    assertThat(Checksum.DEFAULT).containsExactly(Checksum.MD5, Checksum.SHA1).inOrder()
+  }
+
+  @Test
+  fun `extensions match maven layout`() {
+    assertThat(Checksum.MD5.extension).isEqualTo("md5")
+    assertThat(Checksum.SHA1.extension).isEqualTo("sha1")
+    assertThat(Checksum.SHA256.extension).isEqualTo("sha256")
+    assertThat(Checksum.SHA512.extension).isEqualTo("sha512")
+  }
+
+  @Test
+  fun `fromExtension resolves all checksums`() {
+    Checksum.entries.forEach { checksum ->
+      assertThat(Checksum.fromExtension(checksum.extension)).isEqualTo(checksum)
+    }
+  }
+
+  @Test
+  fun `fromExtension fails for unknown extension`() {
+    val exception = assertThrows<IllegalArgumentException> {
+      Checksum.fromExtension("sha384")
+    }
+    assertThat(exception).hasMessageThat().contains("sha384")
+  }
+}

--- a/plugin/src/test/kotlin/com/vanniktech/maven/publish/central/DeploymentFilesTest.kt
+++ b/plugin/src/test/kotlin/com/vanniktech/maven/publish/central/DeploymentFilesTest.kt
@@ -1,0 +1,73 @@
+package com.vanniktech.maven.publish.central
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class DeploymentFilesTest {
+  private val allChecksums = setOf("md5", "sha1", "sha256", "sha512")
+  private val defaultChecksums = setOf("md5", "sha1")
+
+  @Test
+  fun `keeps regular artifacts`() {
+    assertThat(shouldIncludeInDeployment("lib-1.0.jar", excludeSignatureChecksums = true, defaultChecksums)).isTrue()
+    assertThat(shouldIncludeInDeployment("lib-1.0.pom", excludeSignatureChecksums = true, defaultChecksums)).isTrue()
+    assertThat(shouldIncludeInDeployment("lib-1.0.module", excludeSignatureChecksums = true, defaultChecksums)).isTrue()
+  }
+
+  @Test
+  fun `keeps signature files themselves`() {
+    assertThat(shouldIncludeInDeployment("lib-1.0.jar.asc", excludeSignatureChecksums = true, defaultChecksums)).isTrue()
+    assertThat(shouldIncludeInDeployment("lib-1.0.pom.asc", excludeSignatureChecksums = true, defaultChecksums)).isTrue()
+  }
+
+  @Test
+  fun `excludes maven-metadata files`() {
+    assertThat(shouldIncludeInDeployment("maven-metadata.xml", excludeSignatureChecksums = true, allChecksums)).isFalse()
+    assertThat(shouldIncludeInDeployment("maven-metadata.xml.md5", excludeSignatureChecksums = true, allChecksums)).isFalse()
+    assertThat(shouldIncludeInDeployment("maven-metadata.xml.sha1", excludeSignatureChecksums = true, allChecksums)).isFalse()
+  }
+
+  @Test
+  fun `default config keeps md5 and sha1 but drops sha256 and sha512`() {
+    assertThat(shouldIncludeInDeployment("lib-1.0.jar.md5", excludeSignatureChecksums = true, defaultChecksums)).isTrue()
+    assertThat(shouldIncludeInDeployment("lib-1.0.jar.sha1", excludeSignatureChecksums = true, defaultChecksums)).isTrue()
+    assertThat(shouldIncludeInDeployment("lib-1.0.jar.sha256", excludeSignatureChecksums = true, defaultChecksums)).isFalse()
+    assertThat(shouldIncludeInDeployment("lib-1.0.jar.sha512", excludeSignatureChecksums = true, defaultChecksums)).isFalse()
+  }
+
+  @Test
+  fun `allowing all checksums keeps sha256 and sha512`() {
+    assertThat(shouldIncludeInDeployment("lib-1.0.jar.sha256", excludeSignatureChecksums = true, allChecksums)).isTrue()
+    assertThat(shouldIncludeInDeployment("lib-1.0.jar.sha512", excludeSignatureChecksums = true, allChecksums)).isTrue()
+  }
+
+  @Test
+  fun `excludes signature checksums when enabled regardless of allowed checksums`() {
+    assertThat(shouldIncludeInDeployment("lib-1.0.jar.asc.md5", excludeSignatureChecksums = true, allChecksums)).isFalse()
+    assertThat(shouldIncludeInDeployment("lib-1.0.jar.asc.sha1", excludeSignatureChecksums = true, allChecksums)).isFalse()
+    assertThat(shouldIncludeInDeployment("lib-1.0.jar.asc.sha256", excludeSignatureChecksums = true, allChecksums)).isFalse()
+    assertThat(shouldIncludeInDeployment("lib-1.0.jar.asc.sha512", excludeSignatureChecksums = true, allChecksums)).isFalse()
+  }
+
+  @Test
+  fun `keeps signature checksums when exclusion disabled and checksum allowed`() {
+    assertThat(shouldIncludeInDeployment("lib-1.0.jar.asc.md5", excludeSignatureChecksums = false, allChecksums)).isTrue()
+    assertThat(shouldIncludeInDeployment("lib-1.0.jar.asc.sha1", excludeSignatureChecksums = false, allChecksums)).isTrue()
+  }
+
+  @Test
+  fun `signature checksum exclusion and allowed checksums are independent`() {
+    // exclusion disabled but sha256 not allowed -> still dropped because of the checksum allow list
+    assertThat(shouldIncludeInDeployment("lib-1.0.jar.asc.sha256", excludeSignatureChecksums = false, defaultChecksums)).isFalse()
+    // exclusion disabled and md5 allowed -> kept
+    assertThat(shouldIncludeInDeployment("lib-1.0.jar.asc.md5", excludeSignatureChecksums = false, defaultChecksums)).isTrue()
+  }
+
+  @Test
+  fun `checksumExtensionOrNull detects checksum files`() {
+    assertThat(checksumExtensionOrNull("lib-1.0.jar.sha256")).isEqualTo("sha256")
+    assertThat(checksumExtensionOrNull("lib-1.0.jar.asc.md5")).isEqualTo("md5")
+    assertThat(checksumExtensionOrNull("lib-1.0.jar")).isNull()
+    assertThat(checksumExtensionOrNull("lib-1.0.jar.asc")).isNull()
+  }
+}


### PR DESCRIPTION
Drop .asc signature checksums (gradle/gradle#20232) and all .sha256/.sha512 checksums by default. Both are toggleable via DSL or Gradle properties.

This will reduce count of published files by 60% by default to help publishers stay under [the new maven central publishing limits](https://central.sonatype.org/publish/maven-central-publishing-limits/)

---

- [x] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
