### PR TITLE
docs: document conflicts with the java extension

### DIFF
--- a/docs/what.md
+++ b/docs/what.md
@@ -591,3 +591,25 @@ For projects using the `version-catalog` plugin.
       configure(VersionCatalog())
     }
     ```
+
+## Conflicts with `java { withJavadocJar() }`
+
+This plugin creates the javadoc jar itself. Declaring it through the `java` extension as well makes
+two tasks write the same file, and publishing fails:
+
+```text
+A problem was found with the configuration of task ':plainJavadocJar' (type 'JavadocJar').
+  Reason: Task ':generateMetadataFileForMavenPublication' uses this output of task
+  ':plainJavadocJar' without declaring an explicit or implicit dependency.
+```
+
+Remove `withJavadocJar()` from the `java` extension. `withSourcesJar()` does not cause this problem
+and can stay.
+
+!!! info
+
+    Removing `withJavadocJar()` also changes the published Gradle Module Metadata. The
+    `javadocElements` variant is added by the `java` extension, not by this plugin, so it
+    disappears together with the declaration. The javadoc jar itself is still published as a
+    classifier artifact and Maven consumers resolve it as before, but Gradle consumers asking
+    for the javadoc variant will no longer find it.


### PR DESCRIPTION
## What

Documents that `java { withJavadocJar() }` conflicts with this plugin, and what changes in the
published metadata when you remove it.

## Why

`withJavadocJar()` collides with the plugin's own `plainJavadocJar`. The error names the two tasks
but not the cause:

```text
A problem was found with the configuration of task ':plainJavadocJar' (type 'JavadocJar').
  Reason: Task ':generateMetadataFileForMavenPublication' uses this output of task
  ':plainJavadocJar' without declaring an explicit or implicit dependency.
```

Both parts are already reported. #772 is about the error, and a comment there asks for it to be
documented. #1028 is about the metadata change.

## Notes

Docs only, no behaviour changes.

I hit this while migrating a library to the Central Portal, and checked both statements on a
`java-library` project before writing the wording.

Only the javadoc declaration conflicts: `publishToMavenLocal` fails with `withJavadocJar()` and
passes with `withSourcesJar()`. And the generated module metadata contains `javadocElements` only
when `withJavadocJar()` is declared, which is why removing it takes the variant away.

English is not my first language, so I used Claude to help with the wording. The behaviour
described above I reproduced and verified myself.

---

- [ ] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
