### PR TITLE
Support publishing with Shadow plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## [UNRELEASED](https://github.com/vanniktech/gradle-maven-publish-plugin/compare/0.37.0...HEAD) *(2026-xx-xx)*
 
+- Add support for publishing with the Shadow plugin (`com.gradleup.shadow`), requiring minimum version 9.1.0.
+
 #### Minimum supported versions
 - JDK 17
 - Gradle 9.0.0
 - Android Gradle Plugin 8.13.0
 - Kotlin Gradle Plugin 2.2.0
+- Shadow Plugin 9.1.0
 
 #### Compatibility tested up to
 - JDK 26
@@ -16,6 +19,7 @@
 - Android Gradle Plugin 9.3.0-rc01
 - Android Gradle Plugin 9.4.0-alpha01
 - Kotlin Gradle Plugin 2.4.0
+- Shadow Plugin 9.6.1
 
 
 ## [0.37.0](https://github.com/vanniktech/gradle-maven-publish-plugin/releases/tag/0.37.0) *(2026-06-21)*

--- a/docs/what.md
+++ b/docs/what.md
@@ -10,6 +10,7 @@ It is possible to configure publishing for the following Gradle plugins:
     - automatically includes `com.android.kotlin.multiplatform.library`
 - [`java`](#java-library)
 - [`java-library`](#java-library)
+- [`com.gradleup.shadow`](#shadow)
 - [`java-gradle-plugin`](#gradle-plugin)
 - [`com.gradle.plugin-publish`](#gradle-publish-plugin)
 - [`java-platform`](#java-platform)
@@ -349,6 +350,61 @@ For projects using the `java-library` plugin.
       ))
     }
     ```
+
+## Shadow
+
+For projects using the `com.gradleup.shadow` plugin. This will publish the `shadow` component.
+
+=== "build.gradle"
+
+    ```groovy
+    import com.vanniktech.maven.publish.JavadocJar
+    import com.vanniktech.maven.publish.Shadow
+    import com.vanniktech.maven.publish.SourcesJar
+
+    mavenPublishing {
+      configure(new Shadow(
+        // the first parameter configures the -javadoc artifact, possible values:
+        // - `JavadocJar.None()` don't publish this artifact
+        // - `JavadocJar.Empty()` publish an empty jar
+        // - `JavadocJar.Javadoc()` to publish standard javadocs
+        // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is the name of the Dokka task that should be used as input
+        new JavadocJar.Empty(),
+        // configures the -sources artifact, possible values:
+        // - `SourcesJar.None()` don't publish this artifact
+        // - `SourcesJar.Empty()` publish an empty jar
+        // - `SourcesJar.Sources()` publish the sources
+        new SourcesJar.Sources()
+      ))
+    }
+    ```
+
+=== "build.gradle.kts"
+
+    ```kotlin
+    import com.vanniktech.maven.publish.JavadocJar
+    import com.vanniktech.maven.publish.Shadow
+    import com.vanniktech.maven.publish.SourcesJar
+
+    mavenPublishing {
+      configure(Shadow(
+        // configures the -javadoc artifact, possible values:
+        // - `JavadocJar.None()` don't publish this artifact
+        // - `JavadocJar.Empty()` publish an empty jar
+        // - `JavadocJar.Javadoc()` to publish standard javadocs
+        javadocJar = JavadocJar.Empty(),
+        // configures the -sources artifact, possible values:
+        // - `SourcesJar.None()` don't publish this artifact
+        // - `SourcesJar.Empty()` publish an empty jar
+        // - `SourcesJar.Sources()` publish the sources
+        sourcesJar = SourcesJar.Sources(),
+      ))
+    }
+    ```
+
+!!! note
+
+    If you want to publish **both** the standard JAR and the shadowed JAR as a variant in Gradle Module Metadata (using Shadow's `addShadowVariantIntoJavaComponent` feature), configure [`JavaLibrary`](#java-library) or [`KotlinJvm`](#kotlin-jvm-library) instead of `Shadow`.
 
 ## Kotlin JVM Library
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,9 @@ jdkRelease = "17"
 minGradle = "9.0.0"
 minAgp = "8.13.0"
 minKgp = "2.2.0"
+minShadow = "9.1.0"
+
+shadow = "9.6.1"
 
 gradle = "9.7.1"
 
@@ -27,6 +30,7 @@ slf4j = "2.0.18"
 [libraries]
 dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 android-pluginApi = { module = "com.android.tools.build:gradle-api", version.ref = "android-gradle" }
+shadow = { module = "com.gradleup.shadow:shadow-gradle-plugin", version.ref = "shadow" }
 maven-publish-plugin = "com.vanniktech:gradle-maven-publish-plugin:0.37.0"
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }

--- a/plugin/api/plugin.api
+++ b/plugin/api/plugin.api
@@ -238,6 +238,22 @@ public abstract class com/vanniktech/maven/publish/Platform {
 	public abstract fun getSourcesJar ()Lcom/vanniktech/maven/publish/SourcesJar;
 }
 
+public final class com/vanniktech/maven/publish/Shadow : com/vanniktech/maven/publish/Platform {
+	public fun <init> ()V
+	public fun <init> (Lcom/vanniktech/maven/publish/JavadocJar;)V
+	public fun <init> (Lcom/vanniktech/maven/publish/JavadocJar;Lcom/vanniktech/maven/publish/SourcesJar;)V
+	public synthetic fun <init> (Lcom/vanniktech/maven/publish/JavadocJar;Lcom/vanniktech/maven/publish/SourcesJar;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/vanniktech/maven/publish/JavadocJar;
+	public final fun component2 ()Lcom/vanniktech/maven/publish/SourcesJar;
+	public final fun copy (Lcom/vanniktech/maven/publish/JavadocJar;Lcom/vanniktech/maven/publish/SourcesJar;)Lcom/vanniktech/maven/publish/Shadow;
+	public static synthetic fun copy$default (Lcom/vanniktech/maven/publish/Shadow;Lcom/vanniktech/maven/publish/JavadocJar;Lcom/vanniktech/maven/publish/SourcesJar;ILjava/lang/Object;)Lcom/vanniktech/maven/publish/Shadow;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getJavadocJar ()Lcom/vanniktech/maven/publish/JavadocJar;
+	public fun getSourcesJar ()Lcom/vanniktech/maven/publish/SourcesJar;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/vanniktech/maven/publish/SourcesJar {
 }
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -57,6 +57,7 @@ buildConfig {
     buildConfigField("VERSION_NAME", providers.gradleProperty("VERSION_NAME"))
     buildConfigField("ANDROID_GRADLE_MIN", libs.versions.minAgp)
     buildConfigField("KOTLIN_MIN", libs.versions.minKgp)
+    buildConfigField("SHADOW_MIN", libs.versions.minShadow)
   }
 
   sourceSets.named("main") {
@@ -84,6 +85,7 @@ buildConfig {
     buildConfigField("GRADLE_PUBLISH_BETA", beta.versions.gradle.plugin.publish)
     buildConfigField("GRADLE_PUBLISH_RC", rc.versions.gradle.plugin.publish)
     buildConfigField("GRADLE_PUBLISH_STABLE", libs.versions.gradle.plugin.publish)
+    buildConfigField("SHADOW_STABLE", libs.versions.shadow)
     buildConfigField("DOKKA_STABLE", libs.versions.dokka)
   }
 }
@@ -101,6 +103,7 @@ dependencies {
   compileOnly(libs.dokka)
   compileOnly(libs.kotlin.plugin)
   compileOnly(libs.android.pluginApi)
+  compileOnly(libs.shadow)
 
   implementation(projects.centralPortal)
 

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ShadowPluginTest.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/ShadowPluginTest.kt
@@ -1,0 +1,105 @@
+package com.vanniktech.maven.publish
+
+import com.google.testing.junit.testparameterinjector.junit5.TestParameter
+import com.google.testing.junit.testparameterinjector.junit5.TestParameterInjectorTest
+import com.vanniktech.maven.publish.util.ProjectResultSubject.Companion.assertThat
+import com.vanniktech.maven.publish.util.ShadowVersion
+import com.vanniktech.maven.publish.util.ShadowVersionProvider
+import com.vanniktech.maven.publish.util.TestOptions
+import com.vanniktech.maven.publish.util.assumeSupportedJdkAndGradleVersion
+import com.vanniktech.maven.publish.util.shadowProjectSpec
+
+class ShadowPluginTest : BasePluginTest() {
+  @TestParameterInjectorTest
+  fun shadowProject(
+    @TestParameter(valuesProvider = ShadowVersionProvider::class) shadowVersion: ShadowVersion,
+  ) {
+    shadowVersion.assumeSupportedJdkAndGradleVersion(gradleVersion)
+
+    val project = shadowProjectSpec(shadowVersion)
+    val result = project.run()
+
+    assertThat(result).outcome().succeeded()
+    assertThat(result).artifact("all", "jar").exists()
+    assertThat(result).artifact("all", "jar").isSigned()
+    assertThat(result).pom().exists()
+    assertThat(result).pom().isSigned()
+    assertThat(result).pom().matchesExpectedPom("pom")
+    assertThat(result).module().exists()
+    assertThat(result).module().isSigned()
+    assertThat(result).sourcesJar().exists()
+    assertThat(result).sourcesJar().isSigned()
+    assertThat(result).sourcesJar().containsAllSourceFiles()
+    assertThat(result).javadocJar().exists()
+    assertThat(result).javadocJar().isSigned()
+  }
+
+  @TestParameterInjectorTest
+  fun shadowProjectWithEmptyClassifier(
+    @TestParameter(valuesProvider = ShadowVersionProvider::class) shadowVersion: ShadowVersion,
+  ) {
+    shadowVersion.assumeSupportedJdkAndGradleVersion(gradleVersion)
+
+    val project = shadowProjectSpec(shadowVersion).copy(
+      buildFileExtra =
+        """
+        tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+          archiveClassifier = ''
+        }
+        """.trimIndent(),
+    )
+    val result = project.run()
+
+    assertThat(result).outcome().succeeded()
+    assertThat(result).artifact("jar").exists()
+    assertThat(result).artifact("jar").isSigned()
+    assertThat(result).pom().exists()
+    assertThat(result).pom().isSigned()
+    assertThat(result).pom().matchesExpectedPom()
+    assertThat(result).module().exists()
+    assertThat(result).module().isSigned()
+    assertThat(result).sourcesJar().exists()
+    assertThat(result).sourcesJar().isSigned()
+    assertThat(result).sourcesJar().containsAllSourceFiles()
+    assertThat(result).javadocJar().exists()
+    assertThat(result).javadocJar().isSigned()
+  }
+
+  @TestParameterInjectorTest
+  fun shadowProjectWithJavaLibraryAndShadowVariant(
+    @TestParameter(valuesProvider = ShadowVersionProvider::class) shadowVersion: ShadowVersion,
+  ) {
+    shadowVersion.assumeSupportedJdkAndGradleVersion(gradleVersion)
+
+    val project = shadowProjectSpec(shadowVersion).copy(
+      basePluginConfig = "configure(new JavaLibrary(new JavadocJar.Empty(), new SourcesJar.Sources()))",
+      buildFileExtra =
+        if (config == TestOptions.Config.BASE) {
+          ""
+        } else {
+          """
+          mavenPublishing {
+            configure(new JavaLibrary(new JavadocJar.Empty(), new SourcesJar.Sources()))
+          }
+          """.trimIndent()
+        },
+    )
+    val result = project.run()
+
+    assertThat(result).outcome().succeeded()
+    assertThat(result).artifact("jar").exists()
+    assertThat(result).artifact("jar").isSigned()
+    assertThat(result).artifact("all", "jar").exists()
+    assertThat(result).artifact("all", "jar").isSigned()
+    assertThat(result).pom().exists()
+    assertThat(result).pom().isSigned()
+    assertThat(result).pom().matchesExpectedPom()
+    assertThat(result).module().exists()
+    assertThat(result).module().isSigned()
+    assertThat(result).sourcesJar().exists()
+    assertThat(result).sourcesJar().isSigned()
+    assertThat(result).sourcesJar().containsAllSourceFiles()
+    assertThat(result).javadocJar().exists()
+    assertThat(result).javadocJar().isSigned()
+  }
+}

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/util/ProjectSpecs.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/util/ProjectSpecs.kt
@@ -15,6 +15,7 @@ val kotlinAndroidPlugin = PluginSpec("org.jetbrains.kotlin.android")
 val androidLibraryPlugin = PluginSpec("com.android.library")
 val androidMultiplatformLibraryPlugin = PluginSpec("com.android.kotlin.multiplatform.library")
 val androidFusedLibraryPlugin = PluginSpec("com.android.fused-library")
+val shadowPlugin = PluginSpec("com.gradleup.shadow")
 val gradlePluginPublishPlugin = PluginSpec("com.gradle.plugin-publish")
 val dokkaPlugin = PluginSpec("org.jetbrains.dokka", DOKKA_STABLE)
 val dokkaJavadocPlugin = PluginSpec("org.jetbrains.dokka-javadoc", DOKKA_STABLE)
@@ -353,4 +354,19 @@ fun versionCatalogProjectSpec() = ProjectSpec(
         }
     }
     """.trimIndent(),
+)
+
+fun shadowProjectSpec(version: ShadowVersion) = ProjectSpec(
+  plugins = listOf(
+    javaPlugin,
+    shadowPlugin.copy(version = version.value),
+  ),
+  group = "com.example",
+  artifactId = "test-artifact",
+  version = "1.0.0",
+  properties = defaultProperties,
+  sourceFiles = listOf(
+    SourceFile("main", "java", "com/vanniktech/maven/publish/test/JavaTestClass.java"),
+  ),
+  basePluginConfig = "configure(new Shadow(new JavadocJar.Empty(), new SourcesJar.Sources()))",
 )

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/util/TestOptions.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/util/TestOptions.kt
@@ -134,6 +134,23 @@ class PluginPublishVersion(
   }
 }
 
+class ShadowVersion(
+  override val value: String,
+  val minJdkVersion: JavaVersion = JavaVersion.VERSION_17,
+  val minGradleVersion: GradleVersion = GradleVersion.VERSIONS.min(),
+  val firstUnsupportedJdkVersion: JavaVersion? = null,
+  val firstUnsupportedGradleVersion: GradleVersion? = null,
+) : ComparableVersion("Shadow") {
+  companion object {
+    val VERSIONS = setOf(
+      // minimum supported
+      ShadowVersion(Versions.SHADOW_MIN),
+      // latest versions of each type
+      ShadowVersion(Versions.SHADOW_STABLE),
+    )
+  }
+}
+
 fun GradleVersion.assumeSupportedJdkVersion() {
   assume().that(JavaVersion.current()).isAtLeast(minJdkVersion)
   if (firstUnsupportedJdkVersion != null) {
@@ -153,6 +170,17 @@ fun KgpVersion.assumeSupportedJdkAndGradleVersion(gradleVersion: GradleVersion) 
 }
 
 fun AgpVersion.assumeSupportedJdkAndGradleVersion(gradleVersion: GradleVersion) {
+  assume().that(JavaVersion.current()).isAtLeast(minJdkVersion)
+  assume().that(gradleVersion).isAtLeast(minGradleVersion)
+  if (firstUnsupportedJdkVersion != null) {
+    assume().that(JavaVersion.current()).isLessThan(firstUnsupportedJdkVersion)
+  }
+  if (firstUnsupportedGradleVersion != null) {
+    assume().that(gradleVersion).isLessThan(firstUnsupportedGradleVersion)
+  }
+}
+
+fun ShadowVersion.assumeSupportedJdkAndGradleVersion(gradleVersion: GradleVersion) {
   assume().that(JavaVersion.current()).isAtLeast(minJdkVersion)
   assume().that(gradleVersion).isAtLeast(minGradleVersion)
   if (firstUnsupportedJdkVersion != null) {

--- a/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/util/TestOptionsProvider.kt
+++ b/plugin/src/integrationTest/kotlin/com/vanniktech/maven/publish/util/TestOptionsProvider.kt
@@ -39,3 +39,10 @@ class PluginPublishVersionProvider : TestParameterValuesProvider() {
     else -> PluginPublishVersion.VERSIONS.toList()
   }
 }
+
+class ShadowVersionProvider : TestParameterValuesProvider() {
+  override fun provideValues(context: Context?): List<ShadowVersion> = when {
+    QUICK_TEST -> listOf(ShadowVersion.VERSIONS.max())
+    else -> ShadowVersion.VERSIONS.toList()
+  }
+}

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt
@@ -501,6 +501,10 @@ public abstract class MavenPublishBaseExtension @Inject constructor(
         configure(GradlePlugin(javadocJar, sourcesJar))
       }
 
+      project.plugins.hasPlugin("com.gradleup.shadow") -> {
+        configure(Shadow(javadocJar, sourcesJar))
+      }
+
       project.plugins.hasPlugin("org.jetbrains.kotlin.jvm") -> {
         configure(KotlinJvm(javadocJar, sourcesJar))
       }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBasePlugin.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBasePlugin.kt
@@ -2,6 +2,7 @@ package com.vanniktech.maven.publish
 
 import com.vanniktech.maven.publish.BuildConfig.ANDROID_GRADLE_MIN
 import com.vanniktech.maven.publish.BuildConfig.KOTLIN_MIN
+import com.vanniktech.maven.publish.BuildConfig.SHADOW_MIN
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin as GradleMavenPublishPlugin
@@ -46,6 +47,21 @@ public abstract class MavenPublishBasePlugin : Plugin<Project> {
             t,
           )
         }
+      }
+    }
+    plugins.withId("com.gradleup.shadow") {
+      try {
+        if (!isAtLeastShadow()) {
+          error("You need Shadow version $SHADOW_MIN or newer")
+        }
+      } catch (t: Throwable) {
+        throw IllegalStateException(
+          "Make sure the Shadow version $SHADOW_MIN or newer is applied." +
+            "Otherwise, detected Shadow plugin com.gradleup.shadow but was not able to access Shadow plugin classes. Please make sure " +
+            "that the Shadow plugin and the publish plugin are applied to the same project. In many cases this means " +
+            "you need to add both the root project with `apply false`.",
+          t,
+        )
       }
     }
   }

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt
@@ -2,6 +2,7 @@ package com.vanniktech.maven.publish
 
 import com.android.build.api.AndroidPluginVersion
 import com.android.build.api.dsl.LibraryExtension
+import com.github.jengelman.gradle.plugins.shadow.ShadowJavaPlugin
 import com.vanniktech.maven.publish.tasks.JavadocJar.Companion.javadocJarTask
 import com.vanniktech.maven.publish.tasks.JavadocJar.Companion.prefixedTaskName
 import com.vanniktech.maven.publish.tasks.JavadocJar.Companion.updateArchivesBaseNameWithPrefix
@@ -72,6 +73,51 @@ public data class JavaLibrary @JvmOverloads constructor(
     project.gradlePublishing.publications.create(PUBLICATION_NAME, MavenPublication::class.java) {
       it.from(project.components.getByName("java"))
       it.withJavaSourcesJar(sourcesJar, project, multipleTasks = false)
+      it.withJavadocJar(javadocJar, project, multipleTasks = false)
+    }
+
+    setupTestFixtures(project, sourcesJar)
+  }
+}
+
+/**
+ * To be used for `com.gradleup.shadow` projects. Applying this creates a publication for the component called
+ * `shadow`. Depending on the passed parameters for [javadocJar] and [sourcesJar], `-javadoc` and `-sources` jars will
+ * be added to the publication.
+ *
+ * Equivalent Gradle set up:
+ * ```
+ * publishing {
+ *   publications {
+ *     create<MavenPublication>("maven") {
+ *       from(components["shadow"])
+ *     }
+ *   }
+ * }
+ *
+ * java {
+ *   withSourcesJar()
+ *   withJavadocJar()
+ * }
+ * ```
+ */
+public data class Shadow @JvmOverloads constructor(
+  override val javadocJar: JavadocJar = JavadocJar.Empty(),
+  override val sourcesJar: SourcesJar = SourcesJar.Sources(),
+) : Platform() {
+  override fun configure(project: Project) {
+    check(project.plugins.hasPlugin("com.gradleup.shadow")) {
+      "Calling configure(Shadow(...)) requires the com.gradleup.shadow plugin to be applied"
+    }
+
+    project.gradlePublishing.publications.create(PUBLICATION_NAME, MavenPublication::class.java) {
+      it.from(project.components.getByName(ShadowJavaPlugin.COMPONENT_NAME))
+      if (sourcesJar is SourcesJar.Sources) {
+        project.extensions.getByType(JavaPluginExtension::class.java).withSourcesJar()
+        it.artifact(project.tasks.named("sourcesJar"))
+      } else {
+        it.withJavaSourcesJar(sourcesJar, project, multipleTasks = false)
+      }
       it.withJavadocJar(javadocJar, project, multipleTasks = false)
     }
 

--- a/plugin/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
+++ b/plugin/src/main/kotlin/com/vanniktech/maven/publish/ProjectExtensions.kt
@@ -4,6 +4,7 @@ package com.vanniktech.maven.publish
 
 import com.android.build.api.AndroidPluginVersion
 import com.android.build.api.variant.AndroidComponentsExtension
+import com.github.jengelman.gradle.plugins.shadow.ShadowExtension
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
@@ -45,4 +46,12 @@ internal fun isAtLeastAgp(version: String): Boolean {
   // Drop everything after '-' to ignore rc/beta/alpha suffixes. If you want to compare those, use the rc/beta/alpha functions in AndroidPluginVersion.
   val (major, minor, patch) = version.takeWhile { it != '-' }.split(".").map { it.toInt() }
   return AndroidPluginVersion.getCurrent() >= AndroidPluginVersion(major, minor, patch)
+}
+
+internal fun isAtLeastShadow(): Boolean = try {
+  // Shadow 9.1.0 introduced addShadowVariantIntoJavaComponent on ShadowExtension to support publishing shadow variants from the Java component.
+  ShadowExtension::class.java.getMethod("getAddShadowVariantIntoJavaComponent")
+  true
+} catch (_: Throwable) {
+  false
 }


### PR DESCRIPTION
Closes #1123.

---

- [x] [CHANGELOG](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
